### PR TITLE
Add footnote accumulation and image enhancements

### DIFF
--- a/cdx-pandoc/README.md
+++ b/cdx-pandoc/README.md
@@ -62,6 +62,9 @@ Any format Pandoc can read:
 | Math (display) | math | LaTeX format, display=true |
 | Math (inline) | math | LaTeX format, display=false; splits paragraph |
 | Cite | semantic:citation | ref, prefix, suffix, suppressAuthor |
+| Note | semantic:footnote | Superscript ref + block content |
+| Image | image | src, alt, title, width, height |
+| Figure | image | Extracts image with caption |
 | Div | (unwrapped) | Contents extracted |
 | Div#refs | semantic:bibliography | Citeproc bibliography entries |
 
@@ -197,9 +200,10 @@ Convert:
 
 ## Limitations
 
-- Images are referenced but not embedded (future enhancement)
+- Images are referenced by path but not embedded in the archive (future enhancement)
 - Complex table formatting may be simplified
 - Citations require `--citeproc` flag for bibliography generation; without it, only inline citation blocks are emitted
+- Footnote content is appended as blocks at the end of the document
 
 ## License
 

--- a/cdx-pandoc/codex.lua
+++ b/cdx-pandoc/codex.lua
@@ -98,15 +98,25 @@ function Writer(doc, opts)
     -- Convert blocks
     local content = create_content(doc.blocks)
 
+    -- Append accumulated footnotes as semantic:footnote blocks
+    local footnotes = inlines.get_footnotes()
+    local has_footnotes = #footnotes > 0
+    if has_footnotes then
+        local footnote_blocks = blocks.convert_footnotes(footnotes)
+        for _, fb in ipairs(footnote_blocks) do
+            table.insert(content.blocks, fb)
+        end
+    end
+
     -- Create manifest
     local manifest = create_manifest()
 
-    -- Check if citations were used and add semantic extension declaration
+    -- Check if semantic extensions were used (citations or footnotes)
     local citation_keys = blocks.get_citation_keys()
     local has_citations = false
     for _ in pairs(citation_keys) do has_citations = true; break end
 
-    if has_citations then
+    if has_citations or has_footnotes then
         manifest.extensions = {{
             id = "codex.semantic",
             version = "0.1",

--- a/cdx-pandoc/tests/inputs/footnotes.md
+++ b/cdx-pandoc/tests/inputs/footnotes.md
@@ -1,0 +1,12 @@
+---
+title: Footnote Test
+author: Test Author
+---
+# Introduction
+
+This is a statement with a footnote[^1].
+
+Another reference[^note2].
+
+[^1]: This is the first footnote content.
+[^note2]: This is the second footnote with **formatting**.

--- a/cdx-pandoc/tests/inputs/images.md
+++ b/cdx-pandoc/tests/inputs/images.md
@@ -1,0 +1,9 @@
+---
+title: Image Test
+author: Test Author
+---
+# Images
+
+![Alt text](photo.png "Caption text"){width=800 height=600}
+
+An inline image: ![icon](icon.svg).


### PR DESCRIPTION
## Summary
- Footnotes are collected during inline conversion with sequential numbering — references appear as superscript marks in paragraph text, and accumulated content is appended as `semantic:footnote` blocks at the end of the document
- Inline images now use the sentinel pattern, producing proper image blocks instead of `[image]` text
- Image blocks extract `width` and `height` from Pandoc attributes when present
- Manifest declares `codex.semantic` extension when footnotes are present (deduplicated with citations)

**Depends on**: #5 (sentinel infrastructure)

## Test plan
- [x] `make test` passes — all 7 test inputs produce valid JSON
- [x] `make validate` passes — all JSON outputs have correct structure
- [x] Footnote numbers appear as superscript marks in paragraph text
- [x] `semantic:footnote` blocks at end of content with correct `number` and `children`
- [x] Footnote content preserves formatting (bold, etc.)
- [x] Image blocks include `width`/`height` when specified
- [x] Inline images produce image blocks (not `[image]` text)
- [x] Manifest declares semantic extension when footnotes are present
- [x] Existing tests (basic, nested, tables, math, citations) are not regressed