### PR TITLE
Block-id alpha-renaming for document-ID purity (2.4)

### DIFF
--- a/examples/academic-document/manifest.json
+++ b/examples/academic-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:99f0d3023bde292cdb42c99bf29e3cee36ab7455279d4a93e0a3c2601069e156",
+  "id": "sha256:23c321c556615d6428aaa62b01b3b1992b0773a6159b765870db66e9ce77e060",
   "state": "draft",
   "created": "2025-01-28T14:00:00Z",
   "modified": "2025-01-28T14:00:00Z",

--- a/examples/collaboration-document/manifest.json
+++ b/examples/collaboration-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:96b9cc184b77372a0ea0cd609f3653cda1ba52be8e8b75b238e30e491d172784",
+  "id": "sha256:3f17b3d8431ba2fbdbcea56142ccc352a8d005b149874ac662a0b46b330c1da8",
   "state": "draft",
   "created": "2025-01-28T14:00:00Z",
   "modified": "2025-01-28T14:00:00Z",

--- a/examples/comprehensive-document/manifest.json
+++ b/examples/comprehensive-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:33db4471dd1097538cfe03974d258f25171fbbd0f66ec0c2a95f9a23d81f3c53",
+  "id": "sha256:9e1d310db37df76d260cc2b3ab154ee3167d456e175ac0d530484dc31bd0abdd",
   "state": "draft",
   "created": "2025-01-28T14:00:00Z",
   "modified": "2025-01-28T14:00:00Z",

--- a/examples/forms-document/manifest.json
+++ b/examples/forms-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:baf849b43d9c35c72eced9654a863ec5e23c68931f676a245b572cbf28625304",
+  "id": "sha256:5a0181008295eae5f4fc2cb958d24480fe59c926c9f3fee752fff196fa3ed025",
   "state": "draft",
   "created": "2025-01-28T14:00:00Z",
   "modified": "2025-01-28T14:00:00Z",

--- a/examples/legal-document/manifest.json
+++ b/examples/legal-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:f225024c0409b5ce62fdc5c492bddcf2113904802b284fb9f1257bcfeef9307a",
+  "id": "sha256:9321c311cff917acbeffa65b93fcd36f8ae6a77a6b6f9af86385a7686dca46a2",
   "state": "draft",
   "created": "2025-01-30T10:00:00Z",
   "modified": "2025-01-30T10:00:00Z",

--- a/examples/phantoms-document/manifest.json
+++ b/examples/phantoms-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:147384f6c69ce53271064501b5ff9a5b0b64f6a2622625e4c7b3e3b97665fdf6",
+  "id": "sha256:8d0529c189bafb626acefc1714b1e6566b9584b058ca0fb43a4b8ef5c993260b",
   "state": "draft",
   "created": "2025-01-28T14:00:00Z",
   "modified": "2025-01-28T14:00:00Z",

--- a/examples/presentation-document/manifest.json
+++ b/examples/presentation-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:435def982ff9ccb616e0c17ac9cd99807d7400a9fc9fd3ecc8506267a23cb97f",
+  "id": "sha256:757b4076374fa33bb8b2bfe25a14a03138bc416f73654ed966d1d30601ac0a3f",
   "state": "draft",
   "created": "2025-01-29T10:00:00Z",
   "modified": "2025-01-29T10:00:00Z",

--- a/examples/semantic-document/manifest.json
+++ b/examples/semantic-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:acb452d6218dc9547dc84944d09b1507d941dc475b2a26600cfe78723bafa23a",
+  "id": "sha256:3a93cfd7a4689cb0d32a7c598b8a5c671e3535094d7896f3041b694491f4e6d8",
   "state": "draft",
   "created": "2025-01-28T14:00:00Z",
   "modified": "2025-01-28T14:00:00Z",

--- a/examples/signed-document/manifest.json
+++ b/examples/signed-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:d6fb5b1b3185921fc9bbf0d2a72f343979f2a2d717638a3b1957450ed39b0628",
+  "id": "sha256:66db6e3c227d306b57068a4fa5e779e3a4b2ab74c9cb6320ecd57ddf280c2b86",
   "state": "frozen",
   "hashAlgorithm": "sha256",
   "created": "2025-01-10T08:00:00Z",

--- a/examples/signed-document/security/signatures.json
+++ b/examples/signed-document/security/signatures.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1",
-  "documentId": "sha256:d6fb5b1b3185921fc9bbf0d2a72f343979f2a2d717638a3b1957450ed39b0628",
+  "documentId": "sha256:66db6e3c227d306b57068a4fa5e779e3a4b2ab74c9cb6320ecd57ddf280c2b86",
   "signatures": [
     {
       "id": "sig-provider",

--- a/examples/simple-document/manifest.json
+++ b/examples/simple-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:c2a8dc4aaecce91b1031da4c22ccd62a29c46a696a968e5db661f3c0a8bb555c",
+  "id": "sha256:f4e44ff2cdc7ada51ec933747bb3cf4fda401861a51285663b2c0dbb9fab1a9c",
   "state": "draft",
   "created": "2025-01-15T10:00:00Z",
   "modified": "2025-01-15T10:00:00Z",

--- a/scripts/check-document-id.ts
+++ b/scripts/check-document-id.ts
@@ -63,6 +63,14 @@ if (orig && renamed && orig.expectedId !== renamed.expectedId) {
   fail('asset purity — renamed-asset id differs from original');
 }
 
+// Block-id purity is a defining property: two documents differing ONLY in their
+// author-chosen block/anchor labels MUST yield the same id.
+const labelsA = vectors.find((v) => v.name === 'alpha-rename-labels-a');
+const labelsB = vectors.find((v) => v.name === 'alpha-rename-labels-b');
+if (labelsA && labelsB && labelsA.expectedId !== labelsB.expectedId) {
+  fail('block-id purity — relabeled-document id differs from original');
+}
+
 // --- Part 2: example corpus -----------------------------------------------
 console.log('\nExample corpus document ids:');
 const examplesDir = path.join(__dirname, '..', 'examples');

--- a/scripts/kat/document-id-vectors.ts
+++ b/scripts/kat/document-id-vectors.ts
@@ -102,7 +102,7 @@ export const vectors: KatVector[] = [
   },
   {
     name: 'merge-and-id-boundary',
-    description: 'Adjacent equal-mark text nodes merge; a text node carrying an id is a boundary and is preserved.',
+    description: 'Adjacent equal-mark text nodes merge; a text node carrying an id is a boundary, and that id is alpha-renamed (k → b0).',
     parts: {
       manifest: '{}',
       content:
@@ -110,8 +110,8 @@ export const vectors: KatVector[] = [
       dublinCore: DC,
     },
     expectedCanonicalJcs:
-      `{"content":{"blocks":[{"children":[{"type":"text","value":"Hello world"},{"id":"k","type":"text","value":"!"},{"type":"text","value":"?"}],"type":"paragraph"}],"version":"0.1"},${META}}`,
-    expectedId: 'sha256:2032746c797a75e9c34b8ea01cfc8caae33006830150cb8980b3bf983b118bb0',
+      `{"content":{"blocks":[{"children":[{"type":"text","value":"Hello world"},{"id":"b0","type":"text","value":"!"},{"type":"text","value":"?"}],"type":"paragraph"}],"version":"0.1"},${META}}`,
+    expectedId: 'sha256:ae20d2e4a55e2113d93e4c99bc5b6abf3654b0ae177211cc5845fcdfcce2d4c8',
   },
   {
     name: 'strip-derived-and-crdt',
@@ -177,5 +177,44 @@ export const vectors: KatVector[] = [
     expectedCanonicalJcs:
       `{"content":{"blocks":[{"children":[{"type":"text","value":"sha384"}],"type":"paragraph"}],"version":"0.1"},${META}}`,
     expectedId: 'sha384:8776ca4466e5194913ee9cb5999402f5403a532b530faefdd052adeb1695a8042341130f4a83af765e5bc7b55c260070',
+  },
+  {
+    name: 'alpha-rename-labels-a',
+    description: 'Alpha-renaming: author labels title/intro become b0/b1 and the link #title is rewritten to #b0 (§4.3.1 item 5).',
+    parts: {
+      manifest: '{}',
+      content:
+        '{"version":"0.1","blocks":[{"type":"heading","id":"title","level":1,"children":[{"type":"text","value":"Title"}]},{"type":"paragraph","id":"intro","children":[{"type":"text","value":"x","marks":[{"type":"link","href":"#title"}]}]}]}',
+      dublinCore: DC,
+    },
+    expectedCanonicalJcs:
+      `{"content":{"blocks":[{"children":[{"type":"text","value":"Title"}],"id":"b0","level":1,"type":"heading"},{"children":[{"marks":[{"href":"#b0","type":"link"}],"type":"text","value":"x"}],"id":"b1","type":"paragraph"}],"version":"0.1"},${META}}`,
+    expectedId: 'sha256:4c036a36cb087408573539bc639253056cebbd39e7bd5ca3d40207bc91791d0d',
+  },
+  {
+    name: 'alpha-rename-labels-b',
+    description: 'Same structure as -a with DIFFERENT author labels (sec/body, #sec) — MUST canonicalize identically (block-id purity).',
+    parts: {
+      manifest: '{}',
+      content:
+        '{"version":"0.1","blocks":[{"type":"heading","id":"sec","level":1,"children":[{"type":"text","value":"Title"}]},{"type":"paragraph","id":"body","children":[{"type":"text","value":"x","marks":[{"type":"link","href":"#sec"}]}]}]}',
+      dublinCore: DC,
+    },
+    expectedCanonicalJcs:
+      `{"content":{"blocks":[{"children":[{"type":"text","value":"Title"}],"id":"b0","level":1,"type":"heading"},{"children":[{"marks":[{"href":"#b0","type":"link"}],"type":"text","value":"x"}],"id":"b1","type":"paragraph"}],"version":"0.1"},${META}}`,
+    expectedId: 'sha256:4c036a36cb087408573539bc639253056cebbd39e7bd5ca3d40207bc91791d0d',
+  },
+  {
+    name: 'alpha-rename-academic-refs',
+    description: 'Academic uses[] and proof.of references are rewritten to canonical block-id names (#def→#b0, #thm→#b1).',
+    parts: {
+      manifest: '{}',
+      content:
+        '{"version":"0.1","blocks":[{"type":"academic:theorem","id":"def","variant":"definition","children":[]},{"type":"academic:theorem","id":"thm","variant":"theorem","uses":["#def"],"children":[]},{"type":"academic:proof","of":"#thm","children":[]}]}',
+      dublinCore: DC,
+    },
+    expectedCanonicalJcs:
+      `{"content":{"blocks":[{"children":[],"id":"b0","type":"academic:theorem","variant":"definition"},{"children":[],"id":"b1","type":"academic:theorem","uses":["#b0"],"variant":"theorem"},{"children":[],"of":"#b1","type":"academic:proof"}],"version":"0.1"},${META}}`,
+    expectedId: 'sha256:67c275865c3fdab3e46f85600ae82a6efad7171ce05d2953e3b59a4d53ffb349',
   },
 ];

--- a/scripts/lib/canonicalize.ts
+++ b/scripts/lib/canonicalize.ts
@@ -235,9 +235,15 @@ export function canonicalContent(parts: DocumentParts, options: CanonicalizeOpti
   const metadata = projectMetadata(dublinCore);
   const canonicalizedContent = canon(content, assetMap);
 
-  const result = { content: canonicalizedContent, metadata };
-  if (validate) validateStoredByteInvariants(result);
-  return result;
+  // Validate stored-byte invariants (NFC, well-formed Unicode, safe integers) on
+  // the transformed content *before* alpha-renaming, so the original id bytes are
+  // checked before §4.3.1's relabeling replaces them with canonical names.
+  const projected = { content: canonicalizedContent, metadata };
+  if (validate) validateStoredByteInvariants(projected);
+
+  // Canonicalize identifiers: relabel block/anchor ids to position-based names
+  // and rewrite the Content Anchor URI references to them (§4.3.1 item 5).
+  return { content: alphaRenameIds(canonicalizedContent), metadata };
 }
 
 /**
@@ -431,7 +437,17 @@ function normalizeMarks(marks: unknown[], assetMap: Map<string, string>): unknow
     return m;
   });
 
-  const keyed = resolved.map((m) => ({ mark: m, jcs: jcsOf(m) }));
+  return sortDedupMarks(resolved);
+}
+
+/**
+ * Sort marks by JCS serialization (UTF-16 code-unit order) and remove marks with
+ * identical serializations (§4.3.1 item 3). Shared by the marks pipeline and by
+ * the post-alpha-rename re-sort — relabeling an `anchor` mark id or a `link`
+ * href changes that mark's JCS sort key, so its array must be re-sorted.
+ */
+function sortDedupMarks(marks: unknown[]): unknown[] {
+  const keyed = marks.map((m) => ({ mark: m, jcs: jcsOf(m) }));
   keyed.sort((a, b) => (a.jcs < b.jcs ? -1 : a.jcs > b.jcs ? 1 : 0));
 
   const out: unknown[] = [];
@@ -482,6 +498,160 @@ function isMergeableTextNode(n: unknown): n is PlainTextNode {
 function marksEqual(a: PlainTextNode, b: PlainTextNode): boolean {
   // Absent marks ≡ []; both are already normalized when present.
   return jcsOf(a.marks ?? []) === jcsOf(b.marks ?? []);
+}
+
+// ---------------------------------------------------------------------------
+// Alpha-renaming of block/anchor ids (§4.3.1 item 5 "Canonicalize identifiers")
+// ---------------------------------------------------------------------------
+
+/**
+ * Relabel author-chosen identifiers to position-based canonical names so that two
+ * documents differing ONLY in their id *labels* canonicalize identically
+ * (block-id purity). Runs as the final transform, on the already strip/resolve/
+ * marks/merge-canonicalized content; a pure function of that structure.
+ *
+ * Namespace (relabeled): the `id` of every block — a typed object (`type` is a
+ * string) outside a `marks` array — and of every `anchor` mark. This is the
+ * shared block/anchor-id namespace of Anchors & References §4. Requiring a `type`
+ * naturally excludes the deferred non-block ids (`subfigure`, `equationLine`,
+ * `signer` carry no `type`).
+ *
+ * References rewritten: Content Anchor URIs (`#id[/offset]`) in an enumerated set
+ * of reference fields. Identifiers in other namespaces — footnote / glossary /
+ * citation / entity / index / legal marks, equation- and algorithm-line ids,
+ * subfigure ids — are NOT relabeled, and a `#`-reference resolving to none of the
+ * relabeled ids (e.g. a reference to an equation line, or a cross-document anchor)
+ * is left verbatim. A duplicate id within the namespace is rejected.
+ */
+function alphaRenameIds(content: unknown): unknown {
+  const map = new Map<string, string>();
+  let counter = 0;
+
+  // Pass 1 — assign canonical names by a value-independent traversal (arrays in
+  // index order; object keys in sorted order; a node's own id before its
+  // descendants), so alpha-equivalent inputs build identical maps regardless of
+  // the original labels. Reject a duplicate id (Anchors & References §4 requires
+  // uniqueness across the shared namespace).
+  const collect = (value: unknown, inMarks: boolean): void => {
+    if (Array.isArray(value)) {
+      for (const el of value) collect(el, inMarks);
+      return;
+    }
+    if (!isPlainObject(value)) return;
+    const id = definedId(value, inMarks);
+    if (id !== undefined) {
+      if (map.has(id)) {
+        throw new CanonicalizationError(`duplicate id "${id}" in the block/anchor-id namespace`);
+      }
+      map.set(id, `b${counter++}`);
+    }
+    for (const key of Object.keys(value).sort()) {
+      collect(value[key], key === 'marks');
+    }
+  };
+  collect(content, false);
+
+  if (map.size === 0) return content; // no ids to canonicalize
+
+  return rewriteIds(content, map, false);
+}
+
+/** The in-namespace id this node defines (block id or anchor-mark id), if any. */
+function definedId(obj: Record<string, unknown>, inMarks: boolean): string | undefined {
+  if (inMarks) {
+    return obj.type === 'anchor' && typeof obj.id === 'string' ? obj.id : undefined;
+  }
+  return typeof obj.type === 'string' && typeof obj.id === 'string' ? obj.id : undefined;
+}
+
+/** Academic inline reference marks whose `target` is a Content Anchor URI. */
+function isAnchorRefMark(type: unknown): boolean {
+  return type === 'theorem-ref' || type === 'equation-ref' || type === 'algorithm-ref';
+}
+
+/**
+ * Rewrite id-defining fields and the enumerated Content Anchor URI references
+ * using the relabel map. References handled: `link` mark `href`; academic
+ * `theorem-ref`/`equation-ref`/`algorithm-ref` mark `target`; `academic:theorem`
+ * `uses[]`; `academic:proof` `of`; `semantic:ref` and `presentation:reference`
+ * block `target`.
+ */
+function rewriteIds(value: unknown, map: Map<string, string>, inMarks: boolean): unknown {
+  if (Array.isArray(value)) {
+    return value.map((v) => rewriteIds(v, map, inMarks));
+  }
+  if (!isPlainObject(value)) return value;
+
+  const obj: Record<string, unknown> = { ...value };
+  const type = obj.type;
+
+  // Recurse first; a `marks` array is re-sorted+deduped after its members are
+  // rewritten, since relabeling an anchor id or link href changes a mark's JCS
+  // sort key (§4.3.1 item 3). Mark order/multiplicity is non-semantic, so the
+  // re-sort is always safe.
+  for (const key of Object.keys(obj)) {
+    if (key === 'marks' && Array.isArray(obj[key])) {
+      obj[key] = sortDedupMarks((obj[key] as unknown[]).map((m) => rewriteIds(m, map, true)));
+    } else {
+      obj[key] = rewriteIds(obj[key], map, false);
+    }
+  }
+
+  // Rewrite this node's own id and any reference fields it carries.
+  if (inMarks) {
+    if (obj.type === 'anchor' && typeof obj.id === 'string') {
+      obj.id = renameId(obj.id, map);
+    } else if (obj.type === 'link' && typeof obj.href === 'string') {
+      obj.href = rewriteContentAnchor(obj.href, map);
+    } else if (isAnchorRefMark(obj.type) && typeof obj.target === 'string') {
+      obj.target = rewriteContentAnchor(obj.target, map);
+    }
+  } else {
+    if (typeof type === 'string' && typeof obj.id === 'string') {
+      obj.id = renameId(obj.id, map);
+    }
+    if (type === 'academic:proof' && typeof obj.of === 'string') {
+      obj.of = rewriteContentAnchor(obj.of, map);
+    } else if (type === 'academic:theorem' && Array.isArray(obj.uses)) {
+      obj.uses = (obj.uses as unknown[]).map((u) => (typeof u === 'string' ? rewriteContentAnchor(u, map) : u));
+    } else if ((type === 'semantic:ref' || type === 'presentation:reference') && typeof obj.target === 'string') {
+      obj.target = rewriteContentAnchor(obj.target, map);
+    }
+  }
+  return obj;
+}
+
+/** Map a defined id to its canonical name (a def is always present in the map). */
+function renameId(id: string, map: Map<string, string>): string {
+  return map.get(id) ?? id;
+}
+
+/** Shape of a generated canonical id name: `b` followed by decimal digits. */
+const CANONICAL_NAME = /^b\d+$/;
+
+/**
+ * Rewrite the id component of a Content Anchor URI (`#id[/offset[-end]]`, Anchors
+ * & References §2.1) via the relabel map, preserving any `/offset` suffix. A
+ * non-`#` value (e.g. an external URL) or a `#`-reference whose id is not in the
+ * relabeled namespace (e.g. an equation-line id or a cross-document anchor) is
+ * returned verbatim — EXCEPT that an unresolved reference must not itself spell a
+ * generated canonical name (`#b0`, `#b1`, …): left verbatim it would be
+ * byte-identical to a reference that genuinely resolved to that block, collapsing
+ * two distinct documents onto one id. Such a reference is rejected instead.
+ */
+function rewriteContentAnchor(value: string, map: Map<string, string>): string {
+  if (!value.startsWith('#')) return value;
+  const slash = value.indexOf('/');
+  const id = slash === -1 ? value.slice(1) : value.slice(1, slash);
+  const suffix = slash === -1 ? '' : value.slice(slash);
+  const mapped = map.get(id);
+  if (mapped !== undefined) return `#${mapped}${suffix}`;
+  if (CANONICAL_NAME.test(id)) {
+    throw new CanonicalizationError(
+      `reference "${value}" uses the reserved canonical-name form: a "#b<number>" reference must resolve to a block or anchor id`,
+    );
+  }
+  return value;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/test-canonicalize.ts
+++ b/scripts/test-canonicalize.ts
@@ -221,7 +221,7 @@ test('strip: crdt removed from a block', () => {
     content: { version: '0.1', blocks: [{ type: 'paragraph', id: 'p1', crdt: { seq: 42 }, children: [{ type: 'text', value: 'hi' }] }] },
   }).blocks;
   assert.equal('crdt' in blocks[0], false);
-  assert.equal(blocks[0].id, 'p1');
+  assert.equal(blocks[0].id, 'b0'); // id survives crdt stripping, then is alpha-renamed (§4.3.1 item 5)
 });
 
 test('strip: crdt removed from a text node (then it becomes mergeable)', () => {
@@ -471,7 +471,7 @@ test('merge: adjacent text nodes with equal mark-sets merge; differing marks do 
   ]);
 });
 
-test('merge: a text node carrying an id is a boundary (not merged, id preserved)', () => {
+test('merge: a text node carrying an id is a boundary (not merged; id alpha-renamed)', () => {
   const children = canonContent({
     content: {
       version: '0.1',
@@ -487,7 +487,7 @@ test('merge: a text node carrying an id is a boundary (not merged, id preserved)
     },
   }).blocks[0].children;
   assert.deepEqual(children, [
-    { type: 'text', value: 'a', id: 'anchor1' },
+    { type: 'text', value: 'a', id: 'b0' },
     { type: 'text', value: 'b' },
   ]);
 });
@@ -779,6 +779,281 @@ test('asset: an aliasOf entry carrying its own path+hash still resolves', () => 
     content: { version: '0.1', blocks: [{ type: 'image', src: 'assets/images/logo-copy.png', alt: 'x' }] },
   }).blocks;
   assert.equal(blocks[0].src, HASH256('a'));
+});
+
+// ---------------------------------------------------------------------------
+// Alpha-renaming of block/anchor ids (§4.3.1 item 5)
+// ---------------------------------------------------------------------------
+
+test('relabel: block ids are assigned b0,b1,… in document order', () => {
+  const blocks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'heading', id: 'title', level: 1, children: [{ type: 'text', value: 'T' }] },
+        { type: 'paragraph', id: 'intro', children: [{ type: 'text', value: 'p' }] },
+        { type: 'horizontalRule', id: 'rule' },
+      ],
+    },
+  }).blocks;
+  assert.deepEqual([blocks[0].id, blocks[1].id, blocks[2].id], ['b0', 'b1', 'b2']);
+});
+
+test('relabel: a nested block id follows its parent in document order', () => {
+  const blocks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'blockquote', id: 'outer', children: [{ type: 'paragraph', id: 'inner', children: [{ type: 'text', value: 'x' }] }] },
+        { type: 'paragraph', id: 'after', children: [{ type: 'text', value: 'y' }] },
+      ],
+    },
+  }).blocks;
+  assert.equal(blocks[0].id, 'b0'); // outer
+  assert.equal(blocks[0].children[0].id, 'b1'); // inner (after its parent)
+  assert.equal(blocks[1].id, 'b2'); // after
+});
+
+test('relabel: a link href #blockId is rewritten to the canonical name', () => {
+  const blocks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'heading', id: 'sec', level: 1, children: [{ type: 'text', value: 'S' }] },
+        { type: 'paragraph', children: [{ type: 'text', value: 'see', marks: [{ type: 'link', href: '#sec' }] }] },
+      ],
+    },
+  }).blocks;
+  assert.equal(blocks[1].children[0].marks[0].href, '#b0');
+});
+
+test('relabel: a #ref preserves its /offset suffix; an unresolved #ref is left verbatim', () => {
+  const children = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        {
+          type: 'paragraph',
+          id: 'sec',
+          children: [
+            { type: 'text', value: 'a', marks: [{ type: 'link', href: '#sec/10-25' }] },
+            { type: 'text', value: 'b', marks: [{ type: 'link', href: '#ghost' }] },
+          ],
+        },
+      ],
+    },
+  }).blocks[0].children;
+  assert.equal(children[0].marks[0].href, '#b0/10-25'); // id rewritten, offset preserved
+  assert.equal(children[1].marks[0].href, '#ghost'); // unresolved → verbatim (no error)
+});
+
+test('relabel: an anchor mark id is relabeled and a #ref to it is rewritten consistently', () => {
+  const blocks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'paragraph', children: [{ type: 'text', value: 'point', marks: [{ type: 'anchor', id: 'pt' }] }] },
+        { type: 'paragraph', children: [{ type: 'text', value: 'ref', marks: [{ type: 'link', href: '#pt' }] }] },
+      ],
+    },
+  }).blocks;
+  assert.equal(blocks[0].children[0].marks[0].id, 'b0'); // anchor mark id (the only def) → b0
+  assert.equal(blocks[1].children[0].marks[0].href, '#b0'); // link to it rewritten
+});
+
+test('relabel: a marks array is re-sorted after rewriting (so output stays JCS-ordered)', () => {
+  // m is defined before k → m=b0, k=b1. The node lists links href-sorted as
+  // [#k, #m] (#k<#m); after rewrite to [#b1, #b0] they MUST be re-sorted to [#b0,#b1].
+  const marks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'heading', id: 'm', level: 1, children: [{ type: 'text', value: 'M' }] },
+        { type: 'heading', id: 'k', level: 1, children: [{ type: 'text', value: 'K' }] },
+        { type: 'paragraph', children: [{ type: 'text', value: 'x', marks: [{ type: 'link', href: '#k' }, { type: 'link', href: '#m' }] }] },
+      ],
+    },
+  }).blocks[2].children[0].marks;
+  assert.deepEqual(marks, [{ type: 'link', href: '#b0' }, { type: 'link', href: '#b1' }]);
+});
+
+test('relabel: academic uses/of/target rewrite to block ids; an equation-line target stays verbatim', () => {
+  const blocks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'academic:theorem', id: 'def1', variant: 'definition', children: [] },
+        { type: 'academic:theorem', id: 'thm1', variant: 'theorem', uses: ['#def1'], children: [] },
+        { type: 'academic:proof', of: '#thm1', children: [] },
+        { type: 'academic:equation-group', id: 'eqg', lines: [{ value: 'a=b', id: 'eq-1' }] },
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'a', marks: [{ type: 'theorem-ref', target: '#thm1' }] },
+            { type: 'text', value: 'b', marks: [{ type: 'equation-ref', target: '#eq-1' }] },
+            { type: 'text', value: 'c', marks: [{ type: 'algorithm-ref', target: '#def1', line: 'loop' }] },
+          ],
+        },
+      ],
+    },
+  }).blocks;
+  assert.equal(blocks[1].uses[0], '#b0'); // theorem.uses → def1
+  assert.equal(blocks[2].of, '#b1'); // proof.of → thm1
+  const refs = blocks[4].children;
+  assert.equal(refs[0].marks[0].target, '#b1'); // theorem-ref → thm1
+  assert.equal(refs[1].marks[0].target, '#eq-1'); // equation-ref → equation-LINE id: deferred, verbatim
+  assert.equal(refs[2].marks[0].target, '#b0'); // algorithm-ref target → def1
+  assert.equal(refs[2].marks[0].line, 'loop'); // algorithm-ref.line: separate namespace, verbatim
+  assert.equal(blocks[3].lines[0].id, 'eq-1'); // equation-line id (no type field) → deferred, verbatim
+});
+
+test('relabel: semantic:ref and presentation:reference block targets are rewritten', () => {
+  const blocks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'heading', id: 'h', level: 1, children: [{ type: 'text', value: 'H' }] },
+        { type: 'semantic:ref', target: '#h', children: [] },
+        { type: 'presentation:reference', target: '#h', format: 'Fig #' },
+      ],
+    },
+  }).blocks;
+  assert.equal(blocks[1].target, '#b0');
+  assert.equal(blocks[2].target, '#b0');
+});
+
+test('relabel: footnote BLOCK id is relabeled but the footnote MARK id is left verbatim (no false dup)', () => {
+  const blocks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'paragraph', children: [{ type: 'text', value: 'x', marks: [{ type: 'footnote', number: 1, id: 'fn1' }] }] },
+        { type: 'semantic:footnote', number: 1, id: 'fn1', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'note' }] }] },
+      ],
+    },
+  }).blocks;
+  assert.equal(blocks[0].children[0].marks[0].id, 'fn1'); // footnote MARK: separate namespace → verbatim
+  assert.equal(blocks[1].id, 'b0'); // footnote BLOCK: a block id → relabeled
+});
+
+test('relabel: separate-namespace mark fields are verbatim even when equal to a block id', () => {
+  const children = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        {
+          type: 'paragraph',
+          id: 'p',
+          children: [
+            { type: 'text', value: 'a', marks: [{ type: 'glossary', ref: 'p' }] },
+            { type: 'text', value: 'b', marks: [{ type: 'citation', refs: ['p'] }] },
+          ],
+        },
+      ],
+    },
+  }).blocks[0].children;
+  // 'p' is a block id (→ b0), but glossary.ref / citation.refs are NOT anchor refs,
+  // so they keep the literal 'p' even though it coincides with a block id.
+  assert.equal(children[0].marks[0].ref, 'p');
+  assert.equal(children[1].marks[0].refs[0], 'p');
+});
+
+test('relabel: deferred ids lacking a type field (subfigure, equation-line) are left verbatim', () => {
+  const blocks = canonContent({
+    content: {
+      version: '0.1',
+      blocks: [
+        { type: 'figure', id: 'fig', subfigures: [{ id: 'sub-a', label: 'a', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'x' }] }] }] },
+        { type: 'academic:equation-group', id: 'eqg', lines: [{ value: 'a', id: 'line-1' }] },
+      ],
+    },
+  }).blocks;
+  assert.equal(blocks[0].id, 'b0'); // figure block id → relabeled
+  assert.equal(blocks[0].subfigures[0].id, 'sub-a'); // subfigure (no type) → verbatim
+  assert.equal(blocks[1].id, 'b1'); // equation-group block id → relabeled
+  assert.equal(blocks[1].lines[0].id, 'line-1'); // equation-line (no type) → verbatim
+});
+
+test('relabel: a duplicate id in the block/anchor namespace is rejected', () => {
+  assert.throws(
+    () =>
+      canonContent({
+        content: { version: '0.1', blocks: [
+          { type: 'paragraph', id: 'dup', children: [] },
+          { type: 'paragraph', id: 'dup', children: [] },
+        ] },
+      }),
+    CanonicalizationError,
+  );
+});
+
+test('purity: two documents differing only in id labels get the same document id', () => {
+  const mk = (a: string, b: string) =>
+    makeParts({
+      content: {
+        version: '0.1',
+        blocks: [
+          { type: 'heading', id: a, level: 1, children: [{ type: 'text', value: 'Title' }] },
+          { type: 'paragraph', id: b, children: [{ type: 'text', value: 'above', marks: [{ type: 'link', href: `#${a}` }] }] },
+        ],
+      },
+    });
+  assert.equal(computeDocumentId(mk('intro', 'body'), 'sha256'), computeDocumentId(mk('alpha', 'beta'), 'sha256'));
+});
+
+test('purity: relabeling does NOT collapse documents that differ in reference structure', () => {
+  const mk = (target: string) =>
+    makeParts({
+      content: {
+        version: '0.1',
+        blocks: [
+          { type: 'heading', id: 'h1', level: 1, children: [{ type: 'text', value: 'A' }] },
+          { type: 'heading', id: 'h2', level: 1, children: [{ type: 'text', value: 'B' }] },
+          { type: 'paragraph', children: [{ type: 'text', value: 'x', marks: [{ type: 'link', href: `#${target}` }] }] },
+        ],
+      },
+    });
+  assert.notEqual(computeDocumentId(mk('h1'), 'sha256'), computeDocumentId(mk('h2'), 'sha256'));
+});
+
+test('purity: an unresolved #bN reference is rejected (cannot alias a generated canonical name)', () => {
+  // Without this guard a dangling "#b0" would canonicalize byte-identically to a
+  // link that genuinely resolved to the relabeled block — a second-preimage collision.
+  assert.throws(
+    () =>
+      canonContent({
+        content: {
+          version: '0.1',
+          blocks: [{ type: 'paragraph', id: 'real', children: [{ type: 'text', value: 'x', marks: [{ type: 'link', href: '#b0' }] }] }],
+        },
+      }),
+    CanonicalizationError,
+  );
+  // A dangling ref not of the generated shape (`#b` with no digits) is still verbatim.
+  const href = canonContent({
+    content: { version: '0.1', blocks: [{ type: 'paragraph', id: 'p', children: [{ type: 'text', value: 'x', marks: [{ type: 'link', href: '#b' }] }] }] },
+  }).blocks[0].children[0].marks[0].href;
+  assert.equal(href, '#b');
+});
+
+test('purity: alpha-equivalence holds across a text-node id boundary and merge', () => {
+  const mk = (id: string) =>
+    makeParts({
+      content: {
+        version: '0.1',
+        blocks: [
+          {
+            type: 'paragraph',
+            children: [
+              { type: 'text', value: 'Hello ' },
+              { type: 'text', value: 'world', id }, // id makes this a merge boundary; relabeled
+              { type: 'text', value: '!' },
+            ],
+          },
+        ],
+      },
+    });
+  assert.equal(computeDocumentId(mk('w'), 'sha256'), computeDocumentId(mk('other'), 'sha256'));
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/spec/core/06-document-hashing.md
+++ b/spec/core/06-document-hashing.md
@@ -17,7 +17,7 @@ CDX documents use content-addressable hashing as a core identity mechanism. The 
 
 ### 2.1 Content-Addressable Identity
 
-The hash of a document's **canonical** content IS its identity. The document ID is computed over a canonical *transform* of the stored content (section 4) — normalized, with content-referenced asset paths resolved to content hashes — so it is distinct from the file-level `content.hash` (section 5.1), which pins the exact stored bytes. This means:
+The hash of a document's **canonical** content IS its identity. The document ID is computed over a canonical *transform* of the stored content (section 4) — normalized, with content-referenced asset paths resolved to content hashes and author-chosen block and anchor identifiers relabeled to canonical names — so it is distinct from the file-level `content.hash` (section 5.1), which pins the exact stored bytes. This means:
 
 - Identical canonical content produces identical IDs
 - Any change to canonical content produces a different ID
@@ -115,6 +115,7 @@ The following table summarizes what is included in and excluded from the documen
 | Dublin Core metadata | Partial | Only the projection: `title`, `creator`, `subject`, `description`, `language` (structured `creators` excluded) |
 | Content-referenced asset content | Yes (by hash) | Each content asset reference (e.g. an image `src`) is resolved to the asset's content hash, binding the asset's bytes — not its filename — to identity |
 | Asset filenames / paths | No | Resolved away to content hashes; renaming a referenced asset's file does not change the ID |
+| Block & anchor id labels | Canonicalized | Relabeled to position-based names (`b0`, `b1`, …); the author's chosen label does not change the ID, and references to it are rewritten to match (section 4.3.1) |
 | Fonts & non-content-referenced assets | No | Packaged assets referenced only by the presentation layer (e.g. fonts by family name) are not part of semantic identity |
 | Derived content fields | No | `measurement.display` (free-form) and `codeBlock.tokens` (regenerable) — presentational, no canonical form; stripped before hashing |
 | Presentation | No | Visual rendering instructions — not part of semantic identity |
@@ -163,7 +164,10 @@ The canonical content is a *transform* of the stored parts; the stored files are
 2. **Resolve asset references**: replace every content-level asset *path* reference — an `image.src`, `svg.src`, or `signature.image`, or an archive-relative `href` on a `link` mark — with the referenced asset's content hash (`algorithm:hexdigest`). A reference resolves iff, after path normalization (no `.` or `..` segments; case-sensitive), it equals an asset's archive path — that asset's category directory (`assets/` followed by its category, i.e. the key under `manifest.assets` that registers it: the standard `images`, `fonts`, or `embeds`, or any additional category) joined with the asset's index `path` (Asset Embedding, section 3). The following are not asset paths and are left verbatim: an `href` beginning with `#` (an internal Content Anchor reference), a reference marked `external`, and any reference carrying a URL scheme (e.g. `https://`); an `svg` with inline `content` and no `src` has nothing to resolve. A reference beginning with `assets/` that matches no registered asset is a canonicalization error. The document ID thereby inherits the integrity of the asset index `hash` values, which MUST be verified against the asset bytes (Asset Embedding, section 8) before the ID can be trusted.
 3. **Normalize marks**: within each text node, sort the `marks` array by each mark's JCS serialization (UTF-16 code-unit comparison — so bare formatting marks such as `"bold"` sort before structured marks such as `{"type":"link",…}`), remove marks with identical JCS serialization (deduplicate), and omit the `marks` key entirely when the array is empty (absent ≡ `[]`). Mark order is not semantic.
 4. **Merge text nodes**: merge adjacent sibling text nodes that have no intervening non-text inline child and identical canonical mark-sets, concatenating their `value`s. Only a text node whose sole keys are `type`, `value`, and `marks` (after the step 1 stripping) is merge-eligible; a text node that also carries an `id`, `attributes`, or any other field is preserved unchanged and acts as a boundary, so no identifier or annotation is dropped. Offsets are defined over the concatenated text content (Anchors and References, section 3), so this moves no anchor.
-5. **Preserve everything else as authored**: no other field is added, removed, defaulted, or coalesced. In particular `null` and absent are distinct, and JSON-Schema `default`s (such as `colspan`) are never materialized into hashed content.
+5. **Canonicalize identifiers**: relabel author-chosen identifiers to position-based canonical names, so that two documents differing only in their id *labels* produce the same document ID. The relabeled namespace is the shared block-and-anchor-id namespace (Anchors and References, section 4): the `id` of every block (including `namespace:type` extension blocks) and the `id` of every `anchor` mark. Walk the canonical content depth-first — at each node assigning a name to the node's own block or anchor `id` (if any) before recursing into its members (object members in JCS key order, array elements in index order) — and give each id-defining occurrence the next name in the sequence `b0`, `b1`, `b2`, …; a duplicate id within this namespace is a canonicalization error. Then rewrite every Content Anchor URI reference (`#id`, optionally followed by `/offset` or `/start-end`) whose id is one of these names — preserving the suffix — in the following reference fields: a `link` mark `href`; the `theorem-ref`, `equation-ref`, and `algorithm-ref` mark `target`; the `academic:theorem` `uses`; the `academic:proof` `of`; and the `semantic:ref` and `presentation:reference` block `target`. A Content Anchor URI whose id is not a relabeled block or anchor id — for example a reference to an equation line, or a cross-document anchor — is left unchanged, except that such an unresolved reference MUST NOT itself spell a canonical name (`b` followed by digits): an unresolved `#b0` is a canonicalization error, because left unchanged it would be indistinguishable from a reference that resolved to that block, collapsing two distinct documents onto one ID. Because relabeling an `anchor` id or a `link` `href` changes that mark's serialization, the marks of any affected text node are re-sorted and de-duplicated (item 3) after rewriting.
+
+   The following are left as authored, so a document that differs only in one of these labels is not yet guaranteed to share a document ID: the reference fields that address other namespaces — the `footnote` mark `id`, the `glossary` mark `ref`, `semantic:term` `see`, `citation` `refs`, `entity` `uri`, `index` `term`, `legal:cite` citations, and the `algorithm-ref` `line`; and the identifiers that are not block or anchor ids — equation-line ids, algorithm-line labels, and subfigure ids (none of which carry a block `type`). An extension block such as `semantic:footnote` or `semantic:term` still has its own block `id` relabeled like any other block id; only the references into those namespaces are left unchanged. (A single text node is expected to carry at most one `anchor` mark; canonical names for multiple anchors on one node depend on their canonical mark order.)
+6. **Preserve everything else as authored**: no other field is added, removed, defaulted, or coalesced. In particular `null` and absent are distinct, and JSON-Schema `default`s (such as `colspan`) are never materialized into hashed content.
 
 #### 4.3.2 Serialization
 
@@ -183,7 +187,7 @@ The canonical content is a *transform* of the stored parts; the stored files are
 
 ```
 1. Project the Dublin Core metadata (section 4.3.1)
-2. Construct the canonical content tree: strip derived fields, resolve asset references to content hashes, normalize marks, merge text nodes (section 4.3.1)
+2. Construct the canonical content tree: strip derived fields, resolve asset references to content hashes, normalize marks, merge text nodes, canonicalize identifiers (section 4.3.1)
 3. Build the two-slot canonical structure { content, metadata } (section 4.2)
 4. Serialize using JCS (section 4.3.2)
 5. Hash the serialized bytes with the algorithm named by the document id prefix
@@ -475,7 +479,7 @@ function verifyDocument(archive) {
     throw new Error(`hashAlgorithm does not match id prefix`)
   }
 
-  // strip derived fields + crdt, resolve asset refs -> content hash, normalize + merge marks (4.3.1)
+  // strip derived fields + crdt, resolve asset refs -> content hash, normalize + merge marks, relabel ids (4.3.1)
   const content = canonicalizeContent(parseJSON(archive.read(manifest.content.path)),
                                       archive, manifest)
   // keep + flatten the five terms, always-array, omit empty (4.3.1)


### PR DESCRIPTION
## Summary
- Adds a final step to the document-ID canonical form (`06 §4.3.1` step 5) that relabels author-chosen block and `anchor`-mark identifiers to position-based names (`b0, b1, …`) and rewrites the Content Anchor URI references to them, so two documents differing only in their id labels produce the same document ID. Closes the block-id half of the last canonicalization purity gap (`B2-M3-CORR-13`).
- Scope is the shared block/anchor-id namespace only; identifiers in other namespaces (footnote, glossary, citation, entity, index, legal-cite, equation-/algorithm-line, subfigure) are left verbatim as documented residuals.
- A dangling reference that spells a generated canonical name (`#bN`) is rejected, preventing a second-preimage collision on the document ID.
- Stored files keep the original labels, so internal links and the file-level `content.hash` are unaffected (the document ID is a transform distinct from `content.hash`).

## Changes
- `spec/core/06-document-hashing.md`: new §4.3.1 step 5 "Canonicalize identifiers"; §2.1, §4.1a, §4.4, §11.3 updated
- `scripts/lib/canonicalize.ts`: `alphaRenameIds` pass — value-independent traversal, namespace-scoped duplicate-id rejection, marks re-sort after rewrite, stored-byte validation before relabel, and the `#bN` collision guard
- `scripts/test-canonicalize.ts`: alpha-rename unit tests (74 total)
- `scripts/kat/document-id-vectors.ts`: alpha-equivalence KAT pair (different labels → identical id) + academic-refs vector; `merge-and-id-boundary` updated
- `scripts/check-document-id.ts`: block-id-purity cross-check
- `examples/*`: re-froze all 10 document ids + signed-document `documentId`

## Test plan
- [x] `npm test` (schemas + examples)
- [x] `npm run test:canonicalize` (74 passed)
- [x] `npm run check:document-id` (14 KAT vectors + 10 corpus ids verified)
- [x] `check:sync` / `check:refs` / `check:coverage` / `check:hash-centralization`
- [x] `npx tsc --noEmit`
- [x] `npm audit --audit-level=high`