### PR TITLE
Final cleanup: version note, section numbering, CI sync check

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Validate schemas and examples
         run: npm test
+
+      - name: Check spec-schema sync
+        run: npm run check:sync

--- a/spec/core/04-presentation-layers.md
+++ b/spec/core/04-presentation-layers.md
@@ -997,7 +997,7 @@ If `matrix` is specified, it overrides all other transform properties.
 
 ## 17. Examples
 
-### 16.1 Minimal Continuous Presentation
+### 17.1 Minimal Continuous Presentation
 
 ```json
 {
@@ -1024,7 +1024,7 @@ If `matrix` is specified, it overrides all other transform properties.
 }
 ```
 
-### 16.2 Print-Ready Paginated Presentation
+### 17.2 Print-Ready Paginated Presentation
 
 ```json
 {

--- a/spec/extensions/README.md
+++ b/spec/extensions/README.md
@@ -108,4 +108,6 @@ When implementing Codex support, consider the following priority order:
   - Minor: New optional features, backward-compatible
   - Major: Breaking changes
 
+**Note:** Most extensions are at version 0.1 (initial draft). The Collaboration extension is at version 0.2 because it underwent breaking changes to its comment threading model during development. This version difference is intentional and reflects actual specification maturity.
+
 See individual extension READMEs for version history and migration notes.


### PR DESCRIPTION
## Summary

- Add explanatory note to `spec/extensions/README.md` about why the Collaboration extension is at version 0.2 (intentional due to breaking changes during development)
- Fix section numbering in `spec/core/04-presentation-layers.md` where section 17 examples were incorrectly numbered as 16.1/16.2 instead of 17.1/17.2
- Add `npm run check:sync` step to CI workflow for ongoing spec-schema drift detection

## Test plan

- [x] All schemas validate (`npm run validate:schemas`)
- [x] All examples validate (`npm run validate:examples`)
- [x] Sync checker runs successfully (`npm run check:sync`)
- [x] CI workflow updated with new step