### PR TITLE
Add complex typesetting support for metrology certificates

### DIFF
--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -33,8 +33,7 @@
           "description": "Unique block identifier"
         },
         "attributes": {
-          "type": "object",
-          "description": "Type-specific attributes"
+          "$ref": "#/$defs/blockAttributes"
         }
       },
       "allOf": [
@@ -77,8 +76,72 @@
         {
           "if": { "properties": { "type": { "const": "math" } } },
           "then": { "$ref": "#/$defs/math" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "definitionList" } } },
+          "then": { "$ref": "#/$defs/definitionList" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "definitionItem" } } },
+          "then": { "$ref": "#/$defs/definitionItem" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "definitionTerm" } } },
+          "then": { "$ref": "#/$defs/definitionTerm" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "definitionDescription" } } },
+          "then": { "$ref": "#/$defs/definitionDescription" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "measurement" } } },
+          "then": { "$ref": "#/$defs/measurement" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "signature" } } },
+          "then": { "$ref": "#/$defs/signature" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "svg" } } },
+          "then": { "$ref": "#/$defs/svg" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "barcode" } } },
+          "then": { "$ref": "#/$defs/barcode" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "figure" } } },
+          "then": { "$ref": "#/$defs/figure" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "figcaption" } } },
+          "then": { "$ref": "#/$defs/figcaption" }
         }
       ]
+    },
+    "blockAttributes": {
+      "type": "object",
+      "description": "Common block attributes for internationalization and styling",
+      "properties": {
+        "dir": {
+          "type": "string",
+          "enum": ["ltr", "rtl", "auto"],
+          "description": "Text direction"
+        },
+        "lang": {
+          "type": "string",
+          "description": "BCP 47 language tag"
+        },
+        "writingMode": {
+          "type": "string",
+          "enum": ["horizontal-tb", "vertical-rl", "vertical-lr", "sideways-rl", "sideways-lr"],
+          "description": "Text flow direction"
+        },
+        "style": {
+          "type": "string",
+          "description": "Named style to apply"
+        }
+      }
     },
     "textNode": {
       "type": "object",
@@ -99,7 +162,8 @@
                 "enum": ["bold", "italic", "underline", "strikethrough", "code", "superscript", "subscript"]
               },
               { "$ref": "#/$defs/linkMark" },
-              { "$ref": "#/$defs/anchorMark" }
+              { "$ref": "#/$defs/anchorMark" },
+              { "$ref": "#/$defs/mathMark" }
             ]
           }
         }
@@ -129,6 +193,22 @@
           "type": "string",
           "description": "Unique anchor identifier (shares namespace with block IDs)",
           "pattern": "^[A-Za-z0-9._-]+$"
+        }
+      }
+    },
+    "mathMark": {
+      "type": "object",
+      "required": ["type", "format", "source"],
+      "properties": {
+        "type": { "const": "math" },
+        "format": {
+          "type": "string",
+          "enum": ["latex", "mathml"],
+          "description": "Math content format"
+        },
+        "source": {
+          "type": "string",
+          "description": "Math content in specified format"
         }
       }
     },
@@ -342,6 +422,247 @@
       "required": ["type"],
       "properties": {
         "type": { "const": "break" }
+      }
+    },
+    "definitionList": {
+      "type": "object",
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "definitionList" },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/definitionItem" },
+          "minItems": 1
+        }
+      }
+    },
+    "definitionItem": {
+      "type": "object",
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "definitionItem" },
+        "children": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "#/$defs/definitionTerm" },
+              { "$ref": "#/$defs/definitionDescription" }
+            ]
+          },
+          "minItems": 2
+        }
+      }
+    },
+    "definitionTerm": {
+      "type": "object",
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "definitionTerm" },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/textNode" }
+        }
+      }
+    },
+    "definitionDescription": {
+      "type": "object",
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "definitionDescription" },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/block" }
+        }
+      }
+    },
+    "measurement": {
+      "type": "object",
+      "required": ["type", "value", "display"],
+      "properties": {
+        "type": { "const": "measurement" },
+        "value": {
+          "type": "number",
+          "description": "Numeric value"
+        },
+        "uncertainty": {
+          "type": "number",
+          "description": "Measurement uncertainty"
+        },
+        "uncertaintyNotation": {
+          "type": "string",
+          "enum": ["parenthetical", "plusminus", "range", "percent"],
+          "description": "How uncertainty is displayed"
+        },
+        "exponent": {
+          "type": "integer",
+          "description": "Power of 10 for scientific notation"
+        },
+        "unit": {
+          "type": "string",
+          "description": "Unit of measurement"
+        },
+        "display": {
+          "type": "string",
+          "description": "Human-readable display string"
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "required": ["type", "signatureType"],
+      "properties": {
+        "type": { "const": "signature" },
+        "signatureType": {
+          "type": "string",
+          "enum": ["handwritten", "digital", "electronic", "stamp"],
+          "description": "Type of signature"
+        },
+        "image": {
+          "type": "string",
+          "description": "Path to signature image"
+        },
+        "signer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Signer's full name"
+            },
+            "title": {
+              "type": "string",
+              "description": "Professional title"
+            },
+            "organization": {
+              "type": "string",
+              "description": "Organization name"
+            },
+            "email": {
+              "type": "string",
+              "description": "Contact email"
+            },
+            "id": {
+              "type": "string",
+              "description": "Unique identifier"
+            }
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp"
+        },
+        "purpose": {
+          "type": "string",
+          "enum": ["certification", "approval", "witness", "acknowledgment", "authorship"],
+          "description": "Purpose of the signature"
+        },
+        "digitalSignatureRef": {
+          "type": "string",
+          "description": "Reference to cryptographic signature"
+        }
+      }
+    },
+    "svg": {
+      "type": "object",
+      "required": ["type", "alt"],
+      "properties": {
+        "type": { "const": "svg" },
+        "src": {
+          "type": "string",
+          "description": "Path to SVG file"
+        },
+        "content": {
+          "type": "string",
+          "description": "Inline SVG content"
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alternative text"
+        },
+        "title": {
+          "type": "string",
+          "description": "Title/caption"
+        },
+        "width": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Display width in pixels"
+        },
+        "height": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Display height in pixels"
+        }
+      },
+      "oneOf": [
+        { "required": ["src"] },
+        { "required": ["content"] }
+      ]
+    },
+    "barcode": {
+      "type": "object",
+      "required": ["type", "format", "data", "alt"],
+      "properties": {
+        "type": { "const": "barcode" },
+        "format": {
+          "type": "string",
+          "enum": ["qr", "datamatrix", "code128", "code39", "ean13", "ean8", "upca", "pdf417"],
+          "description": "Barcode format"
+        },
+        "data": {
+          "type": "string",
+          "description": "Encoded content"
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alternative text description"
+        },
+        "errorCorrection": {
+          "type": "string",
+          "enum": ["L", "M", "Q", "H"],
+          "description": "Error correction level (QR/DataMatrix)"
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Rendered size in pixels"
+        },
+        "quietZone": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Quiet zone size in modules"
+        }
+      }
+    },
+    "figure": {
+      "type": "object",
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "figure" },
+        "numbering": {
+          "oneOf": [
+            { "type": "string", "enum": ["auto", "none"] },
+            { "type": "integer", "minimum": 1 }
+          ],
+          "description": "Figure numbering mode"
+        },
+        "children": {
+          "type": "array",
+          "description": "Figure content and optional caption",
+          "minItems": 1,
+          "maxItems": 2
+        }
+      }
+    },
+    "figcaption": {
+      "type": "object",
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "figcaption" },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/textNode" }
+        }
       }
     }
   }

--- a/schemas/precise-layout.schema.json
+++ b/schemas/precise-layout.schema.json
@@ -113,12 +113,78 @@
           "type": "boolean",
           "description": "True if element is continued from previous page"
         },
+        "zIndex": {
+          "type": "integer",
+          "description": "Stacking order (higher values render on top)"
+        },
+        "transform": {
+          "$ref": "#/$defs/transform"
+        },
         "lines": {
           "type": "array",
           "description": "Line-level coordinates for legal/court documents",
           "items": {
             "$ref": "#/$defs/linePrecision"
           }
+        }
+      }
+    },
+    "transform": {
+      "type": "object",
+      "description": "Transform properties for rotation, scaling, and skewing",
+      "properties": {
+        "rotate": {
+          "type": "string",
+          "description": "Rotation angle (e.g., '90deg', '-45deg', '0.5rad', '0.25turn')"
+        },
+        "scale": {
+          "oneOf": [
+            { "type": "number", "description": "Uniform scale factor" },
+            {
+              "type": "object",
+              "properties": {
+                "x": { "type": "number" },
+                "y": { "type": "number" }
+              },
+              "required": ["x", "y"]
+            }
+          ]
+        },
+        "skewX": {
+          "type": "string",
+          "description": "Horizontal skew angle"
+        },
+        "skewY": {
+          "type": "string",
+          "description": "Vertical skew angle"
+        },
+        "translateX": {
+          "type": "string",
+          "description": "Horizontal translation"
+        },
+        "translateY": {
+          "type": "string",
+          "description": "Vertical translation"
+        },
+        "matrix": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 6,
+          "maxItems": 6,
+          "description": "Full 2D transform matrix [a, b, c, d, tx, ty]"
+        },
+        "origin": {
+          "oneOf": [
+            { "type": "string", "description": "Transform origin (e.g., 'center', 'top left')" },
+            {
+              "type": "object",
+              "properties": {
+                "x": { "type": "string" },
+                "y": { "type": "string" }
+              },
+              "required": ["x", "y"]
+            }
+          ]
         }
       }
     },

--- a/schemas/presentation.schema.json
+++ b/schemas/presentation.schema.json
@@ -89,6 +89,13 @@
           "type": "string",
           "enum": ["visible", "hidden", "flow"],
           "description": "Overflow behavior"
+        },
+        "zIndex": {
+          "type": "integer",
+          "description": "Stacking order (higher values render on top)"
+        },
+        "transform": {
+          "$ref": "#/$defs/transform"
         }
       }
     },
@@ -112,6 +119,65 @@
           "type": "string",
           "description": "Height",
           "default": "auto"
+        }
+      }
+    },
+    "transform": {
+      "type": "object",
+      "description": "Transform properties for rotation, scaling, and skewing",
+      "properties": {
+        "rotate": {
+          "type": "string",
+          "description": "Rotation angle (e.g., '90deg', '-45deg', '0.5rad', '0.25turn')"
+        },
+        "scale": {
+          "oneOf": [
+            { "type": "number", "description": "Uniform scale factor" },
+            {
+              "type": "object",
+              "properties": {
+                "x": { "type": "number" },
+                "y": { "type": "number" }
+              },
+              "required": ["x", "y"]
+            }
+          ]
+        },
+        "skewX": {
+          "type": "string",
+          "description": "Horizontal skew angle"
+        },
+        "skewY": {
+          "type": "string",
+          "description": "Vertical skew angle"
+        },
+        "translateX": {
+          "type": "string",
+          "description": "Horizontal translation"
+        },
+        "translateY": {
+          "type": "string",
+          "description": "Vertical translation"
+        },
+        "matrix": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 6,
+          "maxItems": 6,
+          "description": "Full 2D transform matrix [a, b, c, d, tx, ty]"
+        },
+        "origin": {
+          "oneOf": [
+            { "type": "string", "description": "Transform origin (e.g., 'center', 'top left')" },
+            {
+              "type": "object",
+              "properties": {
+                "x": { "type": "string" },
+                "y": { "type": "string" }
+              },
+              "required": ["x", "y"]
+            }
+          ]
         }
       }
     },
@@ -247,8 +313,36 @@
           "type": "string",
           "enum": ["none", "uppercase", "lowercase", "capitalize"]
         },
+        "writingMode": {
+          "type": "string",
+          "enum": ["horizontal-tb", "vertical-rl", "vertical-lr", "sideways-rl", "sideways-lr"],
+          "description": "Text flow direction"
+        },
         "color": { "type": "string" },
         "backgroundColor": { "type": "string" },
+        "backgroundImage": {
+          "type": "string",
+          "description": "URL/path to background image"
+        },
+        "backgroundSize": {
+          "type": "string",
+          "description": "Background size (cover, contain, or dimensions)"
+        },
+        "backgroundPosition": {
+          "type": "string",
+          "description": "Background position"
+        },
+        "backgroundRepeat": {
+          "type": "string",
+          "enum": ["repeat", "no-repeat", "repeat-x", "repeat-y"],
+          "description": "Background repeat behavior"
+        },
+        "opacity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Element opacity (0-1)"
+        },
         "marginTop": { "type": "string" },
         "marginRight": { "type": "string" },
         "marginBottom": { "type": "string" },
@@ -260,6 +354,14 @@
         "borderWidth": { "type": "string" },
         "borderStyle": { "type": "string" },
         "borderColor": { "type": "string" },
+        "borderRadius": {
+          "type": "string",
+          "description": "Corner rounding"
+        },
+        "boxShadow": {
+          "type": "string",
+          "description": "Box shadow effect"
+        },
         "width": { "type": "string" },
         "height": { "type": "string" },
         "maxWidth": { "type": "string" },

--- a/spec/core/03-content-blocks.md
+++ b/spec/core/03-content-blocks.md
@@ -165,6 +165,34 @@ The `href` field also accepts Content Anchor URIs for internal links. Values beg
 
 See the Anchors and References specification for the full Content Anchor URI syntax.
 
+#### 4.1.3 Math Mark
+
+Inline mathematical expressions use the math mark:
+
+```json
+{
+  "type": "text",
+  "value": "7.677(9)×10²",
+  "marks": [
+    {
+      "type": "math",
+      "format": "latex",
+      "source": "7.677(9) \\times 10^{2}"
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"math"` |
+| `format` | string | Yes | `"latex"` or `"mathml"` |
+| `source` | string | Yes | Math content in specified format |
+
+The text node's `value` field contains the display/fallback text (used for plain text rendering and accessibility). The mark's `source` field contains the mathematical notation for proper typesetting.
+
+This mark enables inline math without breaking text flow, unlike the block-level `math` type which creates a separate block element.
+
 ### 4.2 Paragraph
 
 Standard paragraph block.
@@ -433,6 +461,315 @@ Children: None (void element)
 
 Used for hard line breaks within paragraphs.
 
+### 4.15 Definition List
+
+Definition lists represent term-description pairs, commonly used for glossaries, metadata displays, and key-value content.
+
+```json
+{
+  "type": "definitionList",
+  "children": [
+    {
+      "type": "definitionItem",
+      "children": [
+        {
+          "type": "definitionTerm",
+          "children": [{ "type": "text", "value": "Nagasa" }]
+        },
+        {
+          "type": "definitionDescription",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [{ "type": "text", "value": "Blade length measured from mune-machi to kissaki." }]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "definitionItem",
+      "children": [
+        {
+          "type": "definitionTerm",
+          "children": [{ "type": "text", "value": "Sori" }]
+        },
+        {
+          "type": "definitionDescription",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [{ "type": "text", "value": "Curvature of the blade." }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Block Type | Children | Description |
+|------------|----------|-------------|
+| `definitionList` | `definitionItem` only | Container for definition items |
+| `definitionItem` | `definitionTerm`, `definitionDescription` | Groups a term with its description(s) |
+| `definitionTerm` | Text nodes only | The term being defined |
+| `definitionDescription` | Block-level content | The definition or description |
+
+A `definitionItem` MUST contain at least one `definitionTerm` and at least one `definitionDescription`. Multiple terms MAY share a single description, and a single term MAY have multiple descriptions.
+
+### 4.16 Measurement
+
+Semantic representation of a measurement with optional uncertainty and units. Used for scientific, engineering, and metrology documents.
+
+```json
+{
+  "type": "measurement",
+  "value": 7.677,
+  "uncertainty": 0.009,
+  "uncertaintyNotation": "parenthetical",
+  "exponent": 2,
+  "unit": "mm",
+  "display": "7.677(9)×10² mm"
+}
+```
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `value` | number | Yes | Numeric value |
+| `uncertainty` | number | No | Measurement uncertainty |
+| `uncertaintyNotation` | string | No | How uncertainty is displayed |
+| `exponent` | integer | No | Power of 10 for scientific notation |
+| `unit` | string | No | Unit of measurement |
+| `display` | string | Yes | Human-readable display string |
+
+#### 4.16.1 Uncertainty Notation
+
+| Value | Display Format | Example |
+|-------|---------------|---------|
+| `parenthetical` | Uncertainty in last digit(s) | 7.677(9) |
+| `plusminus` | Plus-minus format | 7.677 ± 0.009 |
+| `range` | Range format | 7.668–7.686 |
+| `percent` | Percentage | 7.677 ± 0.12% |
+
+The `display` field is REQUIRED for accessibility and fallback rendering. It SHOULD accurately represent the measurement as intended for human readers.
+
+Children: None (void element)
+
+**Note:** For complex expressions like vectors, matrices, or multi-variable measurements, use the `math` block type with LaTeX or MathML.
+
+### 4.17 Signature
+
+Semantic representation of a signature with optional image, signer information, and timestamp.
+
+```json
+{
+  "type": "signature",
+  "id": "sig-metrologist",
+  "signatureType": "handwritten",
+  "image": "assets/signatures/metrologist.png",
+  "signer": {
+    "name": "Dr. Jane Smith",
+    "title": "Chief Metrologist",
+    "organization": "BayKen Metrology"
+  },
+  "timestamp": "2026-01-29T14:15:28Z",
+  "purpose": "certification",
+  "digitalSignatureRef": "security/signatures.json#sig-metrologist"
+}
+```
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `signatureType` | string | Yes | Type of signature |
+| `image` | string | No | Path to signature image |
+| `signer` | object | No | Signer identity information |
+| `timestamp` | string | No | ISO 8601 timestamp |
+| `purpose` | string | No | Purpose of the signature |
+| `digitalSignatureRef` | string | No | Reference to cryptographic signature |
+
+#### 4.17.1 Signature Types
+
+| Value | Description |
+|-------|-------------|
+| `handwritten` | Scanned or drawn handwritten signature |
+| `digital` | Cryptographic digital signature |
+| `electronic` | Typed name or simple electronic mark |
+| `stamp` | Official seal or stamp image |
+
+#### 4.17.2 Signature Purpose
+
+| Value | Description |
+|-------|-------------|
+| `certification` | Certifies document accuracy or compliance |
+| `approval` | Approves content or action |
+| `witness` | Witnesses another signature or event |
+| `acknowledgment` | Acknowledges receipt or understanding |
+| `authorship` | Indicates document authorship |
+
+The `signer` object MAY contain:
+- `name` (string) - Signer's full name
+- `title` (string) - Professional title
+- `organization` (string) - Organization name
+- `email` (string) - Contact email
+- `id` (string) - Unique identifier
+
+Children: None (void element)
+
+### 4.18 SVG
+
+Scalable Vector Graphics for charts, diagrams, and illustrations.
+
+```json
+{
+  "type": "svg",
+  "src": "assets/graphics/chart.svg",
+  "alt": "Mass vs Arc Length chart showing linear relationship",
+  "title": "Figure 1: Mass/Arc Length Distribution",
+  "width": 400,
+  "height": 300
+}
+```
+
+Alternative inline form:
+
+```json
+{
+  "type": "svg",
+  "content": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">...</svg>",
+  "alt": "Simple diagram"
+}
+```
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `src` | string | No* | Path to SVG file |
+| `content` | string | No* | Inline SVG content |
+| `alt` | string | Yes | Alternative text (accessibility) |
+| `title` | string | No | Title/caption |
+| `width` | integer | No | Display width in pixels |
+| `height` | integer | No | Display height in pixels |
+
+*Either `src` or `content` MUST be provided, but not both.
+
+For `src`, the path MUST be a relative path within the archive (e.g., `assets/graphics/chart.svg`) or a URL.
+
+For `content`, the value MUST be a complete SVG element including the `xmlns` attribute.
+
+Children: None (void element)
+
+### 4.19 Barcode
+
+Semantic barcode representation including QR codes, DataMatrix, and linear barcodes.
+
+```json
+{
+  "type": "barcode",
+  "format": "qr",
+  "data": "https://example.com/verify/abc123",
+  "alt": "Verification QR code linking to certificate validation page",
+  "errorCorrection": "M",
+  "size": 100
+}
+```
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `format` | string | Yes | Barcode format |
+| `data` | string | Yes | Encoded content |
+| `alt` | string | Yes | Alternative text description |
+| `errorCorrection` | string | No | Error correction level (QR/DataMatrix) |
+| `size` | integer | No | Rendered size in pixels |
+| `quietZone` | integer | No | Quiet zone size in modules |
+
+#### 4.19.1 Barcode Formats
+
+| Format | Description |
+|--------|-------------|
+| `qr` | QR Code (2D matrix) |
+| `datamatrix` | Data Matrix (2D matrix) |
+| `code128` | Code 128 (linear, alphanumeric) |
+| `code39` | Code 39 (linear, alphanumeric) |
+| `ean13` | EAN-13 (linear, numeric) |
+| `ean8` | EAN-8 (linear, numeric) |
+| `upca` | UPC-A (linear, numeric) |
+| `pdf417` | PDF417 (2D stacked linear) |
+
+#### 4.19.2 Error Correction Levels
+
+For QR codes and DataMatrix:
+
+| Level | Recovery Capacity |
+|-------|------------------|
+| `L` | ~7% |
+| `M` | ~15% (default) |
+| `Q` | ~25% |
+| `H` | ~30% |
+
+The `data` field contains the raw content to encode. For URLs, use the full URL. For structured data, implementations SHOULD encode appropriately for the format.
+
+The `alt` field MUST provide a meaningful description of what the barcode represents, not just "QR code" — include the purpose and destination.
+
+Children: None (void element)
+
+### 4.20 Figure
+
+Container for figures with optional captions. Figures group visual content (images, SVGs, tables, charts) with their captions for semantic association and automatic numbering.
+
+```json
+{
+  "type": "figure",
+  "id": "fig-mass-arc",
+  "children": [
+    {
+      "type": "image",
+      "src": "assets/images/chart.png",
+      "alt": "Line chart showing mass per arc length"
+    },
+    {
+      "type": "figcaption",
+      "children": [
+        { "type": "text", "value": "Figure 1: Mass / Arc Length Distribution" }
+      ]
+    }
+  ],
+  "numbering": "auto"
+}
+```
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `numbering` | string or integer | No | Figure numbering mode |
+
+#### 4.20.1 Numbering Values
+
+| Value | Description |
+|-------|-------------|
+| `auto` | Automatically number in document order |
+| `none` | No numbering |
+| (integer) | Explicit figure number |
+
+**Children:** The figure block MAY contain:
+- Exactly one content block: `image`, `svg`, `table`, `math`, or `barcode`
+- Zero or one `figcaption` block
+
+The `figcaption` block MAY appear before or after the content block.
+
+### 4.21 Figure Caption
+
+Caption for a figure. Only valid as a child of `figure`.
+
+```json
+{
+  "type": "figcaption",
+  "children": [
+    { "type": "text", "value": "Figure 1: System Architecture Overview" }
+  ]
+}
+```
+
+Children: Text nodes or inline content (including links, marks)
+
 ## 5. Extension Block Types
 
 Extensions MAY define additional block types. Extension blocks:
@@ -458,9 +795,9 @@ Example:
 
 ## 6. Internationalization
 
-### 6.1 Text Direction
+### 6.1 Text Direction and Writing Mode
 
-Blocks MAY specify text direction:
+Blocks MAY specify text direction and writing mode:
 
 ```json
 {
@@ -473,10 +810,36 @@ Blocks MAY specify text direction:
 }
 ```
 
+```json
+{
+  "type": "paragraph",
+  "attributes": {
+    "lang": "ja",
+    "writingMode": "vertical-rl"
+  },
+  "children": [...]
+}
+```
+
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `dir` | string | Text direction: "ltr", "rtl", "auto" |
 | `lang` | string | BCP 47 language tag |
+| `writingMode` | string | Text flow direction (see below) |
+
+#### 6.1.1 Writing Mode Values
+
+| Value | Description | Use Case |
+|-------|-------------|----------|
+| `horizontal-tb` | Horizontal text, top-to-bottom block flow (default) | Latin, Cyrillic, Arabic, Hebrew |
+| `vertical-rl` | Vertical text, right-to-left column flow | Traditional Chinese, Japanese, Korean |
+| `vertical-lr` | Vertical text, left-to-right column flow | Mongolian |
+| `sideways-rl` | Text rotated 90° clockwise | Rotated labels |
+| `sideways-lr` | Text rotated 90° counter-clockwise | Rotated labels |
+
+The `writingMode` attribute indicates the semantic writing mode of the content. For CJK text that was authored in vertical mode, this attribute preserves authorial intent even when presentation may vary.
+
+**Relationship to Presentation:** The presentation layer (see Presentation Layers spec, Section 5.1.1) may override the visual rendering of writing mode. The content-level `writingMode` attribute represents the source/semantic writing direction, while the presentation-level `writingMode` style controls actual rendering.
 
 ### 6.2 Unicode
 
@@ -503,6 +866,10 @@ All text content MUST be valid Unicode (UTF-8 encoded in JSON). Implementations 
 3. List children MUST be listItem blocks
 4. Table children MUST be tableRow blocks
 5. TableRow children MUST be tableCell blocks
+6. DefinitionList children MUST be definitionItem blocks
+7. DefinitionItem children MUST include at least one definitionTerm and one definitionDescription
+8. Figure children MUST include exactly one content block and zero or one figcaption
+9. Figcaption is only valid as a child of figure
 
 ### 7.3 Cross-References
 

--- a/spec/core/04-presentation-layers.md
+++ b/spec/core/04-presentation-layers.md
@@ -108,7 +108,7 @@ presentation/
 
 Presentation styling uses a subset of CSS properties. This provides familiarity while constraining complexity.
 
-#### 4.1.1 Supported Properties
+#### Supported Properties
 
 **Typography:**
 - `fontFamily` - Font family stack
@@ -121,6 +121,36 @@ Presentation styling uses a subset of CSS properties. This provides familiarity 
 - `textDecoration` - none, underline, line-through
 - `textTransform` - none, uppercase, lowercase, capitalize
 - `color` - Text color
+- `writingMode` - Text flow direction (see Section 5.1.1)
+
+#### 5.1.1 Writing Mode
+
+The `writingMode` property controls the direction of text flow and block progression:
+
+| Value | Description | Use Case |
+|-------|-------------|----------|
+| `horizontal-tb` | Horizontal text, top-to-bottom blocks (default) | Latin, Cyrillic, Greek |
+| `vertical-rl` | Vertical text, right-to-left columns | Traditional CJK (Chinese, Japanese, Korean) |
+| `vertical-lr` | Vertical text, left-to-right columns | Mongolian |
+| `sideways-rl` | Rotated 90° clockwise | Rotated labels |
+| `sideways-lr` | Rotated 90° counter-clockwise | Rotated labels |
+
+```json
+{
+  "styles": {
+    "verticalText": {
+      "writingMode": "vertical-rl",
+      "fontFamily": "Noto Sans JP, sans-serif"
+    },
+    "rotatedLabel": {
+      "writingMode": "sideways-lr",
+      "fontSize": "10pt"
+    }
+  }
+}
+```
+
+**Note:** The `writingMode` style property works in conjunction with the content-level `writingMode` attribute (see Content Blocks spec). When both are present, the presentation style takes precedence for visual rendering.
 
 **Spacing:**
 - `marginTop`, `marginRight`, `marginBottom`, `marginLeft`
@@ -132,6 +162,15 @@ Presentation styling uses a subset of CSS properties. This provides familiarity 
 
 **Background:**
 - `backgroundColor`
+- `backgroundImage` - URL/path to image (see Section 5.1.2)
+- `backgroundSize` - `cover`, `contain`, or dimensions
+- `backgroundPosition` - Position keywords or values
+- `backgroundRepeat` - `repeat`, `no-repeat`, `repeat-x`, `repeat-y`
+
+**Visual Effects:**
+- `opacity` - Transparency from 0.0 (fully transparent) to 1.0 (fully opaque)
+- `borderRadius` - Rounded corners (e.g., `"4px"`, `"0.5em"`)
+- `boxShadow` - Drop shadow (e.g., `"2px 2px 4px rgba(0,0,0,0.1)"`)
 
 **Layout:**
 - `width`, `height`, `maxWidth`, `maxHeight`
@@ -160,6 +199,73 @@ Colors may be specified as:
 - Hex: `"#ff0000"`, `"#f00"`
 - RGB: `"rgb(255, 0, 0)"`
 - RGBA: `"rgba(255, 0, 0, 0.5)"`
+
+### 5.4 Background Images
+
+Background images enable watermarks, decorative elements, and complex backgrounds:
+
+```json
+{
+  "styles": {
+    "watermarked": {
+      "backgroundImage": "assets/images/watermark.png",
+      "backgroundSize": "contain",
+      "backgroundPosition": "center",
+      "backgroundRepeat": "no-repeat",
+      "opacity": 0.3
+    },
+    "certificateBorder": {
+      "backgroundImage": "assets/images/border-pattern.svg",
+      "backgroundSize": "100% 100%",
+      "backgroundRepeat": "no-repeat"
+    }
+  }
+}
+```
+
+| Property | Values | Description |
+|----------|--------|-------------|
+| `backgroundImage` | path or URL | Image source (relative paths for embedded assets) |
+| `backgroundSize` | `cover`, `contain`, or dimensions | How image is sized |
+| `backgroundPosition` | position keywords or values | Where image is positioned |
+| `backgroundRepeat` | `repeat`, `no-repeat`, `repeat-x`, `repeat-y` | Tiling behavior |
+
+**backgroundSize values:**
+- `cover` - Scale to cover entire element (may crop)
+- `contain` - Scale to fit within element (may leave gaps)
+- Dimensions: `"100px 50px"`, `"100% auto"`, etc.
+
+**backgroundPosition values:**
+- Keywords: `center`, `top`, `bottom left`, `right center`, etc.
+- Lengths: `"10px 20px"`, `"50% 25%"`, etc.
+
+### 5.5 Opacity and Visual Effects
+
+```json
+{
+  "styles": {
+    "subtle": {
+      "opacity": 0.7
+    },
+    "card": {
+      "backgroundColor": "#ffffff",
+      "borderRadius": "8px",
+      "boxShadow": "0 2px 8px rgba(0,0,0,0.15)"
+    }
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `opacity` | number (0.0-1.0) | Element transparency (0 = invisible, 1 = opaque) |
+| `borderRadius` | string | Corner rounding (e.g., `"4px"`, `"0.5em"`, `"50%"`) |
+| `boxShadow` | string | Shadow effect using CSS shadow syntax |
+
+**boxShadow syntax:** `"offset-x offset-y blur-radius spread-radius color"`
+- `"2px 2px 4px rgba(0,0,0,0.1)"` - subtle drop shadow
+- `"0 4px 12px rgba(0,0,0,0.25)"` - elevated card effect
+- `"inset 0 1px 2px rgba(0,0,0,0.1)"` - inset shadow
 
 ## 6. Paginated Presentation
 
@@ -237,6 +343,40 @@ Each page contains positioned elements that reference content blocks:
 | `position` | object | Yes | Position and size |
 | `style` | string | No | Named style to apply |
 | `overflow` | string | No | "visible", "hidden", "flow" |
+| `zIndex` | integer | No | Stacking order (higher values render on top) |
+| `transform` | object | No | Transform properties (see Section 16) |
+
+### 6.3.1 Z-Index and Stacking Order
+
+The `zIndex` property controls the stacking order of overlapping elements:
+
+```json
+{
+  "elements": [
+    {
+      "blockId": "background-image",
+      "position": { "x": "0", "y": "0", "width": "8.5in", "height": "11in" },
+      "zIndex": 0
+    },
+    {
+      "blockId": "signature",
+      "position": { "x": "5in", "y": "9in", "width": "2in", "height": "1in" },
+      "zIndex": 1
+    },
+    {
+      "blockId": "timestamp",
+      "position": { "x": "5.5in", "y": "9.5in", "width": "1in", "height": "0.3in" },
+      "zIndex": 2
+    }
+  ]
+}
+```
+
+**Rules:**
+- Default `zIndex` is 0
+- Higher values render on top of lower values
+- Elements with the same `zIndex` render in document order (later elements on top)
+- Negative values are permitted
 
 ### 6.4 Flow Elements
 
@@ -761,7 +901,101 @@ For text colors, ensure sufficient contrast ratio:
 - Normal text: 4.5:1 minimum
 - Large text (18pt+ or 14pt+ bold): 3:1 minimum
 
-## 16. Examples
+## 16. Transforms
+
+Transforms enable rotation, scaling, skewing, and translation of positioned elements. Transforms are particularly useful for:
+
+- Rotated text (e.g., vertical labels, angled watermarks)
+- Scaled elements
+- Complex layout effects
+
+### 16.1 Transform Properties
+
+Elements in paginated presentations and precise layouts MAY include a `transform` property:
+
+```json
+{
+  "blockId": "hash-text",
+  "position": { "x": "0.3in", "y": "1in", "width": "9in", "height": "0.5in" },
+  "transform": {
+    "rotate": "-90deg",
+    "origin": "top left"
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `rotate` | string | Rotation angle: `"45deg"`, `"-90deg"`, `"0.5rad"`, `"0.25turn"` |
+| `scale` | number or object | Uniform scale: `1.5`, or per-axis: `{ "x": 1.5, "y": 1.0 }` |
+| `skewX` | string | Horizontal skew angle: `"15deg"` |
+| `skewY` | string | Vertical skew angle: `"15deg"` |
+| `translateX` | string | Horizontal translation: `"10px"`, `"0.5in"` |
+| `translateY` | string | Vertical translation: `"10px"`, `"0.5in"` |
+| `matrix` | array | Full 2D transform matrix: `[a, b, c, d, tx, ty]` |
+| `origin` | string or object | Transform origin point |
+
+### 16.2 Rotation Units
+
+| Unit | Description | Example |
+|------|-------------|---------|
+| `deg` | Degrees (360° = full rotation) | `"90deg"`, `"-45deg"` |
+| `rad` | Radians (2π = full rotation) | `"1.5708rad"` |
+| `turn` | Turns (1 = full rotation) | `"0.25turn"` |
+
+### 16.3 Transform Origin
+
+The `origin` property specifies the point around which transforms are applied:
+
+**Keyword values:**
+- Position keywords: `"top left"`, `"center"`, `"bottom right"`, etc.
+- Single keyword: `"center"` (equivalent to `"center center"`)
+
+**Coordinate values:**
+```json
+{
+  "origin": { "x": "50%", "y": "0" }
+}
+```
+
+Default origin is `"center"` (center of the element's bounding box).
+
+### 16.4 Transform Matrix
+
+For complex transforms, use the matrix property with the standard 2D affine transformation matrix:
+
+```json
+{
+  "transform": {
+    "matrix": [1, 0, 0, 1, 0, 0]
+  }
+}
+```
+
+The matrix `[a, b, c, d, tx, ty]` represents:
+```
+| a  c  tx |
+| b  d  ty |
+| 0  0  1  |
+```
+
+Common matrices:
+- Identity (no transform): `[1, 0, 0, 1, 0, 0]`
+- 90° clockwise: `[0, 1, -1, 0, 0, 0]`
+- Scale 2×: `[2, 0, 0, 2, 0, 0]`
+
+### 16.5 Transform Order
+
+When multiple transform properties are specified, they are applied in this order:
+
+1. `translate` (translateX, translateY)
+2. `rotate`
+3. `scale`
+4. `skew` (skewX, skewY)
+
+If `matrix` is specified, it overrides all other transform properties.
+
+## 17. Examples
 
 ### 16.1 Minimal Continuous Presentation
 

--- a/spec/extensions/presentation/README.md
+++ b/spec/extensions/presentation/README.md
@@ -313,6 +313,8 @@ Common features:
 
 ## 7. Figures and Floats
 
+> **Note:** The `figure` and `figcaption` block types are now part of the core specification (see Content Blocks, Sections 4.20-4.21). This extension provides additional float positioning and advanced numbering capabilities.
+
 ### 7.1 Float Positioning
 
 ```json
@@ -330,7 +332,9 @@ Common features:
 Position options: `top`, `bottom`, `inline`, `page-top`, `page-bottom`
 Span options: `column`, `page`, `spread`
 
-### 7.2 Figure Captions
+### 7.2 Advanced Figure Numbering
+
+The core `figure` block supports basic `numbering` ("auto", "none", or explicit number). This extension adds chapter-based numbering:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Add transform system (rotation, scale, skew, matrix) for rotated text like SHA3-256 hashes on margins
- Add writing mode support for CJK vertical text and rotated labels
- Add z-index/layering for overlapping elements (signatures with timestamps)
- Add background images and opacity for watermarks
- Add definition list blocks for term-description pairs
- Add measurement block with uncertainty notation for scientific values
- Add signature block with signer info, timestamp, and purpose
- Add SVG and barcode (QR, DataMatrix, etc.) block types
- Move figure/figcaption from extension to core
- Add inline math mark for mathematical expressions in text
- Add borderRadius and boxShadow visual effects

## Test plan

- [x] All JSON schemas validate with ajv-cli
- [ ] Review spec documentation for consistency
- [ ] Verify schema definitions match spec prose