### PR TITLE
Fix 22 issues from comprehensive spec review

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,15 @@ Codex uses **progressive enhancement** for presentation — the level of layout 
 |----------------|-------------------------|---------------|
 | DRAFT | Reactive only (hints/styles) | Nothing — content flows freely |
 | REVIEW | Reactive (precise optional) | Nothing — still editing |
-| FROZEN | Reactive + **precise required** | Content AND exact appearance |
+| FROZEN | Reactive + **precise required** | Content immutable; appearance locked |
 | PUBLISHED | Same as FROZEN | Authoritative, immutable record |
 
 ### Why This Matters
 
 When a document reaches FROZEN or PUBLISHED state, its **precise layout** (exact coordinates for every element) becomes part of the immutable record:
 
-- **Layout is part of the hash**: The document's identity includes its exact visual appearance
+- **Semantic content is the hash**: The document ID covers semantic content only — what it says, not how it looks
+- **Appearance is locked alongside content**: Precise layouts are immutable when frozen, but separate from the content hash. Use scoped signatures (Security Extension) for appearance attestation
 - **Citations are reliable**: "Page 7, line 23" means the same thing in every viewer
 - **Legal/archival integrity**: Frozen documents render pixel-perfectly, forever
 - **No viewer inconsistency**: Unlike PDF, whose appearance varies by renderer
@@ -123,15 +124,13 @@ This is the key insight: **the state machine isn't just about workflow** — it 
 ```
 DRAFT                    FROZEN/PUBLISHED
 ┌─────────────────┐      ┌─────────────────┐
-│ Semantic content│      │ Semantic content│
-│ (JSON blocks)   │      │ (JSON blocks)   │
+│ Semantic content│      │ Semantic content│  ← Document ID
+│ (JSON blocks)   │      │ (JSON blocks)   │    (content hash)
 ├─────────────────┤      ├─────────────────┤
 │ Reactive hints  │  →   │ Reactive hints  │
-│ (optional)      │      │ + Precise layout│ ← Required
-└─────────────────┘      │ (exact coords)  │
-                         └─────────────────┘
-                                ↓
-                         Included in hash
+│ (optional)      │      │ + Precise layout│ ← Required, immutable
+└─────────────────┘      │ (exact coords)  │    (scoped signatures
+                         └─────────────────┘     for attestation)
 ```
 
 ## Specification Structure

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -447,6 +447,29 @@ This document records key design decisions made during the Codex format specific
 
 ---
 
+## DD-019: Declarative Forms Validation Only
+
+**Decision**: Form validation rules must be purely declarative JSON. No executable expressions (JavaScript or otherwise) are permitted.
+
+**Alternatives Considered**:
+1. JavaScript expression strings (like PDF form scripts)
+2. Sandboxed expression language
+3. WebAssembly-based validators
+4. No custom validation (built-in validators only)
+
+**Rationale**:
+- **Consistent with DD-010** — The core specification explicitly excludes executable content. PDF JavaScript is cited as a cautionary tale in DD-010, and allowing it in form validation would undermine that decision
+- **Security** — Expression evaluation opens injection attack vectors. Even "sandboxed" JavaScript has a long history of sandbox escapes
+- **Declarative sufficiency** — The built-in validators (`required`, `minLength`, `maxLength`, `min`, `max`, `pattern`, `email`, `url`, `containsUppercase`, `containsDigit`, `containsSpecial`, `matchesField`) cover the vast majority of form validation needs
+- **Pattern validator as escape hatch** — The `pattern` validator accepts regular expressions, providing complex string matching without executable code
+- **Implementer simplicity** — Declarative rules can be validated by any JSON processor without requiring a JavaScript runtime
+
+**Consequences**:
+- Some highly dynamic validation (e.g., "field B required only if field A > 10") is not expressible. This is an acceptable limitation — such logic belongs in the application layer, not the document format
+- The `pattern` validator inherits regex complexity concerns, but regex is well-understood and does not enable arbitrary code execution
+
+---
+
 ## Open Questions
 
 ### OQ-001: Binary Variant

--- a/schemas/precise-layout.schema.json
+++ b/schemas/precise-layout.schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codex.document/schemas/precise-layout.schema.json",
+  "title": "Codex Precise Layout",
+  "description": "Schema for precise layout files (presentation/layouts/*.json) in a Codex document. Required for FROZEN and PUBLISHED states.",
+  "type": "object",
+  "required": ["version", "presentationType", "targetFormat", "pageSize", "contentHash", "generatedAt", "pages"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Layout format version",
+      "pattern": "^\\d+\\.\\d+$"
+    },
+    "presentationType": {
+      "type": "string",
+      "description": "Must be 'precise'",
+      "const": "precise"
+    },
+    "targetFormat": {
+      "type": "string",
+      "description": "Page format name (letter, a4, legal, custom)"
+    },
+    "pageSize": {
+      "type": "object",
+      "required": ["width", "height"],
+      "properties": {
+        "width": {
+          "type": "string",
+          "description": "Page width with unit"
+        },
+        "height": {
+          "type": "string",
+          "description": "Page height with unit"
+        }
+      }
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Hash of content when layout was generated. Must match current content hash for FROZEN/PUBLISHED.",
+      "pattern": "^[a-z0-9-]+:[a-f0-9]+$"
+    },
+    "generatedAt": {
+      "type": "string",
+      "description": "ISO 8601 timestamp when layout was generated",
+      "format": "date-time"
+    },
+    "pageTemplate": {
+      "$ref": "#/$defs/pageTemplate"
+    },
+    "pages": {
+      "type": "array",
+      "description": "Array of page definitions with precisely positioned elements",
+      "items": {
+        "$ref": "#/$defs/page"
+      },
+      "minItems": 1
+    },
+    "fonts": {
+      "type": "object",
+      "description": "Font metrics for exact text reproduction",
+      "additionalProperties": {
+        "$ref": "#/$defs/fontMetrics"
+      }
+    }
+  },
+  "$defs": {
+    "page": {
+      "type": "object",
+      "required": ["number", "elements"],
+      "properties": {
+        "number": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Page number"
+        },
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/preciseElement"
+          }
+        }
+      }
+    },
+    "preciseElement": {
+      "type": "object",
+      "required": ["blockId", "x", "y", "width", "height"],
+      "properties": {
+        "blockId": {
+          "type": "string",
+          "description": "Reference to content block ID"
+        },
+        "x": {
+          "type": "string",
+          "description": "Horizontal position from left edge"
+        },
+        "y": {
+          "type": "string",
+          "description": "Vertical position from top edge"
+        },
+        "width": {
+          "type": "string",
+          "description": "Element width"
+        },
+        "height": {
+          "type": "string",
+          "description": "Element height"
+        },
+        "continues": {
+          "type": "boolean",
+          "description": "True if element continues to next page"
+        },
+        "continuation": {
+          "type": "boolean",
+          "description": "True if element is continued from previous page"
+        },
+        "lines": {
+          "type": "array",
+          "description": "Line-level coordinates for legal/court documents",
+          "items": {
+            "$ref": "#/$defs/linePrecision"
+          }
+        }
+      }
+    },
+    "linePrecision": {
+      "type": "object",
+      "required": ["number", "y", "height"],
+      "properties": {
+        "number": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Line number"
+        },
+        "y": {
+          "type": "string",
+          "description": "Vertical position of line"
+        },
+        "height": {
+          "type": "string",
+          "description": "Line height"
+        }
+      }
+    },
+    "pageTemplate": {
+      "type": "object",
+      "properties": {
+        "margins": {
+          "type": "object",
+          "properties": {
+            "top": { "type": "string" },
+            "bottom": { "type": "string" },
+            "left": { "type": "string" },
+            "right": { "type": "string" }
+          }
+        },
+        "header": {
+          "$ref": "#/$defs/headerFooter"
+        },
+        "footer": {
+          "$ref": "#/$defs/headerFooter"
+        }
+      }
+    },
+    "headerFooter": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "Text content with optional variables like {pageNumber}"
+        },
+        "style": {
+          "type": "string",
+          "description": "Named style to apply"
+        },
+        "y": {
+          "type": "string",
+          "description": "Vertical position"
+        }
+      }
+    },
+    "fontMetrics": {
+      "type": "object",
+      "required": ["family", "style", "weight"],
+      "properties": {
+        "family": {
+          "type": "string",
+          "description": "Font family name"
+        },
+        "style": {
+          "type": "string",
+          "description": "Font style (normal, italic)"
+        },
+        "weight": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 900,
+          "description": "Font weight"
+        },
+        "unitsPerEm": {
+          "type": "integer",
+          "description": "Units per em square"
+        },
+        "ascender": {
+          "type": "integer",
+          "description": "Ascender height in font units"
+        },
+        "descender": {
+          "type": "integer",
+          "description": "Descender depth in font units (typically negative)"
+        }
+      }
+    }
+  }
+}

--- a/schemas/presentation.schema.json
+++ b/schemas/presentation.schema.json
@@ -72,9 +72,9 @@
     },
     "pageElement": {
       "type": "object",
-      "required": ["blockRef", "position"],
+      "required": ["blockId", "position"],
       "properties": {
-        "blockRef": {
+        "blockId": {
           "type": "string",
           "description": "Reference to content block ID"
         },

--- a/spec/core/00-introduction.md
+++ b/spec/core/00-introduction.md
@@ -76,16 +76,25 @@ A Codex document is a ZIP archive containing:
 document.cdx
 ├── manifest.json           # Document manifest (required)
 ├── content/
-│   └── document.json       # Semantic content blocks (required)
+│   ├── document.json       # Semantic content blocks (required)
+│   └── block-index.json    # Block hashes for Merkle proofs (optional)
 ├── presentation/
 │   ├── paginated.json      # Fixed layout presentation (optional)
-│   └── continuous.json     # Reflow presentation (optional)
+│   ├── continuous.json     # Reflow presentation (optional)
+│   └── layouts/            # Precise layouts (required for FROZEN/PUBLISHED)
+│       ├── letter.json     # US Letter format coordinates
+│       └── a4.json         # A4 format coordinates
 ├── assets/
 │   ├── images/             # Image assets
 │   ├── fonts/              # Font assets
 │   └── embeds/             # Embedded files
 ├── security/
 │   └── signatures.json     # Digital signatures (optional)
+├── provenance/
+│   └── record.json         # Lineage, timestamps, derivations (optional)
+├── collaboration/
+│   ├── comments.json       # Comments and annotations (optional)
+│   └── changes.json        # Change tracking (optional)
 ├── phantoms/
 │   ├── clusters.json       # Off-page annotation clusters (optional)
 │   └── assets/             # Phantom-specific assets (optional)

--- a/spec/core/02-manifest.md
+++ b/spec/core/02-manifest.md
@@ -158,6 +158,8 @@ Reference to the content layer.
 | `path` | string | Yes | Relative path within archive |
 | `hash` | string | Yes | Hash of file contents |
 | `compression` | string | No | Compression used ("deflate", "zstd", "none") |
+| `merkleRoot` | string | No | Merkle tree root hash of content blocks (see Provenance spec section 4.4) |
+| `blockCount` | integer | No | Number of content blocks in the document |
 
 ### 4.7 `presentation` (Optional)
 
@@ -306,7 +308,7 @@ Phantom data is explicitly outside the content hash boundary. No `hash` field is
 
 ### 4.13 `lineage` (Optional)
 
-Version history and document relationships.
+Version history and document relationships. The manifest lineage provides a summary of the document's version context. The full provenance record (`provenance/record.json`) extends this with the complete ancestor chain, depth, merge history, and timestamps. See the Provenance and Lineage specification for the extended model.
 
 ```json
 {
@@ -350,8 +352,10 @@ The manifest state MUST be consistent with other indicators:
 |-------|---------------------|----------------|
 | draft | Optional | Optional |
 | review | Optional | Optional |
-| frozen | Required | Required |
-| published | Required | Required |
+| frozen | Required | Required if forked |
+| published | Required | Required if forked |
+
+> **Note**: `Lineage.parent` is required for frozen/published documents that were derived from another document (forked). Root documents — those created from scratch, not forked from a parent — have no parent and omit this field.
 
 ## 6. Processing Model
 

--- a/spec/core/03-content-blocks.md
+++ b/spec/core/03-content-blocks.md
@@ -410,8 +410,12 @@ Mathematical content using MathML or LaTeX.
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `display` | boolean | Yes | Display mode (true) vs inline (false) |
-| `format` | string | Yes | "latex" or "mathml" |
+| `format` | string | Yes | `"latex"` or `"mathml"` |
 | `value` | string | Yes | Math content in specified format |
+
+**Format details:**
+- `"latex"` — LaTeX math mode using amsmath package conventions. Content is the expression only (no `$` or `\begin{equation}` delimiters). Example: `"E = mc^2"`, `"\\frac{1}{2}"`, `"\\sum_{i=1}^{n} x_i"`
+- `"mathml"` — MathML 3.0 (W3C Recommendation). Content is the `<math>` element body
 
 Children: None (content in `value` attribute)
 

--- a/spec/core/03a-anchors-and-references.md
+++ b/spec/core/03a-anchors-and-references.md
@@ -237,7 +237,39 @@ Implementations SHOULD validate that anchor targets (block IDs, named anchor IDs
 - `offset` MUST be non-negative
 - For valid ranges, `end` SHOULD NOT exceed the target block's text content length
 
-## 8. Relationship to Extensions
+## 8. Shared Types
+
+### 8.1 Person Object
+
+The Person object is a base type used across multiple extensions to represent a person (author, signer, creator). Defining it once ensures consistency across the specification.
+
+**Base Person fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Display name |
+| `email` | string | No | Email address |
+
+**Base example:**
+
+```json
+{
+  "name": "Jane Doe",
+  "email": "jane@example.com"
+}
+```
+
+Extensions extend the base Person type with additional fields as needed:
+
+| Extension | Additional Fields | Description |
+|-----------|------------------|-------------|
+| Security (signer) | `organization`, `certificate`, `keyId` | Cryptographic identity |
+| Provenance (creator) | `identifier` | DID or URI-based identifier |
+| Collaboration (presence) | `userId`, `color` | Real-time collaboration identity |
+
+All Person objects MUST include at minimum the `name` field. Extensions SHOULD include the base fields alongside their extension-specific fields.
+
+## 9. Relationship to Extensions
 
 The anchor system is defined in the core specification but is primarily consumed by extensions:
 

--- a/spec/core/04-presentation-layers.md
+++ b/spec/core/04-presentation-layers.md
@@ -44,7 +44,7 @@ Presentation precision evolves with document maturity. The presentation layer fo
 
 ### 3.2 Why State-Awareness Matters
 
-1. **Provenance integrity** — When frozen, the hash covers exact appearance, not just content
+1. **Provenance integrity** — When frozen, the precise layout is immutable alongside the content. The document ID covers semantic content; use scoped signatures (Security Extension) for appearance attestation
 2. **Legal/academic needs** — Citations reference "page 7, line 23" with confidence
 3. **Lifecycle alignment** — Precision emerges naturally as documents mature
 4. **No capability loss** — Semantic content always present for accessibility/search
@@ -208,7 +208,7 @@ Each page contains positioned elements that reference content blocks:
   "number": 1,
   "elements": [
     {
-      "blockRef": "block-123",
+      "blockId": "block-123",
       "position": {
         "x": "1in",
         "y": "1in",
@@ -218,7 +218,7 @@ Each page contains positioned elements that reference content blocks:
       "style": "heading1"
     },
     {
-      "blockRef": "block-456",
+      "blockId": "block-456",
       "position": {
         "x": "1in",
         "y": "2in",
@@ -233,7 +233,7 @@ Each page contains positioned elements that reference content blocks:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `blockRef` | string | Yes | Reference to content block ID |
+| `blockId` | string | Yes | Reference to content block ID |
 | `position` | object | Yes | Position and size |
 | `style` | string | No | Named style to apply |
 | `overflow` | string | No | "visible", "hidden", "flow" |
@@ -245,7 +245,7 @@ For automatic text flow across pages:
 ```json
 {
   "type": "flow",
-  "blockRefs": ["block-1", "block-2", "block-3"],
+  "blockIds": ["block-1", "block-2", "block-3"],
   "columns": 1,
   "startPage": 1,
   "regions": [
@@ -547,7 +547,7 @@ presentation/
 | `targetFormat` | string | Yes | Page format name (letter, a4, legal, custom) |
 | `pageSize` | object | Yes | Exact page dimensions |
 | `contentHash` | string | Yes | Hash of content when layout was generated |
-| `generatedAt` | string | Yes | ISO 8601 timestamp |
+| `generatedAt` | string | Yes | ISO 8601 timestamp (when layout was generated — distinct from document `created`/`modified` which are lifecycle timestamps) |
 | `pageTemplate` | object | No | Headers, footers, margins for all pages |
 | `pages` | array | Yes | Array of page definitions |
 | `fonts` | object | No | Font metrics for exact reproduction |

--- a/spec/core/05-asset-embedding.md
+++ b/spec/core/05-asset-embedding.md
@@ -147,6 +147,12 @@ For responsive images, multiple resolutions can be provided:
 }
 ```
 
+**Variant integrity**: Variants inherit the parent asset's hash algorithm. Implementations SHOULD compute and verify variant hashes using the same algorithm as the parent asset.
+
+**Variant selection**: Renderers SHOULD select the variant closest to the display size. If displaying at 800px width, the 640px variant would be used (or the 1280px variant if the renderer prefers to scale down rather than up). If no variant is a good match, fall back to the full-resolution image.
+
+**Missing variants**: If a variant file is missing from the archive, implementations MUST fall back to the full-resolution image. Missing variants SHOULD produce a warning but MUST NOT prevent the image from being displayed.
+
 ### 4.4 Image References
 
 Content blocks reference images by path:

--- a/spec/core/06-document-hashing.md
+++ b/spec/core/06-document-hashing.md
@@ -98,6 +98,9 @@ The canonical content EXCLUDES:
 - Security data (signatures reference the hash, not part of it)
 - Collaboration data (comments, change tracking)
 - Phantom data (off-page annotations)
+- Form data (`forms/data.json` — filled values are mutable even on frozen documents)
+
+> **Metadata inclusion**: The Dublin Core terms included in the hash are `title`, `creator`, `subject`, `description`, and `language`. Administrative terms (`date`, `publisher`, `identifier`, `rights`) are excluded. See Metadata specification, section 6 for details.
 
 > **Note**: The document ID represents the document's semantic identity — what it says, not how it looks. Multiple visual presentations (letter, A4, responsive) of the same content produce the same document ID. For appearance attestation, see Scoped Signatures in the Security Extension.
 

--- a/spec/core/09-provenance-and-lineage.md
+++ b/spec/core/09-provenance-and-lineage.md
@@ -47,7 +47,9 @@ Beyond document-level hashing, individual content blocks have their own hashes. 
 
 ### 3.1 Chain Structure
 
-The lineage field in the manifest establishes the chain:
+The provenance lineage extends the manifest's summary lineage (which contains `parent`, `version`, `branch`, `note`) with additional fields for the full ancestor chain, depth, and merge history. The manifest provides quick access to the immediate parent and version; the provenance record provides the complete lineage for verification and auditing.
+
+The provenance lineage:
 
 ```json
 {

--- a/spec/extensions/collaboration/README.md
+++ b/spec/extensions/collaboration/README.md
@@ -205,7 +205,7 @@ Suggestion statuses: `pending`, `accepted`, `rejected`
 }
 ```
 
-Standard emoji identifiers (without colons).
+Standard emoji identifiers using Unicode CLDR short names (without colons). Examples: `thumbsup`, `heart`, `thinking`, `rocket`. See the [Unicode CLDR annotations](https://cldr.unicode.org/translation/characters-emoji-symbols/short-names-and-keywords) for the canonical list.
 
 ## 5. Change Tracking
 

--- a/spec/extensions/phantoms/README.md
+++ b/spec/extensions/phantoms/README.md
@@ -190,6 +190,18 @@ Connections between phantoms support mind-map style layouts:
 | `style` | string | No | Connection style: `"line"`, `"arrow"`, `"dashed"` |
 | `label` | string | No | Label displayed on the connection |
 
+### 4.7 Connection Validation
+
+Connections between phantoms MUST satisfy the following rules:
+
+| Rule | Requirement | Violation Behavior |
+|------|-------------|--------------------|
+| Target exists | `target` MUST reference an existing phantom ID within the same cluster | Warning in DRAFT/REVIEW; Error in FROZEN/PUBLISHED |
+| No cycles | Connections SHOULD NOT form cycles (A→B→A) | Warning in all states |
+| Same cluster | Connections MUST NOT reference phantoms in other clusters | Error in all states |
+
+Implementations MUST validate connection targets when loading phantom data. Broken connection targets (referencing non-existent phantom IDs) indicate data corruption in frozen documents and partial construction in mutable documents.
+
 ## 5. Hashing Boundary
 
 Phantoms are explicitly OUTSIDE the content hash boundary. The `phantoms/` directory has no `hash` field in the manifest reference. Adding, editing, or removing phantoms never changes the document ID or invalidates signatures.
@@ -252,7 +264,7 @@ The asset index follows the same structure as the core asset index:
     {
       "id": "sketch",
       "path": "sketch.png",
-      "mimeType": "image/png",
+      "type": "image/png",
       "size": 15360
     }
   ]

--- a/spec/extensions/presentation/README.md
+++ b/spec/extensions/presentation/README.md
@@ -351,7 +351,7 @@ Span options: `column`, `page`, `spread`
 
 ### 7.3 Cross-References
 
-The `reference` block's `target` field uses Content Anchor URI syntax (see core Anchors and References specification). The `#` prefix identifies internal document references:
+The `presentation:reference` block's `target` field uses Content Anchor URI syntax (see core Anchors and References specification). The `#` prefix identifies internal document references. The block uses the `presentation:` namespace prefix as required by the core content blocks spec (section 5) for extension block types:
 
 ```json
 {
@@ -360,7 +360,7 @@ The `reference` block's `target` field uses Content Anchor URI syntax (see core 
   "marks": []
 },
 {
-  "type": "reference",
+  "type": "presentation:reference",
   "target": "#fig-architecture",
   "format": "Figure #"
 }

--- a/spec/extensions/semantic/README.md
+++ b/spec/extensions/semantic/README.md
@@ -89,6 +89,8 @@ Location: `metadata/jsonld.json`
 
 ### 4.2 Bibliography Entry
 
+Bibliography entries follow the [CSL JSON schema](https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html) for entry types, fields, and formatting conventions.
+
 Location: `semantic/bibliography.json`
 
 ```json
@@ -148,7 +150,7 @@ Supported styles:
     {
       "type": "entity",
       "uri": "https://www.wikidata.org/wiki/Q937",
-      "type": "Person"
+      "entityType": "Person"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Comprehensive review of the entire Codex specification identified and fixed **22 issues** across core specs, extensions, schemas, and documentation. Changes organized by severity:

### Critical (3)
- **C1**: Remove stale "layout is part of the hash" claims from README (state table, bullet points, diagram) — layout is immutable when frozen but not part of the content hash
- **C2**: Fix same stale hash claim in presentation layers spec section 3.2
- **C3**: Replace executable JavaScript in forms `custom` validation with declarative rules (`containsUppercase`, `containsDigit`, `containsSpecial`, `matchesField`), consistent with DD-010. Adds DD-019

### High (6)
- **H1**: Fix `lineage.parent` required status — "Required if forked" for frozen/published (root documents have no parent)
- **H2**: Clarify manifest lineage (summary) vs provenance lineage (full chain) relationship in both specs
- **H3**: Add `merkleRoot` and `blockCount` optional fields to manifest content table
- **H4**: Define shared Person type in anchors-and-references spec with extension field mapping
- **H5**: Standardize `blockRef` → `blockId` in presentation layers sections 6.3/6.4
- **H6**: Add forms state behavior section (form data outside hash boundary, fillable when frozen)

### Medium (7)
- **M1**: Phantom asset index `mimeType` → `type` for consistency with core
- **M2**: Fix duplicate `type` key in semantic entity annotation → `entityType`
- **M3**: Namespace presentation reference block as `presentation:reference`
- **M4**: Add missing directories to introduction structure diagram (provenance/, collaboration/, block-index.json, layouts/)
- **M5**: Add metadata hash inclusion cross-reference in hashing spec
- **M6**: Add phantom connection validation rules (target exists, no cycles, same cluster)
- **M7**: Create `precise-layout.schema.json` for FROZEN/PUBLISHED validation

### Low (5)
- **L1**: Specify Unicode CLDR short names for emoji identifiers
- **L2**: Specify LaTeX amsmath conventions and MathML 3.0 as math format dialects
- **L3**: Add CSL JSON schema reference for bibliography entries
- **L4**: Add image variant selection, integrity, and fallback rules
- **L5**: Add timestamp naming distinction note (lifecycle vs derived artifact timestamps)

### Files changed (17)
- `README.md` — C1
- `docs/design-decisions.md` — DD-019
- `schemas/presentation.schema.json` — H5 (blockRef→blockId)
- `schemas/precise-layout.schema.json` — M7 (new file)
- `spec/core/00-introduction.md` — M4
- `spec/core/02-manifest.md` — H1, H2, H3
- `spec/core/03-content-blocks.md` — L2
- `spec/core/03a-anchors-and-references.md` — H4
- `spec/core/04-presentation-layers.md` — C2, H5, L5
- `spec/core/05-asset-embedding.md` — L4
- `spec/core/06-document-hashing.md` — M5, H6
- `spec/core/09-provenance-and-lineage.md` — H2
- `spec/extensions/collaboration/README.md` — L1
- `spec/extensions/forms/README.md` — C3, H6
- `spec/extensions/phantoms/README.md` — M1, M6
- `spec/extensions/presentation/README.md` — M3
- `spec/extensions/semantic/README.md` — M2, L3

## Test plan

- [ ] Verify no remaining "layout is part of the hash" claims: `grep -ri "layout is part of the hash" spec/ README.md`
- [ ] Verify no executable JavaScript in specs: `grep -r "value.length" spec/`
- [ ] Verify `blockRef` fully replaced: `grep -r '"blockRef"' spec/ schemas/`
- [ ] Verify `mimeType` fully replaced: `grep -r '"mimeType"' spec/`
- [ ] Verify no duplicate JSON keys in semantic entity: check `spec/extensions/semantic/README.md` section 5.1
- [ ] Validate `schemas/precise-layout.schema.json` is valid JSON
- [ ] Validate `schemas/presentation.schema.json` is valid JSON
- [ ] Cross-check manifest content table includes `merkleRoot`/`blockCount`
- [ ] Verify introduction directory structure includes provenance/, collaboration/, block-index.json, layouts/