### PR TITLE
Clean up spec repository and improve schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ The specification is modular:
 - [Collaboration Extension](spec/extensions/collaboration/) - CRDT hooks, comments, change tracking
 - [Presentation Extension](spec/extensions/presentation/) - Advanced layout, print styling
 - [Forms Extension](spec/extensions/forms/) - Input fields, validation
-- [Multimedia Extension](spec/extensions/multimedia/) - Video, audio, interactive elements
 - [Semantic Extension](spec/extensions/semantic/) - JSON-LD, knowledge graphs, citations
 
 ## Quick Start

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,91 @@
+# Codex JSON Schemas
+
+This directory contains JSON Schema definitions for validating Codex document components.
+
+## Schema Files
+
+| Schema | Purpose | Validates |
+|--------|---------|-----------|
+| `manifest.schema.json` | Document manifest | `manifest.json` |
+| `content.schema.json` | Semantic content blocks | `content/document.json` |
+| `presentation.schema.json` | Presentation layer | `presentation/*.json` |
+| `precise-layout.schema.json` | Precise layouts | `presentation/layouts/*.json` |
+| `asset-index.schema.json` | Asset index | `assets/index.json` |
+| `dublin-core.schema.json` | Dublin Core metadata | `metadata/dublin-core.json` |
+| `provenance.schema.json` | Provenance records | `provenance/record.json` |
+| `anchor.schema.json` | Content anchor definitions | (shared definitions) |
+| `phantoms.schema.json` | Phantom clusters | `phantoms/clusters.json` |
+
+## Schema Dependencies
+
+Some schemas reference definitions from other schema files:
+
+```
+phantoms.schema.json
+    └── $ref: anchor.schema.json#/$defs/contentAnchor
+```
+
+The `anchor.schema.json` file provides shared definitions for `ContentAnchor` and `ContentAnchorUri` that are used by multiple extensions (phantoms, collaboration, etc.).
+
+## Using These Schemas
+
+### With ajv (Node.js)
+
+```bash
+npm install -g ajv-cli
+
+# Validate a manifest
+ajv validate -s schemas/manifest.schema.json -d document.cdx/manifest.json
+
+# Validate with referenced schemas (for phantoms)
+ajv validate -s schemas/phantoms.schema.json -r schemas/anchor.schema.json -d document.cdx/phantoms/clusters.json
+```
+
+### With jsonschema (Python)
+
+```python
+import json
+from jsonschema import validate, RefResolver
+
+# Load schemas
+with open('schemas/manifest.schema.json') as f:
+    schema = json.load(f)
+
+with open('document.cdx/manifest.json') as f:
+    document = json.load(f)
+
+validate(instance=document, schema=schema)
+```
+
+For schemas with references, use a RefResolver:
+
+```python
+from jsonschema import RefResolver
+
+schema_store = {}
+for schema_file in ['anchor.schema.json', 'phantoms.schema.json']:
+    with open(f'schemas/{schema_file}') as f:
+        schema = json.load(f)
+        schema_store[schema['$id']] = schema
+
+resolver = RefResolver.from_schema(schema_store['https://codex.document/schemas/phantoms.schema.json'], store=schema_store)
+validate(instance=document, schema=phantoms_schema, resolver=resolver)
+```
+
+### With check-jsonschema (CLI)
+
+```bash
+pip install check-jsonschema
+
+check-jsonschema --schemafile schemas/manifest.schema.json document.cdx/manifest.json
+```
+
+## Schema Version
+
+All schemas are written for JSON Schema Draft 2020-12 (`https://json-schema.org/draft/2020-12/schema`).
+
+## Validation Notes
+
+- Schemas use `additionalProperties: false` on most objects to catch typos and invalid properties
+- The `metadata` object in `phantoms.schema.json` intentionally allows additional properties for application-specific extensibility
+- The `styles` object in `presentation.schema.json` allows arbitrary named styles, but each style definition is strictly validated

--- a/schemas/presentation.schema.json
+++ b/schemas/presentation.schema.json
@@ -130,9 +130,11 @@
         },
         "attributes": {
           "type": "object",
-          "description": "Inline style attributes"
+          "description": "Inline style attributes",
+          "additionalProperties": true
         }
-      }
+      },
+      "additionalProperties": false
     },
     "breakpoint": {
       "type": "object",
@@ -150,7 +152,8 @@
           "type": "string",
           "description": "Maximum viewport width"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "pageTemplate": {
       "type": "object",
@@ -182,9 +185,11 @@
             "right": {
               "$ref": "#/$defs/headerFooterContent"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "headerFooterContent": {
       "oneOf": [
@@ -272,7 +277,7 @@
           "enum": ["auto", "always", "avoid"]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     }
   }
 }

--- a/spec/extensions/phantoms/README.md
+++ b/spec/extensions/phantoms/README.md
@@ -321,7 +321,7 @@ Phantom content references these assets with paths relative to the archive root 
                 "children": [
                   {
                     "type": "text",
-                    "value": "TODO: Verify sample size is comparable."
+                    "value": "Needs further investigation - compare with control group data."
                   }
                 ]
               }


### PR DESCRIPTION
## Summary

- Remove multimedia extension reference from README (spec doesn't exist)
- Fix presentation schema to use `additionalProperties: false` for stricter validation
- Replace TODO text in phantoms example with realistic annotation text
- Add `schemas/README.md` documenting schema relationships and validation tools
- Remove empty placeholder directories

## Changes

### Phase 1: Quick Wins

1. **Phantoms example TODO** - Replaced "TODO: Verify sample size is comparable" with realistic annotation text to avoid confusion with incomplete spec work

2. **Empty directories removed**:
   - `/tools/`
   - `/spec/profiles/`
   - `/spec/extensions/multimedia/`
   - `/examples/collaborative-document/`

3. **Schema strictness** - Changed `presentation.schema.json` to use `additionalProperties: false` on:
   - `style` definition (catches typos in style properties)
   - `section` definition
   - `breakpoint` definition  
   - `pageHeaderFooter` definition
   - `pageHeaderFooter.content` definition

### Phase 2: Documentation

1. **README.md** - Removed non-existent multimedia extension from Extension Specifications list

2. **schemas/README.md** - New documentation covering:
   - Purpose of each schema file
   - Dependency graph (phantoms depends on anchor)
   - How to use schemas for validation
   - Tool recommendations (ajv, jsonschema, check-jsonschema)

## Test plan

- [ ] Verify all markdown links in README are valid
- [ ] Validate example documents against updated schemas
- [ ] Review schema changes don't break existing valid documents