### PR TITLE
Add academic extension for scientific documents

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -17,6 +17,13 @@ This directory contains JSON Schema definitions for validating Codex document co
 | `annotations.schema.json` | Core annotations | `security/annotations.json` |
 | `phantoms.schema.json` | Phantom clusters | `phantoms/clusters.json` |
 
+### Extension Schemas
+
+| Schema | Purpose | Validates |
+|--------|---------|-----------|
+| `semantic.schema.json` | Semantic extension | `semantic:*` blocks and marks |
+| `academic.schema.json` | Academic extension | `academic:*` blocks and marks |
+
 ## Schema Dependencies
 
 Some schemas reference definitions from other schema files:

--- a/schemas/academic.schema.json
+++ b/schemas/academic.schema.json
@@ -1,0 +1,518 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codex.document/schemas/academic.schema.json",
+  "title": "Codex Academic Extension",
+  "description": "Schema for academic extension blocks and marks in a Codex document",
+  "$defs": {
+    "theoremVariant": {
+      "type": "string",
+      "description": "Built-in theorem-like environment variants",
+      "enum": [
+        "theorem",
+        "lemma",
+        "proposition",
+        "corollary",
+        "definition",
+        "conjecture",
+        "remark",
+        "example"
+      ]
+    },
+    "proofMethod": {
+      "type": "string",
+      "description": "Proof methodology",
+      "enum": [
+        "direct",
+        "contradiction",
+        "contrapositive",
+        "induction",
+        "strong-induction",
+        "structural-induction",
+        "cases",
+        "construction",
+        "counting",
+        "probabilistic"
+      ]
+    },
+    "qedStyle": {
+      "type": "string",
+      "description": "QED marker style",
+      "enum": ["symbol", "text", "none"],
+      "default": "symbol"
+    },
+    "difficulty": {
+      "type": "string",
+      "description": "Exercise difficulty level",
+      "enum": ["easy", "medium", "hard"]
+    },
+    "solutionVisibility": {
+      "type": "string",
+      "description": "Solution visibility mode",
+      "enum": ["visible", "hidden", "spoiler", "instructor-only"],
+      "default": "hidden"
+    },
+    "equationEnvironment": {
+      "type": "string",
+      "description": "LaTeX multi-line equation environment",
+      "enum": ["align", "gather", "alignat", "split"]
+    },
+    "numberingStyle": {
+      "type": "string",
+      "description": "Numbering style pattern",
+      "enum": ["number", "chapter.number", "section.number", "chapter.section.number"]
+    },
+    "resetTrigger": {
+      "type": "string",
+      "description": "When to reset counters",
+      "enum": ["chapter", "section", "none"]
+    },
+    "theoremBlock": {
+      "type": "object",
+      "description": "Theorem-like environment block",
+      "required": ["type", "variant", "children"],
+      "properties": {
+        "type": { "const": "academic:theorem" },
+        "variant": {
+          "type": "string",
+          "description": "Variant name (built-in or custom)"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for cross-referencing"
+        },
+        "number": {
+          "type": "string",
+          "description": "Explicit number (e.g., '2.3.8')"
+        },
+        "numbering": {
+          "type": "string",
+          "description": "Numbering mode",
+          "enum": ["auto", "none"]
+        },
+        "title": {
+          "type": "string",
+          "description": "Custom title (e.g., 'Maximum Principle')"
+        },
+        "uses": {
+          "type": "array",
+          "description": "Content Anchor URIs of dependencies",
+          "items": { "type": "string" }
+        },
+        "restate": {
+          "type": "boolean",
+          "description": "If true, this is a restatement of a previously stated theorem",
+          "default": false
+        },
+        "children": {
+          "type": "array",
+          "description": "Theorem content blocks"
+        }
+      },
+      "additionalProperties": false
+    },
+    "proofBlock": {
+      "type": "object",
+      "description": "Proof block",
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "academic:proof" },
+        "of": {
+          "type": "string",
+          "description": "Content Anchor URI to the theorem being proved"
+        },
+        "title": {
+          "type": "string",
+          "description": "Override title (default: 'Proof')"
+        },
+        "method": { "$ref": "#/$defs/proofMethod" },
+        "qed": { "$ref": "#/$defs/qedStyle" },
+        "children": {
+          "type": "array",
+          "description": "Proof content blocks"
+        }
+      },
+      "additionalProperties": false
+    },
+    "solution": {
+      "type": "object",
+      "description": "Exercise solution",
+      "required": ["children"],
+      "properties": {
+        "visibility": { "$ref": "#/$defs/solutionVisibility" },
+        "revealAfter": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 datetime after which solution becomes visible"
+        },
+        "children": {
+          "type": "array",
+          "description": "Solution content blocks"
+        }
+      },
+      "additionalProperties": false
+    },
+    "exercisePart": {
+      "type": "object",
+      "description": "A sub-part of a multi-part exercise",
+      "required": ["label", "children"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Part label (e.g., 'a', 'i', '1')"
+        },
+        "children": {
+          "type": "array",
+          "description": "Part problem statement"
+        },
+        "hints": {
+          "type": "array",
+          "description": "Part-specific hints"
+        },
+        "solution": { "$ref": "#/$defs/solution" }
+      },
+      "additionalProperties": false
+    },
+    "exerciseBlock": {
+      "type": "object",
+      "description": "Exercise/problem block",
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "academic:exercise" },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier"
+        },
+        "number": {
+          "type": "string",
+          "description": "Exercise number"
+        },
+        "difficulty": { "$ref": "#/$defs/difficulty" },
+        "children": {
+          "type": "array",
+          "description": "Problem statement (preamble if parts exist)"
+        },
+        "parts": {
+          "type": "array",
+          "description": "Multi-part sub-exercises",
+          "items": { "$ref": "#/$defs/exercisePart" }
+        },
+        "hints": {
+          "type": "array",
+          "description": "Hint paragraphs"
+        },
+        "solution": { "$ref": "#/$defs/solution" }
+      },
+      "additionalProperties": false
+    },
+    "exerciseSetBlock": {
+      "type": "object",
+      "description": "Container for grouped exercises with shared context",
+      "required": ["type", "exercises"],
+      "properties": {
+        "type": { "const": "academic:exercise-set" },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier"
+        },
+        "title": {
+          "type": "string",
+          "description": "Set title"
+        },
+        "preamble": {
+          "type": "array",
+          "description": "Shared context/instructions for all exercises"
+        },
+        "exercises": {
+          "type": "array",
+          "description": "Array of exercise blocks",
+          "items": { "$ref": "#/$defs/exerciseBlock" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "equationLine": {
+      "type": "object",
+      "description": "A single line in an equation group",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "LaTeX content for this line"
+        },
+        "number": {
+          "type": ["string", "null"],
+          "description": "Line number, or null for unnumbered"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Custom tag (e.g., '*', '\\dagger') instead of number"
+        },
+        "id": {
+          "type": "string",
+          "description": "Line identifier for references"
+        }
+      },
+      "additionalProperties": false
+    },
+    "equationGroupBlock": {
+      "type": "object",
+      "description": "Multi-line equation environment",
+      "required": ["type", "lines"],
+      "properties": {
+        "type": { "const": "academic:equation-group" },
+        "environment": { "$ref": "#/$defs/equationEnvironment" },
+        "id": {
+          "type": "string",
+          "description": "Group identifier"
+        },
+        "lines": {
+          "type": "array",
+          "description": "Array of equation lines",
+          "items": { "$ref": "#/$defs/equationLine" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "algorithmParameter": {
+      "type": "object",
+      "description": "Algorithm input or output parameter",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Parameter name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Parameter description"
+        }
+      },
+      "additionalProperties": false
+    },
+    "algorithmLine": {
+      "type": "object",
+      "description": "A line of pseudocode in an algorithm",
+      "required": ["content"],
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "Line content (may include LaTeX)"
+        },
+        "indent": {
+          "type": "integer",
+          "description": "Indentation level",
+          "minimum": 0,
+          "default": 0
+        },
+        "label": {
+          "type": "string",
+          "description": "Label for line references"
+        },
+        "comment": {
+          "type": "string",
+          "description": "Inline comment"
+        }
+      },
+      "additionalProperties": false
+    },
+    "algorithmBlock": {
+      "type": "object",
+      "description": "Algorithm block with line-numbered pseudocode",
+      "required": ["type", "lines"],
+      "properties": {
+        "type": { "const": "academic:algorithm" },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier"
+        },
+        "number": {
+          "type": "string",
+          "description": "Algorithm number"
+        },
+        "title": {
+          "type": "string",
+          "description": "Algorithm name"
+        },
+        "caption": {
+          "type": "string",
+          "description": "Description caption"
+        },
+        "lineNumbering": {
+          "type": "boolean",
+          "description": "Show line numbers",
+          "default": true
+        },
+        "startLine": {
+          "type": "integer",
+          "description": "Starting line number",
+          "minimum": 1,
+          "default": 1
+        },
+        "lines": {
+          "type": "array",
+          "description": "Pseudocode lines",
+          "items": { "$ref": "#/$defs/algorithmLine" }
+        },
+        "inputs": {
+          "type": "array",
+          "description": "Input parameters",
+          "items": { "$ref": "#/$defs/algorithmParameter" }
+        },
+        "outputs": {
+          "type": "array",
+          "description": "Output description",
+          "items": { "$ref": "#/$defs/algorithmParameter" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "theoremRefMark": {
+      "type": "object",
+      "description": "Reference to a theorem-like block",
+      "required": ["type", "target"],
+      "properties": {
+        "type": { "const": "theorem-ref" },
+        "target": {
+          "type": "string",
+          "description": "Content Anchor URI to the theorem"
+        },
+        "format": {
+          "type": "string",
+          "description": "Display format (e.g., 'Theorem {number}')"
+        }
+      },
+      "additionalProperties": false
+    },
+    "equationRefMark": {
+      "type": "object",
+      "description": "Reference to a numbered equation",
+      "required": ["type", "target"],
+      "properties": {
+        "type": { "const": "equation-ref" },
+        "target": {
+          "type": "string",
+          "description": "Content Anchor URI to the equation"
+        },
+        "format": {
+          "type": "string",
+          "description": "Display format (e.g., '({number})')"
+        }
+      },
+      "additionalProperties": false
+    },
+    "algorithmRefMark": {
+      "type": "object",
+      "description": "Reference to an algorithm or algorithm line",
+      "required": ["type", "target"],
+      "properties": {
+        "type": { "const": "algorithm-ref" },
+        "target": {
+          "type": "string",
+          "description": "Content Anchor URI to the algorithm"
+        },
+        "line": {
+          "type": "string",
+          "description": "Line label for line-specific references"
+        },
+        "format": {
+          "type": "string",
+          "description": "Display format"
+        }
+      },
+      "additionalProperties": false
+    },
+    "customVariantDefinition": {
+      "type": "object",
+      "description": "Definition of a custom theorem-like variant",
+      "required": ["label"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Display label for the variant"
+        },
+        "sharesWith": {
+          "type": ["string", "null"],
+          "description": "Share counter with this variant, or null for independent"
+        }
+      },
+      "additionalProperties": false
+    },
+    "counterConfig": {
+      "type": "object",
+      "description": "Counter sharing configuration for a theorem variant",
+      "properties": {
+        "share": {
+          "type": "array",
+          "description": "Variants that share this counter",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "numberingConfig": {
+      "type": "object",
+      "description": "Numbering configuration for the academic extension",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Configuration version"
+        },
+        "equations": {
+          "type": "object",
+          "description": "Equation numbering settings",
+          "properties": {
+            "style": { "$ref": "#/$defs/numberingStyle" },
+            "resetOn": { "$ref": "#/$defs/resetTrigger" }
+          },
+          "additionalProperties": false
+        },
+        "theorems": {
+          "type": "object",
+          "description": "Theorem numbering settings",
+          "properties": {
+            "style": { "$ref": "#/$defs/numberingStyle" },
+            "counters": {
+              "type": "object",
+              "description": "Counter sharing configuration",
+              "additionalProperties": { "$ref": "#/$defs/counterConfig" }
+            }
+          },
+          "additionalProperties": false
+        },
+        "algorithms": {
+          "type": "object",
+          "description": "Algorithm numbering settings",
+          "properties": {
+            "style": { "$ref": "#/$defs/numberingStyle" },
+            "resetOn": { "$ref": "#/$defs/resetTrigger" }
+          },
+          "additionalProperties": false
+        },
+        "exercises": {
+          "type": "object",
+          "description": "Exercise numbering settings",
+          "properties": {
+            "style": { "$ref": "#/$defs/numberingStyle" },
+            "resetOn": { "$ref": "#/$defs/resetTrigger" }
+          },
+          "additionalProperties": false
+        },
+        "customVariants": {
+          "type": "object",
+          "description": "Custom theorem-like variant definitions",
+          "additionalProperties": { "$ref": "#/$defs/customVariantDefinition" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "description": "Academic extension configuration",
+  "properties": {
+    "numbering": {
+      "type": "string",
+      "description": "Path to numbering configuration file (e.g., 'academic/numbering.json')"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -18,6 +18,7 @@ interface DependentSchema {
 
 // Standalone schemas (no cross-references)
 const standaloneSchemas: string[] = [
+  'academic.schema.json',
   'anchor.schema.json',
   'asset-index.schema.json',
   'content.schema.json',

--- a/spec/extensions/academic/README.md
+++ b/spec/extensions/academic/README.md
@@ -1,0 +1,899 @@
+# Academic Extension
+
+**Extension ID**: `codex.academic`
+**Version**: 0.1
+**Status**: Draft
+
+## 1. Overview
+
+The Academic Extension provides structured support for academic and scientific documents:
+
+- Theorem-like environments (theorem, lemma, definition, etc.)
+- Proof blocks with method annotations
+- Exercises with multi-part support, hints, and solutions
+- Exercise sets for grouped problems
+- Multi-line equation environments with numbering
+- Algorithm blocks with line-numbered pseudocode
+- Cross-references for theorems and equations
+- Configurable numbering systems
+
+## 2. Extension Declaration
+
+```json
+{
+  "extensions": [
+    {
+      "id": "codex.academic",
+      "version": "0.1",
+      "required": false
+    }
+  ],
+  "academic": {
+    "numbering": "academic/numbering.json"
+  }
+}
+```
+
+## 3. Theorem-Like Blocks
+
+### 3.1 academic:theorem
+
+Covers built-in variants: theorem, lemma, proposition, corollary, definition, conjecture, remark, example.
+
+```json
+{
+  "type": "academic:theorem",
+  "variant": "theorem",
+  "id": "thm-max-principle",
+  "number": "2.3.8",
+  "numbering": "auto",
+  "title": "Maximum Principle",
+  "uses": ["#def-harmonic", "#lemma-subharmonic"],
+  "restate": false,
+  "children": [
+    { "type": "paragraph", "children": [...] }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"academic:theorem"` |
+| `variant` | string | Yes | Built-in or custom variant name |
+| `id` | string | No | Unique identifier for cross-referencing |
+| `number` | string | No | Explicit number (e.g., "2.3.8") |
+| `numbering` | string | No | `"auto"`, `"none"`, or omit for default |
+| `title` | string | No | Custom title (e.g., "Hille-Yoshida Theorem") |
+| `uses` | array | No | Content Anchor URIs of dependencies (definitions, lemmas used) |
+| `restate` | boolean | No | If `true`, this is a restatement of a previously stated theorem |
+| `children` | array | Yes | Content blocks |
+
+### 3.2 Built-in Variants
+
+| Variant | Typical Use |
+|---------|-------------|
+| `theorem` | Major results |
+| `lemma` | Supporting results |
+| `proposition` | Secondary results |
+| `corollary` | Consequences of theorems |
+| `definition` | Formal definitions |
+| `conjecture` | Unproven statements |
+| `remark` | Observations and notes |
+| `example` | Illustrative examples |
+
+### 3.3 Custom Variants
+
+Define custom theorem-like environments in the numbering configuration:
+
+```json
+{
+  "customVariants": {
+    "axiom": {
+      "label": "Axiom",
+      "sharesWith": "definition"
+    },
+    "postulate": {
+      "label": "Postulate",
+      "sharesWith": "definition"
+    },
+    "law": {
+      "label": "Law",
+      "sharesWith": "theorem"
+    },
+    "invariant": {
+      "label": "Invariant",
+      "sharesWith": null
+    }
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `label` | string | Yes | Display label for the variant |
+| `sharesWith` | string\|null | No | Share counter with this variant, or `null` for independent counter |
+
+## 4. Proof Blocks
+
+### 4.1 academic:proof
+
+```json
+{
+  "type": "academic:proof",
+  "of": "#thm-max-principle",
+  "title": "Proof",
+  "method": "contradiction",
+  "qed": "symbol",
+  "children": [
+    { "type": "paragraph", "children": [...] }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"academic:proof"` |
+| `of` | string | No | Content Anchor URI to the theorem being proved |
+| `title` | string | No | Override title (default: "Proof") |
+| `method` | string | No | Proof method (see below) |
+| `qed` | string | No | QED style: `"symbol"` (default), `"text"`, `"none"` |
+| `children` | array | Yes | Proof content |
+
+### 4.2 Proof Methods
+
+| Method | Description |
+|--------|-------------|
+| `direct` | Direct proof |
+| `contradiction` | Proof by contradiction (reductio ad absurdum) |
+| `contrapositive` | Proof by contrapositive |
+| `induction` | Proof by mathematical induction |
+| `strong-induction` | Proof by strong/complete induction |
+| `structural-induction` | Proof by structural induction |
+| `cases` | Proof by exhaustive cases |
+| `construction` | Proof by construction |
+| `counting` | Combinatorial/counting argument |
+| `probabilistic` | Probabilistic method |
+
+## 5. Exercises
+
+### 5.1 academic:exercise
+
+```json
+{
+  "type": "academic:exercise",
+  "id": "ex-2-5",
+  "number": "2.5",
+  "difficulty": "medium",
+  "children": [
+    { "type": "paragraph", "children": [...] }
+  ],
+  "parts": [
+    {
+      "label": "a",
+      "children": [{ "type": "paragraph", "children": [...] }],
+      "hints": [...],
+      "solution": { "visibility": "hidden", "children": [...] }
+    },
+    {
+      "label": "b",
+      "children": [{ "type": "paragraph", "children": [...] }]
+    }
+  ],
+  "hints": [
+    { "type": "paragraph", "children": [...] }
+  ],
+  "solution": {
+    "visibility": "hidden",
+    "children": [...]
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"academic:exercise"` |
+| `id` | string | No | Unique identifier |
+| `number` | string | No | Exercise number |
+| `difficulty` | string | No | `"easy"`, `"medium"`, `"hard"` |
+| `children` | array | Yes | Problem statement (preamble if parts exist) |
+| `parts` | array | No | Multi-part sub-exercises |
+| `hints` | array | No | Hint paragraphs (applies to whole exercise) |
+| `solution` | object | No | Solution with visibility control |
+
+### 5.2 Exercise Parts
+
+Each part in the `parts` array:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `label` | string | Yes | Part label (e.g., "a", "i", "1") |
+| `children` | array | Yes | Part problem statement |
+| `hints` | array | No | Part-specific hints |
+| `solution` | object | No | Part-specific solution |
+
+### 5.3 Solution Visibility
+
+```json
+{
+  "visibility": "hidden",
+  "children": [...]
+}
+```
+
+| Visibility | Description |
+|------------|-------------|
+| `visible` | Solution is always shown |
+| `hidden` | Solution is not rendered by default |
+| `spoiler` | Solution is hidden behind a reveal interaction |
+| `instructor-only` | Solution requires instructor/elevated access |
+
+Optional date-based reveal:
+
+```json
+{
+  "visibility": "hidden",
+  "revealAfter": "2025-03-15T00:00:00Z",
+  "children": [...]
+}
+```
+
+### 5.4 Exercise Sets
+
+Group related exercises with shared context:
+
+```json
+{
+  "type": "academic:exercise-set",
+  "id": "exercises-ch2",
+  "title": "Chapter 2 Exercises",
+  "preamble": [
+    { "type": "paragraph", "children": [
+      { "type": "text", "value": "In exercises 1-5, let " },
+      { "type": "text", "value": "f", "marks": [{ "type": "math", "format": "latex", "source": "f" }] },
+      { "type": "text", "value": " be a continuous function on [0,1]." }
+    ]}
+  ],
+  "exercises": [
+    { "type": "academic:exercise", "number": "1", ... },
+    { "type": "academic:exercise", "number": "2", ... }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"academic:exercise-set"` |
+| `id` | string | No | Unique identifier |
+| `title` | string | No | Set title (e.g., "Chapter 2 Exercises") |
+| `preamble` | array | No | Shared context/instructions for all exercises |
+| `exercises` | array | Yes | Array of `academic:exercise` blocks |
+
+## 6. Multi-Line Equations
+
+### 6.1 academic:equation-group
+
+```json
+{
+  "type": "academic:equation-group",
+  "environment": "align",
+  "id": "eq-group-1",
+  "lines": [
+    {
+      "value": "f(x) &= x^2 + 1",
+      "number": "2.5",
+      "id": "eq-fx"
+    },
+    {
+      "value": "&= (x+i)(x-i)",
+      "number": null
+    },
+    {
+      "value": "g(x) &= 2x",
+      "tag": "*",
+      "id": "eq-gx"
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"academic:equation-group"` |
+| `environment` | string | No | LaTeX environment: `"align"`, `"gather"`, `"alignat"`, `"split"` |
+| `id` | string | No | Group identifier |
+| `lines` | array | Yes | Array of equation lines |
+
+### 6.2 Equation Lines
+
+Each line in the `lines` array:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `value` | string | Yes | LaTeX for this line |
+| `number` | string\|null | No | Line number, `null` for unnumbered |
+| `tag` | string | No | Custom tag (e.g., `"*"`, `"\dagger"`) instead of number |
+| `id` | string | No | Line identifier for references |
+
+**Note:** Use either `number` or `tag`, not both. If `tag` is present, it takes precedence.
+
+## 7. Algorithm Blocks
+
+### 7.1 academic:algorithm
+
+```json
+{
+  "type": "academic:algorithm",
+  "id": "alg-quicksort",
+  "number": "1",
+  "title": "QuickSort",
+  "caption": "Recursive quicksort algorithm",
+  "lineNumbering": true,
+  "startLine": 1,
+  "lines": [
+    { "content": "\\textbf{function} QuickSort(A, lo, hi)", "label": "fn-start" },
+    { "content": "  \\textbf{if} lo < hi \\textbf{then}", "indent": 1 },
+    { "content": "    p \\gets Partition(A, lo, hi)", "indent": 2 },
+    { "content": "    QuickSort(A, lo, p - 1)", "indent": 2 },
+    { "content": "    QuickSort(A, p + 1, hi)", "indent": 2 },
+    { "content": "  \\textbf{end if}", "indent": 1 },
+    { "content": "\\textbf{end function}", "label": "fn-end" }
+  ],
+  "inputs": [
+    { "name": "A", "description": "Array to sort" },
+    { "name": "lo", "description": "Lower index" },
+    { "name": "hi", "description": "Upper index" }
+  ],
+  "outputs": [
+    { "name": "A", "description": "Sorted array (in-place)" }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"academic:algorithm"` |
+| `id` | string | No | Unique identifier |
+| `number` | string | No | Algorithm number |
+| `title` | string | No | Algorithm name |
+| `caption` | string | No | Description caption |
+| `lineNumbering` | boolean | No | Show line numbers (default: `true`) |
+| `startLine` | integer | No | Starting line number (default: 1) |
+| `lines` | array | Yes | Pseudocode lines |
+| `inputs` | array | No | Input parameters |
+| `outputs` | array | No | Output description |
+
+### 7.2 Algorithm Lines
+
+Each line in the `lines` array:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | string | Yes | Line content (may include LaTeX for math/formatting) |
+| `indent` | integer | No | Indentation level (default: 0) |
+| `label` | string | No | Label for line references |
+| `comment` | string | No | Inline comment |
+
+### 7.3 Algorithm Input/Output
+
+```json
+{
+  "name": "A",
+  "description": "Array of n integers"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Parameter name |
+| `description` | string | No | Parameter description |
+
+## 8. Cross-References
+
+### 8.1 theorem-ref Mark
+
+Reference a theorem-like block:
+
+```json
+{
+  "type": "text",
+  "value": "Theorem 2.3.8",
+  "marks": [
+    {
+      "type": "theorem-ref",
+      "target": "#thm-max-principle",
+      "format": "Theorem {number}"
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"theorem-ref"` |
+| `target` | string | Yes | Content Anchor URI to the theorem |
+| `format` | string | No | Display format (default: `"{variant} {number}"`) |
+
+Format placeholders:
+- `{variant}` - Variant name (e.g., "Theorem", "Lemma")
+- `{number}` - Theorem number
+- `{title}` - Theorem title (if present)
+
+### 8.2 equation-ref Mark
+
+Reference a numbered equation:
+
+```json
+{
+  "type": "text",
+  "value": "(2.5)",
+  "marks": [
+    {
+      "type": "equation-ref",
+      "target": "#eq-fx",
+      "format": "({number})"
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"equation-ref"` |
+| `target` | string | Yes | Content Anchor URI to the equation |
+| `format` | string | No | Display format (default: `"({number})"`) |
+
+### 8.3 algorithm-ref Mark
+
+Reference an algorithm or algorithm line:
+
+```json
+{
+  "type": "text",
+  "value": "Algorithm 1",
+  "marks": [
+    {
+      "type": "algorithm-ref",
+      "target": "#alg-quicksort",
+      "format": "Algorithm {number}"
+    }
+  ]
+}
+```
+
+For line references:
+
+```json
+{
+  "type": "text",
+  "value": "line 3",
+  "marks": [
+    {
+      "type": "algorithm-ref",
+      "target": "#alg-quicksort",
+      "line": "fn-start",
+      "format": "line {line}"
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"algorithm-ref"` |
+| `target` | string | Yes | Content Anchor URI to the algorithm |
+| `line` | string | No | Line label for line-specific references |
+| `format` | string | No | Display format |
+
+## 9. Numbering Configuration
+
+Location: `academic/numbering.json`
+
+```json
+{
+  "version": "0.1",
+  "equations": {
+    "style": "chapter.number",
+    "resetOn": "chapter"
+  },
+  "theorems": {
+    "style": "chapter.section.number",
+    "counters": {
+      "theorem": { "share": ["lemma", "proposition", "corollary"] },
+      "definition": { "share": ["conjecture"] },
+      "remark": { "share": ["example"] }
+    }
+  },
+  "algorithms": {
+    "style": "number",
+    "resetOn": "chapter"
+  },
+  "exercises": {
+    "style": "chapter.number",
+    "resetOn": "chapter"
+  },
+  "customVariants": {
+    "axiom": {
+      "label": "Axiom",
+      "sharesWith": "definition"
+    },
+    "postulate": {
+      "label": "Postulate",
+      "sharesWith": "definition"
+    },
+    "law": {
+      "label": "Law",
+      "sharesWith": "theorem"
+    }
+  }
+}
+```
+
+### 9.1 Numbering Styles
+
+| Style | Example | Description |
+|-------|---------|-------------|
+| `number` | 1, 2, 3 | Simple sequential |
+| `chapter.number` | 2.1, 2.2 | Chapter-prefixed |
+| `chapter.section.number` | 2.3.1, 2.3.2 | Full hierarchical |
+| `section.number` | 3.1, 3.2 | Section-prefixed |
+
+### 9.2 Counter Sharing
+
+Theorem-like environments can share counters. When counters are shared, all variants in the group increment the same counter:
+
+```json
+"counters": {
+  "theorem": { "share": ["lemma", "proposition", "corollary"] }
+}
+```
+
+This produces: Theorem 1, Lemma 2, Proposition 3, Theorem 4, etc.
+
+### 9.3 Reset Triggers
+
+| Reset On | Description |
+|----------|-------------|
+| `chapter` | Reset at each chapter |
+| `section` | Reset at each section |
+| `none` | Never reset (document-wide numbering) |
+
+## 10. Examples
+
+### 10.1 Complete Theorem with Proof
+
+```json
+[
+  {
+    "type": "academic:theorem",
+    "variant": "definition",
+    "id": "def-harmonic",
+    "number": "2.3.1",
+    "children": [
+      {
+        "type": "paragraph",
+        "children": [
+          { "type": "text", "value": "A function " },
+          { "type": "text", "value": "u", "marks": [{ "type": "math", "format": "latex", "source": "u" }] },
+          { "type": "text", "value": " is " },
+          { "type": "text", "value": "harmonic", "marks": [{ "type": "strong" }] },
+          { "type": "text", "value": " if " },
+          { "type": "text", "value": "\\Delta u = 0", "marks": [{ "type": "math", "format": "latex", "source": "\\Delta u = 0" }] },
+          { "type": "text", "value": "." }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "academic:theorem",
+    "variant": "theorem",
+    "id": "thm-max-principle",
+    "number": "2.3.8",
+    "title": "Maximum Principle",
+    "uses": ["#def-harmonic"],
+    "children": [
+      {
+        "type": "paragraph",
+        "children": [
+          { "type": "text", "value": "Let " },
+          { "type": "text", "value": "u", "marks": [{ "type": "math", "format": "latex", "source": "u" }] },
+          { "type": "text", "value": " be a harmonic function on a bounded domain " },
+          { "type": "text", "value": "\\Omega", "marks": [{ "type": "math", "format": "latex", "source": "\\Omega" }] },
+          { "type": "text", "value": ". Then " },
+          { "type": "text", "value": "u", "marks": [{ "type": "math", "format": "latex", "source": "u" }] },
+          { "type": "text", "value": " attains its maximum on the boundary." }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "academic:proof",
+    "of": "#thm-max-principle",
+    "method": "contradiction",
+    "qed": "symbol",
+    "children": [
+      {
+        "type": "paragraph",
+        "children": [
+          { "type": "text", "value": "Suppose " },
+          { "type": "text", "value": "u", "marks": [{ "type": "math", "format": "latex", "source": "u" }] },
+          { "type": "text", "value": " attains a maximum at an interior point. Then by the mean value property..." }
+        ]
+      }
+    ]
+  }
+]
+```
+
+### 10.2 Multi-Part Exercise with Solution
+
+```json
+{
+  "type": "academic:exercise",
+  "id": "ex-2-5",
+  "number": "2.5",
+  "difficulty": "medium",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        { "type": "text", "value": "Let " },
+        { "type": "text", "value": "f(x) = x^2 + 1", "marks": [{ "type": "math", "format": "latex", "source": "f(x) = x^2 + 1" }] },
+        { "type": "text", "value": "." }
+      ]
+    }
+  ],
+  "parts": [
+    {
+      "label": "a",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            { "type": "text", "value": "Find " },
+            { "type": "text", "value": "f'(x)", "marks": [{ "type": "math", "format": "latex", "source": "f'(x)" }] },
+            { "type": "text", "value": "." }
+          ]
+        }
+      ],
+      "solution": {
+        "visibility": "spoiler",
+        "children": [
+          {
+            "type": "paragraph",
+            "children": [
+              { "type": "text", "value": "f'(x) = 2x", "marks": [{ "type": "math", "format": "latex", "source": "f'(x) = 2x" }] }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "b",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            { "type": "text", "value": "Find the critical points of " },
+            { "type": "text", "value": "f", "marks": [{ "type": "math", "format": "latex", "source": "f" }] },
+            { "type": "text", "value": "." }
+          ]
+        }
+      ],
+      "hints": [
+        {
+          "type": "paragraph",
+          "children": [
+            { "type": "text", "value": "Set the derivative equal to zero." }
+          ]
+        }
+      ],
+      "solution": {
+        "visibility": "hidden",
+        "children": [
+          {
+            "type": "paragraph",
+            "children": [
+              { "type": "text", "value": "Setting " },
+              { "type": "text", "value": "f'(x) = 0", "marks": [{ "type": "math", "format": "latex", "source": "f'(x) = 0" }] },
+              { "type": "text", "value": " gives " },
+              { "type": "text", "value": "x = 0", "marks": [{ "type": "math", "format": "latex", "source": "x = 0" }] },
+              { "type": "text", "value": "." }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### 10.3 Algorithm with References
+
+```json
+[
+  {
+    "type": "academic:algorithm",
+    "id": "alg-binary-search",
+    "number": "2",
+    "title": "BinarySearch",
+    "caption": "Binary search in a sorted array",
+    "lineNumbering": true,
+    "inputs": [
+      { "name": "A", "description": "Sorted array of n elements" },
+      { "name": "target", "description": "Value to find" }
+    ],
+    "outputs": [
+      { "name": "index", "description": "Index of target, or -1 if not found" }
+    ],
+    "lines": [
+      { "content": "lo \\gets 0", "label": "init-lo" },
+      { "content": "hi \\gets n - 1", "label": "init-hi" },
+      { "content": "\\textbf{while} lo \\leq hi \\textbf{do}", "label": "loop-start" },
+      { "content": "mid \\gets \\lfloor (lo + hi) / 2 \\rfloor", "indent": 1 },
+      { "content": "\\textbf{if} A[mid] = target \\textbf{then}", "indent": 1 },
+      { "content": "\\textbf{return} mid", "indent": 2, "label": "found" },
+      { "content": "\\textbf{else if} A[mid] < target \\textbf{then}", "indent": 1 },
+      { "content": "lo \\gets mid + 1", "indent": 2 },
+      { "content": "\\textbf{else}", "indent": 1 },
+      { "content": "hi \\gets mid - 1", "indent": 2 },
+      { "content": "\\textbf{end if}", "indent": 1 },
+      { "content": "\\textbf{end while}", "label": "loop-end" },
+      { "content": "\\textbf{return} -1", "comment": "not found" }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      { "type": "text", "value": "The loop invariant at " },
+      {
+        "type": "text",
+        "value": "line 3",
+        "marks": [
+          {
+            "type": "algorithm-ref",
+            "target": "#alg-binary-search",
+            "line": "loop-start",
+            "format": "line {line}"
+          }
+        ]
+      },
+      { "type": "text", "value": " ensures that if target exists, it is in A[lo..hi]." }
+    ]
+  }
+]
+```
+
+### 10.4 Equation Group with Custom Tags
+
+```json
+{
+  "type": "academic:equation-group",
+  "environment": "align",
+  "id": "eq-maxwell",
+  "lines": [
+    {
+      "value": "\\nabla \\cdot \\mathbf{E} &= \\frac{\\rho}{\\epsilon_0}",
+      "number": "1",
+      "id": "eq-gauss"
+    },
+    {
+      "value": "\\nabla \\cdot \\mathbf{B} &= 0",
+      "number": "2",
+      "id": "eq-gauss-mag"
+    },
+    {
+      "value": "\\nabla \\times \\mathbf{E} &= -\\frac{\\partial \\mathbf{B}}{\\partial t}",
+      "number": "3",
+      "id": "eq-faraday"
+    },
+    {
+      "value": "\\nabla \\times \\mathbf{B} &= \\mu_0 \\mathbf{J} + \\mu_0 \\epsilon_0 \\frac{\\partial \\mathbf{E}}{\\partial t}",
+      "number": "4",
+      "id": "eq-ampere"
+    },
+    {
+      "value": "&\\quad\\text{(in Gaussian units)}",
+      "tag": "*"
+    }
+  ]
+}
+```
+
+### 10.5 Exercise Set with Shared Context
+
+```json
+{
+  "type": "academic:exercise-set",
+  "id": "exercises-integration",
+  "title": "Integration Exercises",
+  "preamble": [
+    {
+      "type": "paragraph",
+      "children": [
+        { "type": "text", "value": "In exercises 1-3, evaluate the integral. Show all work." }
+      ]
+    }
+  ],
+  "exercises": [
+    {
+      "type": "academic:exercise",
+      "number": "1",
+      "difficulty": "easy",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            { "type": "text", "value": "\\int x^2 \\, dx", "marks": [{ "type": "math", "format": "latex", "source": "\\int x^2 \\, dx" }] }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "academic:exercise",
+      "number": "2",
+      "difficulty": "medium",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            { "type": "text", "value": "\\int e^x \\sin x \\, dx", "marks": [{ "type": "math", "format": "latex", "source": "\\int e^x \\sin x \\, dx" }] }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "academic:exercise",
+      "number": "3",
+      "difficulty": "hard",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            { "type": "text", "value": "\\int \\frac{1}{1+x^4} \\, dx", "marks": [{ "type": "math", "format": "latex", "source": "\\int \\frac{1}{1+x^4} \\, dx" }] }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 10.6 Restated Theorem Before Proof
+
+```json
+[
+  {
+    "type": "academic:theorem",
+    "variant": "theorem",
+    "id": "thm-fundamental",
+    "number": "1.2.3",
+    "title": "Fundamental Theorem of Calculus",
+    "restate": true,
+    "children": [
+      {
+        "type": "paragraph",
+        "children": [
+          { "type": "text", "value": "If " },
+          { "type": "text", "value": "f", "marks": [{ "type": "math", "format": "latex", "source": "f" }] },
+          { "type": "text", "value": " is continuous on " },
+          { "type": "text", "value": "[a,b]", "marks": [{ "type": "math", "format": "latex", "source": "[a,b]" }] },
+          { "type": "text", "value": ", then..." }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "academic:proof",
+    "of": "#thm-fundamental",
+    "method": "direct",
+    "children": [
+      {
+        "type": "paragraph",
+        "children": [
+          { "type": "text", "value": "We proceed by considering the limit definition..." }
+        ]
+      }
+    ]
+  }
+]
+```


### PR DESCRIPTION
## Summary

- Introduces `codex.academic` extension for academic and scientific documents
- Adds theorem-like environments (theorem, lemma, definition, proposition, corollary, conjecture, remark, example) with custom variant support
- Adds proof blocks with method annotations (direct, contradiction, induction, cases, etc.)
- Adds multi-part exercises with hints and visibility-controlled solutions (hidden, spoiler, instructor-only)
- Adds exercise sets for grouping problems with shared context
- Adds multi-line equation groups (align, gather, alignat, split) with numbering and custom tags
- Adds algorithm blocks with line-numbered pseudocode and input/output specifications
- Adds cross-reference marks for theorems, equations, and algorithm lines
- Adds configurable numbering system with counter sharing and reset triggers
- Includes comprehensive JSON Schema validation

## Files Changed

| File | Description |
|------|-------------|
| `spec/extensions/academic/README.md` | Extension specification |
| `schemas/academic.schema.json` | JSON Schema for validation |
| `schemas/README.md` | Added extension schemas section |
| `scripts/validate-schemas.ts` | Added academic schema to validation |

## Test plan

- [x] Schema compiles and validates correctly (`npm test` passes)
- [x] All existing tests continue to pass
- [ ] Review specification for completeness and consistency