### PR TITLE
Update GitHub org references to Entrolution

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussions
-    url: https://github.com/gvonness-apolitical/codex-file-format-spec/discussions
+    url: https://github.com/Entrolution/codex-file-format-spec/discussions
     about: For general questions and community discussion
   - name: Reference Implementation
-    url: https://github.com/gvonness-apolitical/cdx-core
+    url: https://github.com/Entrolution/cdx-core
     about: For issues with the Rust reference implementation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,8 @@ All contributors must agree to the following:
 
 ## Getting Help
 
-- Open a [GitHub Issue](https://github.com/gvonness-apolitical/codex-file-format-spec/issues) for questions
-- Use [GitHub Discussions](https://github.com/gvonness-apolitical/codex-file-format-spec/discussions) for general conversation and ideas
+- Open a [GitHub Issue](https://github.com/Entrolution/codex-file-format-spec/issues) for questions
+- Use [GitHub Discussions](https://github.com/Entrolution/codex-file-format-spec/discussions) for general conversation and ideas
 - Tag issues with `question` for specific inquiries
 - Email [greg.vonnessi@entrolution.ai](mailto:greg.vonnessi@entrolution.ai) for private matters
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Document Format
 
-[![Validate Schemas](https://github.com/gvonness-apolitical/codex-file-format-spec/actions/workflows/validate-schemas.yml/badge.svg)](https://github.com/gvonness-apolitical/codex-file-format-spec/actions/workflows/validate-schemas.yml)
+[![Validate Schemas](https://github.com/Entrolution/codex-file-format-spec/actions/workflows/validate-schemas.yml/badge.svg)](https://github.com/Entrolution/codex-file-format-spec/actions/workflows/validate-schemas.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 **An open specification for documents that unify viewing and editing, with modern security and machine readability.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ If you find a security flaw in the specification itself (e.g., a cryptographic w
 
 ### For Implementation Issues
 
-If you find a security issue in the reference implementation ([cdx-core](https://github.com/gvonness-apolitical/cdx-core)), please report it in that repository's security advisories.
+If you find a security issue in the reference implementation ([cdx-core](https://github.com/Entrolution/cdx-core)), please report it in that repository's security advisories.
 
 ## Scope
 

--- a/docs/archive/2025-01-25-initial-spec-strategy.md
+++ b/docs/archive/2025-01-25-initial-spec-strategy.md
@@ -20,7 +20,7 @@ Built the full Codex Document Format specification from the feasibility study:
 
 ### Repository Setup
 
-- Pushed to GitHub: `gvonness-apolitical/codex-file-format-spec`
+- Pushed to GitHub: `Entrolution/codex-file-format-spec`
 - File extension: `.cdx`, MIME type: `application/vnd.codex+json`
 - Key design choices: ZIP container, content-addressable hashing (SHA-256), explicit state machine (draft → review → frozen → published), ES256 required for signatures, no scripting
 


### PR DESCRIPTION
## Summary

- Update all hardcoded GitHub URLs from `gvonness-apolitical` to `Entrolution` org
- Affected: README badge, SECURITY.md cdx-core link, CONTRIBUTING.md issue/discussion links, issue template config, archived strategy doc