### PR TITLE
Consolidate unreleased changelog items into v0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,6 @@ All notable changes to the Codex file format specification.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
-
-### Added
-- Legal extension example document (`examples/legal-document/`)
-- Precise layout example (`examples/presentation-document/presentation/layouts/letter.json`)
-- Highlight annotation documentation in collaboration extension (Section 4.7)
-- Example coverage checking capability in sync checker
-
-### Fixed
-- Broken cross-reference in presentation layers spec (Section 5.1.2 → 5.4)
-- Sync checker false positives for MIME types, token types, and enum values
-
-### Changed
-- Content schema now references legal extension marks (`legal:cite`)
-
 ## [0.1] - 2025-01 (Draft)
 
 ### Added
@@ -31,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Provenance and lineage tracking
 - Anchors and references system
 - Presentation layers (paginated, continuous, responsive, precise)
+- Highlight annotation documentation in collaboration extension (Section 4.7)
 
 #### Extensions
 - **Academic** (`codex.academic`) - Theorems, proofs, exercises, algorithms, equation groups
@@ -45,12 +31,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 #### Profiles
 - Simple Documents profile for recreational reading
 
+#### Examples
+- Legal extension example document (`examples/legal-document/`)
+- Precise layout example (`examples/presentation-document/presentation/layouts/letter.json`)
+
 #### Tooling
 - JSON Schema validation for all specification components
 - Example document validation
 - Cross-reference validation
 - Spec-schema synchronization checking
+- Example coverage checking capability in sync checker
 - Template generation script
+
+### Fixed
+- Broken cross-reference in presentation layers spec (Section 5.1.2 → 5.4)
+- Sync checker false positives for MIME types, token types, and enum values
+
+### Changed
+- Content schema now references legal extension marks (`legal:cite`)
 
 ### Notes
 - This is an initial draft specification


### PR DESCRIPTION
## Summary
- Roll all previously-unreleased changelog items into the 0.1 draft release section
- Removes the `[Unreleased]` heading, distributing items into appropriate 0.1 sub-sections (Added, Fixed, Changed)
- Preparation for public release

## Test plan
- [ ] Verify CHANGELOG.md formatting is correct
- [ ] Confirm all previously-unreleased items appear under `[0.1]`