### PR TITLE
Add OSS infrastructure for community engagement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report an error or inconsistency in the specification
+title: '[BUG] '
+labels: bug, needs-triage
+assignees: ''
+---
+
+## Summary
+
+A clear description of what the bug or inconsistency is.
+
+## Location in Specification
+
+- **File**: (e.g., `spec/core/04-presentation-layers.md`)
+- **Section**: (e.g., Section 12.3)
+- **Line numbers** (if applicable):
+
+## Expected Behavior
+
+What the specification should say or how it should behave.
+
+## Actual Behavior
+
+What the specification currently says or how it actually behaves.
+
+## Impact
+
+How does this affect implementers or users of the specification?
+
+## Suggested Fix
+
+If you have a suggestion for how to fix this, please describe it here.
+
+## Additional Context
+
+Add any other context, references, or screenshots here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/gvonness-apolitical/codex-file-format-spec/discussions
+    about: For general questions and community discussion
+  - name: Reference Implementation
+    url: https://github.com/gvonness-apolitical/cdx-core
+    about: For issues with the Rust reference implementation

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature Request
+about: Propose a new feature or extension to the specification
+title: '[FEATURE] '
+labels: enhancement, needs-triage
+assignees: ''
+---
+
+## Summary
+
+A clear description of the feature you'd like to see in the specification.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed Solution
+
+Describe your proposed solution in detail.
+
+## Alternatives Considered
+
+What alternative approaches have you considered?
+
+## Compatibility
+
+How does this feature interact with existing parts of the specification?
+
+- [ ] This is a backward-compatible addition
+- [ ] This requires changes to existing features
+- [ ] This is a breaking change
+
+## Target Audience
+
+Who would benefit from this feature? (e.g., legal documents, academic papers, collaborative editing)
+
+## Implementation Considerations
+
+Any thoughts on how this might be implemented in reference implementations?
+
+## Additional Context
+
+Add any other context, mockups, or examples here.

--- a/.github/ISSUE_TEMPLATE/spec_clarification.md
+++ b/.github/ISSUE_TEMPLATE/spec_clarification.md
@@ -1,0 +1,42 @@
+---
+name: Specification Clarification
+about: Request clarification on ambiguous or unclear parts of the specification
+title: '[CLARIFICATION] '
+labels: documentation, needs-triage
+assignees: ''
+---
+
+## Summary
+
+What part of the specification needs clarification?
+
+## Location in Specification
+
+- **File**: (e.g., `spec/core/03-content-blocks.md`)
+- **Section**: (e.g., Section 5.2)
+
+## Current Text
+
+Quote the current text that is unclear:
+
+> [paste the unclear text here]
+
+## What's Unclear
+
+Explain what is ambiguous or confusing about this text.
+
+## Questions
+
+List specific questions you need answered:
+
+1.
+2.
+3.
+
+## Suggested Clarification
+
+If you have a suggestion for clearer wording, please provide it.
+
+## Context
+
+Why do you need this clarification? (e.g., implementing a feature, writing documentation)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Summary
+
+Brief description of the changes in this PR.
+
+## Type of Change
+
+- [ ] Specification addition (new feature/section)
+- [ ] Specification modification (changes to existing spec)
+- [ ] Bug fix (corrects an error in the spec)
+- [ ] Documentation (README, examples, design decisions)
+- [ ] Schema update (JSON schemas)
+- [ ] Other (describe below)
+
+## Related Issues
+
+Fixes #(issue number)
+
+## Changes Made
+
+-
+-
+-
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
+- [ ] My changes follow the existing specification style
+- [ ] I have updated relevant JSON schemas (if applicable)
+- [ ] I have added/updated examples (if applicable)
+- [ ] I have updated the design decisions document (if this is a significant change)
+- [ ] Section numbers are consistent and sequential
+
+## Compatibility
+
+- [ ] This is backward compatible with existing implementations
+- [ ] This requires updates to existing implementations (describe below)
+
+## Additional Notes
+
+Any additional context or notes for reviewers.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Contributor Covenant Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+For the full text, please visit: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it by contacting the project maintainers.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this specification, please report it responsibly.
+
+### For Specification Issues
+
+If you find a security flaw in the specification itself (e.g., a cryptographic weakness, a design flaw that could be exploited), please:
+
+1. **Do not** open a public issue
+2. Email the maintainers directly with details
+3. Allow reasonable time for the issue to be addressed before public disclosure
+
+### For Implementation Issues
+
+If you find a security issue in the reference implementation (cdx-core), please report it in that repository's security advisories.
+
+## Scope
+
+This security policy covers:
+
+- The Codex Document Format specification
+- JSON schemas in this repository
+- Example documents in this repository
+
+## Security Considerations in the Specification
+
+The specification includes several security-relevant sections:
+
+- **Document Hashing** (spec/core/06-document-hashing.md) - Content integrity
+- **State Machine** (spec/core/07-state-machine.md) - Document lifecycle security
+- **Security Extension** (spec/extensions/security/) - Signatures and encryption
+
+When implementing the specification, pay particular attention to these sections.
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |


### PR DESCRIPTION
## Summary
Sets up the repository for open source community engagement.

## Changes
- **Issue templates**: Bug report, feature request, spec clarification
- **PR template**: Standardized checklist for contributions
- **CODE_OF_CONDUCT.md**: Contributor Covenant v2.1
- **SECURITY.md**: Vulnerability reporting guidelines

## GitHub Settings Configured
- Branch protection on `main` (requires 1 approving review, dismisses stale reviews)
- GitHub Discussions enabled

## Test plan
- [ ] Verify issue templates appear when creating new issues
- [ ] Verify PR template appears when creating new PRs
- [ ] Verify branch protection prevents direct pushes to main