### PR TITLE
chore: update GitHub username references to gvonnessi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: gvonness-apolitical
+github: gvonnessi
 patreon: Entrolution


### PR DESCRIPTION
Updates GitHub username references after the account rename `gvonness-apolitical` (and older `gvonness`) → `gvonnessi`.

Metadata only — no code/logic changes.

Files:
- `.github/FUNDING.yml`
