### PR TITLE
Fix GitHub Sponsors account in funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: Entrolution
+github: gvonness-apolitical
 patreon: Entrolution


### PR DESCRIPTION
## Summary

- Revert `github` field to `gvonness-apolitical` which has an active GitHub Sponsors profile