### PR TITLE
Update references to renamed repo (cdx-file-format-spec)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussions
-    url: https://github.com/Entrolution/codex-file-format-spec/discussions
+    url: https://github.com/Entrolution/cdx-file-format-spec/discussions
     about: For general questions and community discussion
   - name: Reference Implementation
     url: https://github.com/Entrolution/cdx-core

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,8 @@ All contributors must agree to the following:
 
 ## Getting Help
 
-- Open a [GitHub Issue](https://github.com/Entrolution/codex-file-format-spec/issues) for questions
-- Use [GitHub Discussions](https://github.com/Entrolution/codex-file-format-spec/discussions) for general conversation and ideas
+- Open a [GitHub Issue](https://github.com/Entrolution/cdx-file-format-spec/issues) for questions
+- Use [GitHub Discussions](https://github.com/Entrolution/cdx-file-format-spec/discussions) for general conversation and ideas
 - Tag issues with `question` for specific inquiries
 - Email [greg.vonnessi@entrolution.ai](mailto:greg.vonnessi@entrolution.ai) for private matters
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CDX
 
-[![Validate Schemas](https://github.com/Entrolution/codex-file-format-spec/actions/workflows/validate-schemas.yml/badge.svg)](https://github.com/Entrolution/codex-file-format-spec/actions/workflows/validate-schemas.yml)
+[![Validate Schemas](https://github.com/Entrolution/cdx-file-format-spec/actions/workflows/validate-schemas.yml/badge.svg)](https://github.com/Entrolution/cdx-file-format-spec/actions/workflows/validate-schemas.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 **CDX — Content-addressed Document eXchange.** An open specification for documents that unify viewing and editing, with modern security and machine readability.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "codex-file-format-spec",
+  "name": "cdx-file-format-spec",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codex-file-format-spec",
+      "name": "cdx-file-format-spec",
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "codex-file-format-spec",
+  "name": "cdx-file-format-spec",
   "version": "0.1.0",
   "description": "Specification for CDX (Content-addressed Document eXchange)",
   "private": true,


### PR DESCRIPTION
## Summary
The GitHub repo was renamed `codex-file-format-spec` → `cdx-file-format-spec`. This updates the in-repo references to match:
- README CI badge URL
- CONTRIBUTING issue/discussion links
- `.github/ISSUE_TEMPLATE/config.yml` discussion URL
- `package.json` / `package-lock.json` `name`

`docs/archive/**` left unchanged (historical record). GitHub auto-redirects the old URLs, so this is cosmetic/correctness.

## Test plan
- [x] `npm test` — schemas + examples validate