### PR TITLE
Add Pandoc reader for Codex format

### DIFF
--- a/cdx-pandoc/Makefile
+++ b/cdx-pandoc/Makefile
@@ -9,7 +9,7 @@ TEST_INPUTS := $(wildcard tests/inputs/*.md)
 TEST_OUTPUTS := $(patsubst tests/inputs/%.md,tests/outputs/%.json,$(TEST_INPUTS))
 TEST_CDX := $(patsubst tests/inputs/%.md,tests/outputs/%.cdx,$(TEST_INPUTS))
 
-.PHONY: all test clean test-json test-cdx help check-deps
+.PHONY: all test clean test-json test-cdx test-reader help check-deps
 
 all: test
 
@@ -17,10 +17,11 @@ help:
 	@echo "Codex Pandoc Writer"
 	@echo ""
 	@echo "Targets:"
-	@echo "  test        Run all tests (JSON output)"
-	@echo "  test-cdx    Run full pipeline tests (creates .cdx files)"
-	@echo "  clean       Remove generated files"
-	@echo "  check-deps  Check for required dependencies"
+	@echo "  test         Run all tests (JSON output)"
+	@echo "  test-cdx     Run full pipeline tests (creates .cdx files)"
+	@echo "  test-reader  Test round-trip (JSON → Pandoc → markdown)"
+	@echo "  clean        Remove generated files"
+	@echo "  check-deps   Check for required dependencies"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make test"
@@ -69,6 +70,16 @@ validate: test-json
 		echo "  OK"; \
 	done
 	@echo "Validation complete."
+
+# Test reader round-trip: JSON → Pandoc → markdown
+test-reader: test-json
+	@echo "Testing round-trip..."
+	@for f in tests/outputs/*.json; do \
+		base=$$(basename $$f .json); \
+		echo "Round-trip: $$base"; \
+		$(PANDOC) -f cdx-reader.lua $$f -t markdown > tests/outputs/$$base.roundtrip.md 2>/dev/null && echo "  OK" || echo "  FAIL"; \
+	done
+	@echo "Reader tests complete."
 
 # Clean generated files
 clean:

--- a/cdx-pandoc/README.md
+++ b/cdx-pandoc/README.md
@@ -45,6 +45,18 @@ Any format Pandoc can read:
 - reStructuredText (.rst)
 - And many more...
 
+## Reading Codex Documents
+
+Convert Codex JSON back to any Pandoc-supported output format:
+
+```bash
+pandoc -f cdx-reader.lua output.json -o document.md
+pandoc -f cdx-reader.lua output.json -o document.tex
+pandoc -f cdx-reader.lua output.json -o document.html
+```
+
+The reader handles core block types (paragraphs, headings, lists, code blocks, blockquotes, tables, math, images). Extension blocks (`semantic:citation`, `semantic:footnote`) are silently skipped.
+
 ## Features
 
 ### Block Types Supported
@@ -137,23 +149,27 @@ The packaging script extracts these into the proper Codex directory structure.
 make test          # Run JSON output tests
 make validate      # Validate JSON structure
 make test-cdx      # Run full pipeline tests
+make test-reader   # Test round-trip (JSON → markdown)
 ```
 
 ### Project Structure
 
 ```
 cdx-pandoc/
-├── codex.lua           # Main Pandoc custom writer
+├── codex.lua              # Main Pandoc custom writer
+├── cdx-reader.lua         # Codex → Pandoc reader
 ├── lib/
-│   ├── blocks.lua      # Block type converters
-│   ├── inlines.lua     # Inline/text node converters
-│   ├── metadata.lua    # Dublin Core extraction
-│   └── json.lua        # JSON encoding utilities
+│   ├── blocks.lua         # Writer: block type converters
+│   ├── inlines.lua        # Writer: inline/text node converters
+│   ├── metadata.lua       # Writer: Dublin Core extraction
+│   ├── json.lua           # Writer: JSON encoding utilities
+│   ├── reader_blocks.lua  # Reader: block type reverse mapping
+│   └── reader_inlines.lua # Reader: mark → inline wrapping
 ├── scripts/
-│   └── pandoc-to-cdx.sh  # Full pipeline wrapper
+│   └── pandoc-to-cdx.sh   # Full pipeline wrapper
 ├── tests/
-│   ├── inputs/         # Test input files
-│   └── outputs/        # Generated test outputs
+│   ├── inputs/            # Test input files
+│   └── outputs/           # Generated test outputs
 ├── Makefile
 └── README.md
 ```

--- a/cdx-pandoc/cdx-reader.lua
+++ b/cdx-pandoc/cdx-reader.lua
@@ -1,0 +1,101 @@
+-- Codex Document Format → Pandoc Reader
+-- Converts Codex JSON to Pandoc AST for output to any format.
+--
+-- Usage:
+--   pandoc -f cdx-reader.lua output.json -o document.md
+--   pandoc -f cdx-reader.lua output.json -o document.tex
+--   pandoc -f cdx-reader.lua output.json -o document.html
+
+-- Dynamically find and load library modules
+local function load_lib(name)
+    local paths = {
+        "lib/" .. name .. ".lua",
+        "cdx-pandoc/lib/" .. name .. ".lua",
+        PANDOC_SCRIPT_FILE and (PANDOC_SCRIPT_FILE:match("(.*/)" ) or "") .. "lib/" .. name .. ".lua",
+    }
+    for _, path in ipairs(paths) do
+        local f = io.open(path, "r")
+        if f then
+            f:close()
+            return dofile(path)
+        end
+    end
+    error("Cannot find library: " .. name)
+end
+
+local reader_blocks = load_lib("reader_blocks")
+local reader_inlines = load_lib("reader_inlines")
+
+-- Initialize cross-module references
+reader_blocks.set_inlines(reader_inlines)
+
+-- Reconstruct Pandoc metadata from Dublin Core
+local function reconstruct_metadata(dc)
+    if not dc then return pandoc.Meta({}) end
+
+    local meta = {}
+    local terms = dc.terms or dc
+
+    if terms.title then
+        meta.title = pandoc.MetaInlines({pandoc.Str(terms.title)})
+    end
+
+    -- Handle creator as string or array
+    if terms.creator then
+        if type(terms.creator) == "string" then
+            meta.author = pandoc.MetaList({
+                pandoc.MetaInlines({pandoc.Str(terms.creator)})
+            })
+        elseif type(terms.creator) == "table" then
+            local authors = {}
+            for _, a in ipairs(terms.creator) do
+                table.insert(authors, pandoc.MetaInlines({pandoc.Str(a)}))
+            end
+            meta.author = pandoc.MetaList(authors)
+        end
+    end
+
+    if terms.date then
+        meta.date = pandoc.MetaInlines({pandoc.Str(terms.date)})
+    end
+
+    if terms.description then
+        meta.abstract = pandoc.MetaBlocks({pandoc.Para({pandoc.Str(terms.description)})})
+    end
+
+    if terms.language then
+        meta.lang = pandoc.MetaString(terms.language)
+    end
+
+    if terms.subject then
+        if type(terms.subject) == "string" then
+            meta.keywords = pandoc.MetaList({pandoc.MetaString(terms.subject)})
+        elseif type(terms.subject) == "table" then
+            local keywords = {}
+            for _, k in ipairs(terms.subject) do
+                table.insert(keywords, pandoc.MetaString(k))
+            end
+            meta.keywords = pandoc.MetaList(keywords)
+        end
+    end
+
+    return pandoc.Meta(meta)
+end
+
+-- Main reader function
+function Reader(input, opts)
+    local json_str = tostring(input)
+    local parsed = pandoc.json.decode(json_str)
+
+    -- Extract content blocks
+    local content = parsed.content or parsed
+    local raw_blocks = content.blocks or {}
+
+    -- Convert blocks
+    local pandoc_blocks = reader_blocks.convert(raw_blocks)
+
+    -- Reconstruct metadata
+    local meta = reconstruct_metadata(parsed.dublin_core)
+
+    return pandoc.Pandoc(pandoc_blocks, meta)
+end

--- a/cdx-pandoc/lib/reader_blocks.lua
+++ b/cdx-pandoc/lib/reader_blocks.lua
@@ -1,0 +1,227 @@
+-- Reader: Codex blocks → Pandoc blocks
+-- Converts Codex block types to Pandoc AST block elements.
+
+local M = {}
+
+local reader_inlines = nil
+
+function M.set_inlines(mod)
+    reader_inlines = mod
+end
+
+-- Convert an array of Codex blocks to Pandoc blocks
+function M.convert(blocks)
+    local result = {}
+    for _, block in ipairs(blocks) do
+        local converted = M.convert_block(block)
+        if converted then
+            if type(converted) == "table" and converted.tag then
+                -- Single Pandoc element
+                table.insert(result, converted)
+            elseif type(converted) == "table" and #converted > 0 then
+                -- Array of Pandoc elements
+                for _, b in ipairs(converted) do
+                    table.insert(result, b)
+                end
+            end
+        end
+    end
+    return result
+end
+
+-- Convert a single Codex block to Pandoc block(s)
+function M.convert_block(block)
+    local btype = block.type or ""
+
+    if btype == "paragraph" then
+        return M.paragraph(block)
+    elseif btype == "heading" then
+        return M.heading(block)
+    elseif btype == "codeBlock" then
+        return M.code_block(block)
+    elseif btype == "blockquote" then
+        return M.blockquote(block)
+    elseif btype == "list" then
+        return M.list(block)
+    elseif btype == "horizontalRule" then
+        return pandoc.HorizontalRule()
+    elseif btype == "table" then
+        return M.table_block(block)
+    elseif btype == "math" then
+        return M.math_block(block)
+    elseif btype == "image" then
+        return M.image_block(block)
+    elseif btype:match("^semantic:") or btype:match("^forms:") or btype:match("^collaboration:") then
+        -- Extension blocks — silently skip
+        io.stderr:write("cdx-reader: skipping extension block: " .. btype .. "\n")
+        return nil
+    elseif btype == "listItem" or btype == "tableRow" or btype == "tableCell" then
+        -- Sub-block types handled by their parent converter
+        return nil
+    else
+        if btype ~= "" then
+            io.stderr:write("cdx-reader: unknown block type: " .. btype .. "\n")
+        end
+        return nil
+    end
+end
+
+-- Paragraph
+function M.paragraph(block)
+    local inlines = reader_inlines.convert(block.children or {})
+    if #inlines == 0 then return nil end
+    return pandoc.Para(inlines)
+end
+
+-- Heading
+function M.heading(block)
+    local level = block.level or 1
+    local inlines = reader_inlines.convert(block.children or {})
+    local attr = pandoc.Attr(block.id or "")
+    return pandoc.Header(level, inlines, attr)
+end
+
+-- Code block
+function M.code_block(block)
+    local text = ""
+    if block.children then
+        for _, child in ipairs(block.children) do
+            if child.value then
+                text = text .. child.value
+            end
+        end
+    end
+    local lang = block.language or ""
+    local attr = pandoc.Attr("", lang ~= "" and {lang} or {})
+    return pandoc.CodeBlock(text, attr)
+end
+
+-- Blockquote
+function M.blockquote(block)
+    local inner_blocks = M.convert(block.children or {})
+    return pandoc.BlockQuote(inner_blocks)
+end
+
+-- List (ordered or unordered)
+function M.list(block)
+    local items = {}
+    for _, child in ipairs(block.children or {}) do
+        if child.type == "listItem" then
+            local item_blocks = M.convert_list_item(child)
+            table.insert(items, item_blocks)
+        end
+    end
+
+    if block.ordered then
+        local start = block.start or 1
+        return pandoc.OrderedList(items, pandoc.ListAttributes(start))
+    else
+        return pandoc.BulletList(items)
+    end
+end
+
+-- Convert a single list item to an array of blocks
+function M.convert_list_item(item)
+    local blocks = {}
+    for _, child in ipairs(item.children or {}) do
+        local converted = M.convert_block(child)
+        if converted then
+            if type(converted) == "table" and converted.tag then
+                table.insert(blocks, converted)
+            elseif type(converted) == "table" and #converted > 0 then
+                for _, b in ipairs(converted) do
+                    table.insert(blocks, b)
+                end
+            end
+        end
+    end
+    -- If no blocks, try to create a plain text from children directly
+    if #blocks == 0 then
+        local inlines = reader_inlines.convert(item.children or {})
+        if #inlines > 0 then
+            table.insert(blocks, pandoc.Plain(inlines))
+        end
+    end
+    return blocks
+end
+
+-- Table (uses SimpleTable for broad Pandoc version compatibility)
+function M.table_block(block)
+    local header_cells = {}
+    local body_rows = {}
+    local num_cols = 0
+
+    for _, child in ipairs(block.children or {}) do
+        if child.type == "tableRow" then
+            local cells = {}
+            for _, cell_block in ipairs(child.children or {}) do
+                if cell_block.type == "tableCell" then
+                    local cell_inlines = reader_inlines.convert(cell_block.children or {})
+                    table.insert(cells, cell_inlines)
+                end
+            end
+            if #cells > num_cols then num_cols = #cells end
+
+            if child.header then
+                header_cells = cells
+            else
+                table.insert(body_rows, cells)
+            end
+        end
+    end
+
+    -- Build alignment and width specs
+    local aligns = {}
+    local widths = {}
+    for _ = 1, num_cols do
+        table.insert(aligns, pandoc.AlignDefault)
+        table.insert(widths, 0)
+    end
+
+    -- Pad rows to num_cols
+    local function pad_row(row)
+        while #row < num_cols do
+            table.insert(row, {})
+        end
+        return row
+    end
+
+    header_cells = pad_row(header_cells)
+    for i, row in ipairs(body_rows) do
+        body_rows[i] = pad_row(row)
+    end
+
+    local simple = pandoc.SimpleTable(
+        {},            -- caption
+        aligns,
+        widths,
+        header_cells,
+        body_rows
+    )
+
+    return pandoc.utils.from_simple_table(simple)
+end
+
+-- Math block
+function M.math_block(block)
+    local math_type = block.display and pandoc.DisplayMath or pandoc.InlineMath
+    local math_el = pandoc.Math(math_type, block.value or "")
+    return pandoc.Para({math_el})
+end
+
+-- Image block
+function M.image_block(block)
+    local src = block.src or ""
+    local alt = block.alt or ""
+    local title = block.title or ""
+
+    local alt_inlines = {}
+    if alt ~= "" then
+        alt_inlines = {pandoc.Str(alt)}
+    end
+
+    local img = pandoc.Image(alt_inlines, src, title)
+    return pandoc.Figure(pandoc.Plain({img}))
+end
+
+return M

--- a/cdx-pandoc/lib/reader_inlines.lua
+++ b/cdx-pandoc/lib/reader_inlines.lua
@@ -1,0 +1,105 @@
+-- Reader: Codex text nodes → Pandoc inlines
+-- Converts Codex text nodes with marks to Pandoc inline elements.
+
+local M = {}
+
+-- Mark type to Pandoc inline constructor mapping
+-- Order matters: we wrap from innermost to outermost.
+local mark_wrappers = {
+    bold = function(inlines) return pandoc.Strong(inlines) end,
+    italic = function(inlines) return pandoc.Emph(inlines) end,
+    strikethrough = function(inlines) return pandoc.Strikeout(inlines) end,
+    underline = function(inlines) return pandoc.Underline(inlines) end,
+    superscript = function(inlines) return pandoc.Superscript(inlines) end,
+    subscript = function(inlines) return pandoc.Subscript(inlines) end,
+}
+
+-- Convert an array of Codex text nodes to Pandoc inlines
+function M.convert(nodes)
+    local result = {}
+    for _, node in ipairs(nodes) do
+        local inlines = M.convert_node(node)
+        for _, inline in ipairs(inlines) do
+            table.insert(result, inline)
+        end
+    end
+    return result
+end
+
+-- Convert a single text node to Pandoc inline(s)
+function M.convert_node(node)
+    -- Handle non-text nodes (shouldn't appear in reader input, but be safe)
+    if not node.value and not node.type then
+        return {}
+    end
+
+    -- Skip sentinel types that might appear
+    if node.type and node.type:match("_sentinel$") then
+        return {}
+    end
+
+    local text = node.value or ""
+    if text == "" and not (node.marks and #node.marks > 0) then
+        return {}
+    end
+
+    local marks = node.marks or {}
+
+    -- Start with the text content
+    -- Handle Code mark specially — it wraps text as pandoc.Code
+    local has_code = false
+    local has_link = nil
+    local other_marks = {}
+
+    for _, mark in ipairs(marks) do
+        local mark_type = M.get_mark_type(mark)
+        if mark_type == "code" then
+            has_code = true
+        elseif mark_type == "link" then
+            has_link = mark
+        else
+            table.insert(other_marks, mark_type)
+        end
+    end
+
+    -- Build the inline element
+    local inline
+    if has_code then
+        inline = pandoc.Code(text)
+    else
+        inline = pandoc.Str(text)
+    end
+
+    -- Wrap in formatting marks (innermost first)
+    for _, mark_type in ipairs(other_marks) do
+        local wrapper = mark_wrappers[mark_type]
+        if wrapper then
+            inline = wrapper({inline})
+        end
+    end
+
+    -- Wrap in link if present
+    if has_link then
+        local href = ""
+        local title = ""
+        if type(has_link) == "table" then
+            href = has_link.href or ""
+            title = has_link.title or ""
+        end
+        inline = pandoc.Link({inline}, href, title)
+    end
+
+    return {inline}
+end
+
+-- Extract mark type from a mark (handles both string and table formats)
+function M.get_mark_type(mark)
+    if type(mark) == "string" then
+        return mark
+    elseif type(mark) == "table" then
+        return mark.type or "unknown"
+    end
+    return "unknown"
+end
+
+return M


### PR DESCRIPTION
## Summary

- Adds `cdx-reader.lua` enabling round-trip conversion from Codex JSON back to any Pandoc-supported output format (Markdown, LaTeX, HTML, etc.)
- Supports all core block types: paragraph, heading, codeBlock, blockquote, list, horizontalRule, table, math, image
- Extension blocks (`semantic:citation`, `semantic:footnote`) are silently skipped with stderr warning
- Reconstructs Dublin Core metadata into Pandoc metadata fields

## Design

Modular structure matching the writer's architecture:
- `cdx-reader.lua` — Main entry point with `Reader()` function and metadata reconstruction
- `lib/reader_blocks.lua` — Block type reverse mapping (Codex blocks → Pandoc AST blocks)
- `lib/reader_inlines.lua` — Text node mark wrapping (Codex marks → Pandoc inline constructors)

Uses `pandoc.SimpleTable` + `pandoc.utils.from_simple_table()` for table conversion, ensuring compatibility with Pandoc 3.x.

## Test plan

- [x] `make test` — All 7 writer JSON tests pass
- [x] `make validate` — All 7 JSON structure validations pass
- [x] `make test-reader` — All 7 round-trip tests pass (basic, citations, footnotes, images, math, nested, tables)
- [ ] Verify round-trip preserves headings, paragraphs, bold/italic/code formatting, links, ordered/unordered lists, code blocks with language, blockquotes, horizontal rules
- [ ] Verify math blocks round-trip to `$...$` / `$$...$$`
- [ ] Verify extension blocks are silently skipped (no errors)