### PR TITLE
Cache npm packages on Blacksmith instead of GitHub

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -32,7 +32,15 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
-          cache: 'npm'
+
+      # Blacksmith-native npm cache (colocated with the runner — cheaper and
+      # faster than GitHub's cache backend); replaces setup-node's cache: 'npm'.
+      - name: Cache npm packages
+        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.0.2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- The CI runner is already a Blacksmith runner (`blacksmith-2vcpu-ubuntu-2404`); this routes the **npm cache** through Blacksmith's colocated cache (`useblacksmith/cache`) instead of GitHub's backend — cheaper and faster (the GitHub `cache: 'npm'` on `setup-node` is removed).
- Caches `~/.npm` keyed on `package-lock.json`, with a prefix `restore-keys` fallback — same pattern as `../event-horizon`'s `ci.yml`.
- Pinned to the **v5.0.2 release commit** (`c5fe29eb`), preserving the repo's existing SHA-pinned-actions convention rather than a floating `@v5` tag.

## Test plan
- [ ] PR CI run completes green on the Blacksmith runner (first run is a cold cache → miss-then-save; subsequent runs restore `~/.npm`).