### PR TITLE
Downgrade Blacksmith runners to 2vcpu

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   validate:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Reduces runner size to stay within the free tier (3,000 min/month).