### PR TITLE
Add sentinel infrastructure, math blocks, and citation support

### DIFF
--- a/cdx-pandoc/README.md
+++ b/cdx-pandoc/README.md
@@ -59,7 +59,11 @@ Any format Pandoc can read:
 | BlockQuote | blockquote | Nested content |
 | HorizontalRule | horizontalRule | Thematic break |
 | Table | table | Headers and cells |
+| Math (display) | math | LaTeX format, display=true |
+| Math (inline) | math | LaTeX format, display=false; splits paragraph |
+| Cite | semantic:citation | ref, prefix, suffix, suppressAuthor |
 | Div | (unwrapped) | Contents extracted |
+| Div#refs | semantic:bibliography | Citeproc bibliography entries |
 
 ### Inline Formatting
 
@@ -194,9 +198,8 @@ Convert:
 ## Limitations
 
 - Images are referenced but not embedded (future enhancement)
-- Math blocks are converted to code format (LaTeX preserved)
-- Citations are rendered inline (bibliography extension planned)
 - Complex table formatting may be simplified
+- Citations require `--citeproc` flag for bibliography generation; without it, only inline citation blocks are emitted
 
 ## License
 

--- a/cdx-pandoc/codex.lua
+++ b/cdx-pandoc/codex.lua
@@ -101,6 +101,19 @@ function Writer(doc, opts)
     -- Create manifest
     local manifest = create_manifest()
 
+    -- Check if citations were used and add semantic extension declaration
+    local citation_keys = blocks.get_citation_keys()
+    local has_citations = false
+    for _ in pairs(citation_keys) do has_citations = true; break end
+
+    if has_citations then
+        manifest.extensions = {{
+            id = "codex.semantic",
+            version = "0.1",
+            required = false
+        }}
+    end
+
     -- Combine into output structure
     local output = {
         manifest = manifest,

--- a/cdx-pandoc/lib/blocks.lua
+++ b/cdx-pandoc/lib/blocks.lua
@@ -6,6 +6,9 @@ local M = {}
 -- Inlines module (will be set by init)
 local inlines = nil
 
+-- Track citation keys used in the document
+M._citation_keys = {}
+
 -- Set the inlines module reference
 function M.set_inlines(inlines_module)
     inlines = inlines_module
@@ -69,7 +72,13 @@ function M.convert_block(block)
         return M.table_block(block)
 
     elseif tag == "Div" then
-        -- Div is a container - unwrap its contents
+        local attr = block.attr or {}
+        local id = attr.identifier or (attr[1] or "")
+        if id == "refs" then
+            -- Citeproc bibliography Div — extract structured entries
+            return M.bibliography_from_refs(block)
+        end
+        -- Normal Div — unwrap contents
         return {
             multi = true,
             blocks = M.convert(block.content)
@@ -113,17 +122,105 @@ function M.convert_block(block)
     end
 end
 
--- Convert Para/Plain to paragraph
+-- Convert Para/Plain to paragraph (sentinel-aware)
 function M.paragraph(block)
     local content = block.content or block.c
-    if not content then
-        return nil
+    if not content then return nil end
+
+    local flat = inlines.flatten(content)
+
+    -- Check for any sentinels
+    local has_sentinel = false
+    for _, node in ipairs(flat) do
+        if node.type and node.type:match("_sentinel$") then
+            has_sentinel = true
+            break
+        end
     end
 
-    return {
-        type = "paragraph",
-        children = inlines.convert(content)
-    }
+    if not has_sentinel then
+        return {type = "paragraph", children = inlines.merge_adjacent(flat)}
+    end
+
+    -- Split around sentinels
+    local result_blocks = {}
+    local current_text = {}
+
+    for _, node in ipairs(flat) do
+        if node.type and node.type:match("_sentinel$") then
+            -- Flush accumulated text as paragraph
+            if #current_text > 0 then
+                local merged = inlines.merge_adjacent(current_text)
+                if #merged > 0 then
+                    table.insert(result_blocks, {type = "paragraph", children = merged})
+                end
+                current_text = {}
+            end
+            -- Convert sentinel to its target block(s)
+            local sentinel_blocks = M.convert_sentinel(node)
+            for _, sb in ipairs(sentinel_blocks) do
+                table.insert(result_blocks, sb)
+            end
+        else
+            table.insert(current_text, node)
+        end
+    end
+
+    -- Flush remaining text
+    if #current_text > 0 then
+        local merged = inlines.merge_adjacent(current_text)
+        if #merged > 0 then
+            table.insert(result_blocks, {type = "paragraph", children = merged})
+        end
+    end
+
+    if #result_blocks == 1 then
+        return result_blocks[1]
+    else
+        return {multi = true, blocks = result_blocks}
+    end
+end
+
+-- Convert a sentinel node to its target block(s)
+function M.convert_sentinel(node)
+    if node.type == "math_sentinel" then
+        return {{
+            type = "math",
+            display = (node.mathtype == "DisplayMath"),
+            format = "latex",
+            value = node.text
+        }}
+    elseif node.type == "citation_sentinel" then
+        return M.convert_citation_sentinel(node)
+    elseif node.type == "image_sentinel" then
+        return {{type = "image", src = node.src, alt = node.alt, title = node.title}}
+    else
+        return {}
+    end
+end
+
+-- Convert a citation sentinel to semantic:citation block(s)
+function M.convert_citation_sentinel(node)
+    local result = {}
+    for _, cite in ipairs(node.citations) do
+        M._citation_keys[cite.id] = true
+        local block = {
+            type = "semantic:citation",
+            ref = cite.id,
+        }
+        if cite.prefix and cite.prefix ~= "" then block.prefix = cite.prefix end
+        if cite.suffix and cite.suffix ~= "" then block.suffix = cite.suffix end
+        if cite.mode == "SuppressAuthor" then block.suppressAuthor = true end
+        table.insert(result, block)
+    end
+    return result
+end
+
+-- Get citation keys collected during conversion and reset tracker
+function M.get_citation_keys()
+    local keys = M._citation_keys
+    M._citation_keys = {}
+    return keys
 end
 
 -- Convert Header to heading
@@ -497,6 +594,32 @@ function M.image(img, caption)
     end
 
     return result
+end
+
+-- Convert citeproc #refs Div to a bibliography block
+function M.bibliography_from_refs(block)
+    local entries = {}
+    for _, child in ipairs(block.content) do
+        if child.t == "Div" then
+            local entry_id = child.attr and (child.attr.identifier or child.attr[1]) or ""
+            local text = pandoc.utils.stringify(child)
+            if entry_id ~= "" then
+                table.insert(entries, {
+                    id = entry_id:gsub("^ref%-", ""),
+                    entryType = "other",
+                    title = text,
+                })
+            end
+        end
+    end
+    if #entries > 0 then
+        return {
+            type = "semantic:bibliography",
+            style = "apa",
+            entries = entries,
+        }
+    end
+    return {multi = true, blocks = {}}
 end
 
 return M

--- a/cdx-pandoc/lib/inlines.lua
+++ b/cdx-pandoc/lib/inlines.lua
@@ -157,10 +157,12 @@ function M.convert_inline(inline, marks)
         return {M.text_node(inline.caption and pandoc.utils.stringify(inline.caption) or "[image]", marks)}
 
     elseif tag == "Math" then
-        -- Inline math - represent as code for now (could be extension)
-        local new_marks = deep_copy(marks)
-        table.insert(new_marks, "code")
-        return {M.text_node(inline.text, new_marks)}
+        return {{
+            type = "math_sentinel",
+            mathtype = inline.mathtype,
+            text = inline.text,
+            value = ""
+        }}
 
     elseif tag == "RawInline" then
         -- Raw content - just include as text
@@ -178,8 +180,16 @@ function M.convert_inline(inline, marks)
         return nodes
 
     elseif tag == "Cite" then
-        -- Citations - just render the content for now
-        return M.flatten(inline.content, marks)
+        local citations = {}
+        for _, c in ipairs(inline.citations) do
+            table.insert(citations, {
+                id = c.id,
+                mode = c.mode,
+                prefix = c.prefix and pandoc.utils.stringify(c.prefix) or nil,
+                suffix = c.suffix and pandoc.utils.stringify(c.suffix) or nil,
+            })
+        end
+        return {{type = "citation_sentinel", citations = citations, value = ""}}
 
     elseif tag == "SmallCaps" then
         -- SmallCaps not supported in Codex, render as-is
@@ -223,36 +233,55 @@ function M.text_node(value, marks)
     return node
 end
 
+-- Check if a node is a sentinel (non-text node that needs block-level handling)
+local function is_sentinel(node)
+    return node.type and node.type:match("_sentinel$")
+end
+
 -- Merge adjacent text nodes with identical marks
--- @param nodes Array of text nodes
--- @return Merged array of text nodes
+-- Sentinel nodes are passed through untouched
+-- @param nodes Array of text nodes (and possibly sentinel nodes)
+-- @return Merged array of nodes
 function M.merge_adjacent(nodes)
     if #nodes == 0 then
         return {}
     end
 
     local result = {}
-    local current = deep_copy(nodes[1])
+    local current = nil
 
-    for i = 2, #nodes do
-        local node = nodes[i]
-        local current_marks = current.marks or {}
-        local node_marks = node.marks or {}
-
-        if marks_arrays_equal(current_marks, node_marks) then
-            -- Same marks, merge text
-            current.value = current.value .. node.value
-        else
-            -- Different marks, push current and start new
-            if current.value ~= "" then
-                table.insert(result, current)
+    for _, node in ipairs(nodes) do
+        if is_sentinel(node) then
+            -- Flush current text node if any
+            if current then
+                if current.value ~= "" then
+                    table.insert(result, current)
+                end
+                current = nil
             end
+            -- Pass sentinel through as-is
+            table.insert(result, node)
+        elseif current == nil then
             current = deep_copy(node)
+        else
+            local current_marks = current.marks or {}
+            local node_marks = node.marks or {}
+
+            if marks_arrays_equal(current_marks, node_marks) then
+                -- Same marks, merge text
+                current.value = current.value .. node.value
+            else
+                -- Different marks, push current and start new
+                if current.value ~= "" then
+                    table.insert(result, current)
+                end
+                current = deep_copy(node)
+            end
         end
     end
 
     -- Don't forget the last node
-    if current.value ~= "" then
+    if current and current.value ~= "" then
         table.insert(result, current)
     end
 

--- a/cdx-pandoc/tests/inputs/citations.md
+++ b/cdx-pandoc/tests/inputs/citations.md
@@ -1,0 +1,11 @@
+---
+title: Citation Test
+author: Test Author
+---
+# Introduction
+
+As shown by @smith2023, the results are significant.
+
+This has been confirmed [-@jones2024, pp. 42-45].
+
+Multiple citations [@smith2023; @jones2024] support this.

--- a/cdx-pandoc/tests/inputs/math.md
+++ b/cdx-pandoc/tests/inputs/math.md
@@ -1,0 +1,19 @@
+---
+title: Math Test
+author: Test Author
+---
+# Math Examples
+
+The equation $E = mc^2$ is famous.
+
+$$\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}$$
+
+Mixed: start $a + b$ middle $c + d$ end.
+
+$x = 1$ starts a paragraph.
+
+A paragraph ends with $y = 2$.
+
+$\alpha$$\beta$ consecutive math (no text between).
+
+> Blockquote with $inline$ math.


### PR DESCRIPTION
## Summary
- Refactors paragraph conversion with a sentinel-aware splitting mechanism — any inline that can't be a text node (math, citations, images) returns a sentinel from `inlines.lua`, and the paragraph converter detects and splits around them
- Math inlines (`$...$` and `$$...$$`) produce `{type:"math", display:bool, format:"latex", value:string}` blocks
- Citations produce `semantic:citation` blocks with `ref`, `prefix`, `suffix`, and `suppressAuthor` fields
- Citeproc `#refs` Div is converted to a `semantic:bibliography` block with extracted entries
- Manifest declares the `codex.semantic` extension when citations are present
- Adds test inputs for math edge cases (paragraph splitting, consecutive math, blockquote math) and citations

## Test plan
- [x] `make test` passes — all 5 test inputs produce valid JSON
- [x] `make validate` passes — all JSON outputs have correct structure
- [x] Display math produces `{type:"math", display:true, format:"latex"}`
- [x] Inline math splits surrounding paragraph correctly (no empty paragraphs)
- [x] Consecutive math expressions produce adjacent math blocks
- [x] Math inside blockquotes works
- [x] Citation blocks have correct `ref`, `prefix`, `suffix`, `suppressAuthor`
- [x] Manifest declares semantic extension when citations are present
- [x] Existing tests (basic, nested, tables) are not regressed