### PR TITLE
Add maintainer contact info for public release

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ For the full text, please visit: https://www.contributor-covenant.org/version/2/
 
 ## Reporting
 
-If you experience or witness unacceptable behavior, please report it by contacting the project maintainers.
+If you experience or witness unacceptable behavior, please report it by emailing [greg.vonnessi@entrolution.ai](mailto:greg.vonnessi@entrolution.ai).
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,10 @@ All contributors must agree to the following:
 
 ## Getting Help
 
-- Open a GitHub Issue for questions
-- Tag issues with `question` for general inquiries
+- Open a [GitHub Issue](https://github.com/gvonness-apolitical/codex-file-format-spec/issues) for questions
+- Use [GitHub Discussions](https://github.com/gvonness-apolitical/codex-file-format-spec/discussions) for general conversation and ideas
+- Tag issues with `question` for specific inquiries
+- Email [greg.vonnessi@entrolution.ai](mailto:greg.vonnessi@entrolution.ai) for private matters
 
 ## Recognition
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,12 +9,12 @@ If you discover a security vulnerability in this specification, please report it
 If you find a security flaw in the specification itself (e.g., a cryptographic weakness, a design flaw that could be exploited), please:
 
 1. **Do not** open a public issue
-2. Email the maintainers directly with details
+2. Email [greg.vonnessi@entrolution.ai](mailto:greg.vonnessi@entrolution.ai) with details
 3. Allow reasonable time for the issue to be addressed before public disclosure
 
 ### For Implementation Issues
 
-If you find a security issue in the reference implementation (cdx-core), please report it in that repository's security advisories.
+If you find a security issue in the reference implementation ([cdx-core](https://github.com/gvonness-apolitical/cdx-core)), please report it in that repository's security advisories.
 
 ## Scope
 


### PR DESCRIPTION
## Summary
- Add maintainer email (greg.vonnessi@entrolution.ai) to SECURITY.md, CODE_OF_CONDUCT.md, and CONTRIBUTING.md
- Link to cdx-core repo in SECURITY.md for implementation issue reporting
- Add GitHub Issues and GitHub Discussions links to CONTRIBUTING.md

## Test plan
- [ ] Verify SECURITY.md has email contact for vulnerability reports
- [ ] Verify CODE_OF_CONDUCT.md has email for violation reports
- [ ] Verify CONTRIBUTING.md links to Issues, Discussions, and email
- [ ] Verify cdx-core link in SECURITY.md points to correct repo