### PR TITLE
Phase 3: signature trust model (manifest authentication + X.509 trust core)

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -74,3 +74,6 @@ jobs:
 
       - name: Check manifest projection
         run: npm run check:manifest-projection
+
+      - name: Check JWS envelope
+        run: npm run check:jws-envelope

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -71,3 +71,6 @@ jobs:
 
       - name: Check document ids
         run: npm run check:document-id
+
+      - name: Check manifest projection
+        run: npm run check:manifest-projection

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -77,3 +77,6 @@ jobs:
 
       - name: Check JWS envelope
         run: npm run check:jws-envelope
+
+      - name: Check trust state
+        run: npm run check:trust-state

--- a/examples/signed-document/security/signatures.json
+++ b/examples/signed-document/security/signatures.json
@@ -4,14 +4,8 @@
   "signatures": [
     {
       "id": "sig-provider",
-      "algorithm": "ES256",
-      "signedAt": "2025-01-15T10:00:00Z",
-      "signer": {
-        "name": "Jane Smith",
-        "email": "jane.smith@acme.com",
-        "organization": "Acme Corporation",
-        "title": "Chief Executive Officer"
-      },
+      "protected": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sInNpZ1QiOiIyMDI1LTAxLTE1VDEwOjAwOjAwWiIsIng1YyI6WyJNSUlCaXhVTlZFUklGSUVEcGxhY2Vob2xkZXJERVJjZXJ0aWZpY2F0ZUJBU0U2NEZPUklMTFVTVFJBVElPTnh3PT0iXSwieDV0I1MyNTYiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBIn0",
+      "signature": "UExBQ0VIT0xERVJfbm9uX3ZlcmlmeWluZ19wcm92aWRlcl9zaWduYXR1cmU",
       "scope": {
         "documentId": "sha256:66db6e3c227d306b57068a4fa5e779e3a4b2ab74c9cb6320ecd57ddf280c2b86",
         "manifest": {
@@ -27,7 +21,12 @@
           "lineage": { "parent": null, "version": 1 }
         }
       },
-      "value": "MEUCIQDf9Ky7BpL5Rj9E8JH3YqKPvXxNmVhKD5bXc4Qz1A2wAiEA7HjKLm8NoPqRsTuVwXyZ012ABcdEFghIJklMNopQRst",
+      "signer": {
+        "name": "Jane Smith",
+        "email": "jane.smith@acme.com",
+        "organization": "Acme Corporation",
+        "title": "Chief Executive Officer"
+      },
       "timestamp": {
         "authority": "https://timestamp.digicert.com",
         "time": "2025-01-15T10:00:05Z",
@@ -36,14 +35,8 @@
     },
     {
       "id": "sig-client",
-      "algorithm": "ES256",
-      "signedAt": "2025-01-15T14:22:00Z",
-      "signer": {
-        "name": "John Doe",
-        "email": "john.doe@xyz-enterprises.com",
-        "organization": "XYZ Enterprises",
-        "title": "President"
-      },
+      "protected": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sInNpZ1QiOiIyMDI1LTAxLTE1VDE0OjIyOjAwWiIsIng1YyI6WyJNSUlCaXhVTlZFUklGSUVEcGxhY2Vob2xkZXJERVJjZXJ0aWZpY2F0ZUJBU0U2NEZPUklMTFVTVFJBVElPTnh3PT0iXSwieDV0I1MyNTYiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBIn0",
+      "signature": "UExBQ0VIT0xERVJfbm9uX3ZlcmlmeWluZ19jbGllbnRfc2lnbmF0dXJl",
       "scope": {
         "documentId": "sha256:66db6e3c227d306b57068a4fa5e779e3a4b2ab74c9cb6320ecd57ddf280c2b86",
         "manifest": {
@@ -59,7 +52,12 @@
           "lineage": { "parent": null, "version": 1 }
         }
       },
-      "value": "MEQCIH5abcDEFghijKLmnoPQRstuvWXyz012345ABCdefGHIJKLMAIgMNop456qrSTUvwxYZ789abcdefghijklmnopqrstuvwx",
+      "signer": {
+        "name": "John Doe",
+        "email": "john.doe@xyz-enterprises.com",
+        "organization": "XYZ Enterprises",
+        "title": "President"
+      },
       "timestamp": {
         "authority": "https://timestamp.digicert.com",
         "time": "2025-01-15T14:22:05Z",

--- a/examples/signed-document/security/signatures.json
+++ b/examples/signed-document/security/signatures.json
@@ -12,6 +12,21 @@
         "organization": "Acme Corporation",
         "title": "Chief Executive Officer"
       },
+      "scope": {
+        "documentId": "sha256:66db6e3c227d306b57068a4fa5e779e3a4b2ab74c9cb6320ecd57ddf280c2b86",
+        "manifest": {
+          "cdx": "0.1",
+          "state": "frozen",
+          "content": {
+            "path": "content/document.json",
+            "hash": "sha256:dac719a7afeb6b8bfb05fa673154f3a840ba8554348a2c085859889abe240bb7"
+          },
+          "extensions": [
+            { "id": "cdx.security", "version": "0.1", "required": true }
+          ],
+          "lineage": { "parent": null, "version": 1 }
+        }
+      },
       "value": "MEUCIQDf9Ky7BpL5Rj9E8JH3YqKPvXxNmVhKD5bXc4Qz1A2wAiEA7HjKLm8NoPqRsTuVwXyZ012ABcdEFghIJklMNopQRst",
       "timestamp": {
         "authority": "https://timestamp.digicert.com",
@@ -28,6 +43,21 @@
         "email": "john.doe@xyz-enterprises.com",
         "organization": "XYZ Enterprises",
         "title": "President"
+      },
+      "scope": {
+        "documentId": "sha256:66db6e3c227d306b57068a4fa5e779e3a4b2ab74c9cb6320ecd57ddf280c2b86",
+        "manifest": {
+          "cdx": "0.1",
+          "state": "frozen",
+          "content": {
+            "path": "content/document.json",
+            "hash": "sha256:dac719a7afeb6b8bfb05fa673154f3a840ba8554348a2c085859889abe240bb7"
+          },
+          "extensions": [
+            { "id": "cdx.security", "version": "0.1", "required": true }
+          ],
+          "lineage": { "parent": null, "version": 1 }
+        }
       },
       "value": "MEQCIH5abcDEFghijKLmnoPQRstuvWXyz012345ABCdefGHIJKLMAIgMNop456qrSTUvwxYZ789abcdefghijklmnopqrstuvwx",
       "timestamp": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check:coverage": "npx tsx scripts/check-example-coverage.ts",
     "check:hash-centralization": "npx tsx scripts/check-hash-centralization.ts",
     "check:document-id": "npx tsx scripts/check-document-id.ts",
+    "check:manifest-projection": "npx tsx scripts/check-manifest-projection.ts",
     "generate:template": "npx tsx scripts/generate-template.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:hash-centralization": "npx tsx scripts/check-hash-centralization.ts",
     "check:document-id": "npx tsx scripts/check-document-id.ts",
     "check:manifest-projection": "npx tsx scripts/check-manifest-projection.ts",
+    "check:jws-envelope": "npx tsx scripts/check-jws-envelope.ts",
     "generate:template": "npx tsx scripts/generate-template.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check:document-id": "npx tsx scripts/check-document-id.ts",
     "check:manifest-projection": "npx tsx scripts/check-manifest-projection.ts",
     "check:jws-envelope": "npx tsx scripts/check-jws-envelope.ts",
+    "check:trust-state": "npx tsx scripts/check-trust-state.ts",
     "generate:template": "npx tsx scripts/generate-template.ts"
   },
   "devDependencies": {

--- a/schemas/security.schema.json
+++ b/schemas/security.schema.json
@@ -118,14 +118,83 @@
       },
       "additionalProperties": false
     },
+    "manifestProjection": {
+      "type": "object",
+      "description": "Canonical projection of the security-relevant manifest declarations a scoped signature attests (see section 9.7). Constructed from manifest.json by the normative projector and serialized with JCS. The document ID is carried by scope.documentId and is not repeated here.",
+      "required": ["cdx", "state", "content"],
+      "properties": {
+        "cdx": {
+          "type": "string",
+          "description": "Specification version, mirrored from the manifest",
+          "pattern": "^\\d+\\.\\d+$"
+        },
+        "state": {
+          "type": "string",
+          "description": "Document lifecycle state, mirrored from the manifest",
+          "enum": ["draft", "review", "frozen", "published"]
+        },
+        "content": {
+          "type": "object",
+          "description": "Content part path and hash",
+          "required": ["path", "hash"],
+          "properties": {
+            "path": { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/relativePath" },
+            "hash": { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentHash" }
+          },
+          "additionalProperties": false
+        },
+        "presentation": {
+          "type": "array",
+          "description": "Presentation declaration: each presentation part's type, path and hash, plus the default-selection flag on the default entry",
+          "items": {
+            "type": "object",
+            "required": ["type", "path", "hash"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["paginated", "continuous", "responsive"]
+              },
+              "path": { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/relativePath" },
+              "hash": { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentHash" },
+              "default": { "const": true }
+            },
+            "additionalProperties": false
+          }
+        },
+        "extensions": {
+          "type": "array",
+          "description": "Required-extension set: each extension's id, version and required flag, plus the config of a required extension",
+          "items": {
+            "type": "object",
+            "required": ["id", "version", "required"],
+            "properties": {
+              "id": { "type": "string" },
+              "version": { "type": "string" },
+              "required": { "type": "boolean" },
+              "config": { "type": "object", "additionalProperties": true }
+            },
+            "additionalProperties": false
+          }
+        },
+        "lineage": {
+          "type": "object",
+          "description": "Lineage, bound verbatim from the manifest"
+        }
+      },
+      "additionalProperties": false
+    },
     "signatureScope": {
       "type": "object",
-      "description": "Scoped signature covering content and optional layouts",
+      "description": "Scoped signature: an explicit, signed declaration of what a signature covers — always the document ID, plus optionally the manifest projection (section 9.7) and/or precise-layout hashes (section 9.3). A frozen or published document's signatures MUST include manifest.",
       "required": ["documentId"],
       "properties": {
         "documentId": {
           "description": "Content hash (must match top-level documentId)",
           "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentHash"
+        },
+        "manifest": {
+          "$ref": "#/$defs/manifestProjection",
+          "description": "Signed projection of the security-relevant manifest declarations (section 9.7). Present iff this signature attests the manifest; REQUIRED for a frozen or published document."
         },
         "layouts": {
           "type": "object",
@@ -138,7 +207,7 @@
           }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "webauthnSignature": {
       "type": "object",

--- a/schemas/security.schema.json
+++ b/schemas/security.schema.json
@@ -68,7 +68,7 @@
       "enum": ["valid", "invalid", "expired", "revoked", "untrusted", "unknown"]
     },
     "signer": {
-      "description": "Signer identity information extending base person",
+      "description": "Advisory signer display information extending base person. The authoritative identity is the signing-certificate (x5c) subject, not these fields.",
       "allOf": [
         { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/person" },
         {
@@ -77,14 +77,6 @@
             "organization": {
               "type": "string",
               "description": "Signer's organization"
-            },
-            "certificate": {
-              "type": "string",
-              "description": "X.509 certificate in PEM format"
-            },
-            "keyId": {
-              "type": "string",
-              "description": "Key identifier (DID, URL, or other identifier)"
             }
           }
         }
@@ -235,46 +227,36 @@
     },
     "signature": {
       "type": "object",
-      "description": "A digital signature entry",
-      "required": ["id", "algorithm", "signedAt", "signer", "value"],
+      "description": "A detached-JWS signature entry (section 3.3). The signed payload is JCS(scope); the signed protected header (base64url-encoded) carries alg, x5c, x5t#S256 and sigT.",
+      "required": ["id", "protected", "signature", "scope"],
       "properties": {
         "id": {
           "type": "string",
           "description": "Unique signature identifier"
         },
-        "algorithm": {
-          "$ref": "#/$defs/signatureAlgorithm"
-        },
-        "signedAt": {
+        "protected": {
           "type": "string",
-          "format": "date-time",
-          "description": "ISO 8601 signing timestamp"
+          "description": "base64url-encoded signed JWS protected header (carries alg, x5c, x5t#S256, sigT)",
+          "pattern": "^[A-Za-z0-9_-]+$",
+          "minLength": 4
         },
-        "signer": {
-          "$ref": "#/$defs/signer"
-        },
-        "value": {
-          "description": "Base64-encoded signature value",
-          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/base64"
-        },
-        "certificateChain": {
-          "type": "array",
-          "description": "Certificate chain for validation",
-          "items": {
-            "type": "string",
-            "description": "X.509 certificate in PEM format"
-          }
-        },
-        "timestamp": {
-          "$ref": "#/$defs/trustedTimestamp"
+        "signature": {
+          "type": "string",
+          "description": "base64url-encoded JWS signature over BASE64URL(protected) + '.' + JCS(scope)",
+          "pattern": "^[A-Za-z0-9_-]+$",
+          "minLength": 4
         },
         "scope": {
           "$ref": "#/$defs/signatureScope",
-          "description": "Scoped signature attestation (content + layout)"
+          "description": "The detached payload: what the signature covers (document id, manifest projection, layouts)"
         },
-        "webauthn": {
-          "$ref": "#/$defs/webauthnSignature",
-          "description": "WebAuthn signature data (alternative to value)"
+        "signer": {
+          "$ref": "#/$defs/signer",
+          "description": "Advisory signer display information; the authoritative identity is the signing-certificate subject"
+        },
+        "timestamp": {
+          "$ref": "#/$defs/trustedTimestamp",
+          "description": "Advisory trusted timestamp"
         }
       },
       "additionalProperties": false

--- a/scripts/check-jws-envelope.ts
+++ b/scripts/check-jws-envelope.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Enforcing gate for the detached-JWS signature envelope (Security Extension
+ * §3.3) — the 3.2a-i envelope migration.
+ *
+ * Part 1 — Header encoding: the reference encoder reproduces each hand-specified
+ *   base64url protected header.
+ * Part 2 — Signing input: the construction `BASE64URL(protected) || '.' ||
+ *   JCS(scope)` reproduces each independently-computed SHA-256.
+ * Part 3 — Example corpus: every signature is a well-formed JWS envelope
+ *   (protected + signature + scope; header passes the shape profile; signing
+ *   input reconstructs) and carries NONE of the removed bespoke fields
+ *   (value/algorithm/signedAt/certificateChain/webauthn) — the migration guard.
+ *
+ * This gate asserts ENVELOPE structure only. It does NOT verify signatures or
+ * anchor trust (the trust core is a later increment); a verifier MUST NOT report
+ * `valid` on the strength of anything checked here.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import {
+  encodeProtectedHeader,
+  decodeProtectedHeader,
+  validateProtectedHeader,
+  jwsSigningInput,
+  base64urlDecode,
+} from './lib/jws-envelope.js';
+import { headerVectors, signingInputVectors } from './kat/jws-envelope-vectors.js';
+
+let failures = 0;
+const fail = (msg: string): void => {
+  console.log(`  ✗ ${msg}`);
+  failures++;
+};
+const sha256Of = (s: string): string => 'sha256:' + crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+
+/** Bespoke fields removed by the JWS migration — their presence is a regression. */
+const REMOVED_SIGNATURE_FIELDS = ['value', 'algorithm', 'signedAt', 'certificateChain', 'webauthn'];
+
+// --- Part 1: header encoding ----------------------------------------------
+console.log('Protected-header encoding vectors:');
+for (const v of headerVectors) {
+  let got: string;
+  try {
+    got = encodeProtectedHeader(v.header);
+  } catch (err) {
+    fail(`${v.name} — threw: ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+  if (got !== v.expectedProtected) {
+    fail(`${v.name} — protected mismatch`);
+    console.log(`      expected ${v.expectedProtected}`);
+    console.log(`      actual   ${got}`);
+    continue;
+  }
+  console.log(`  ✓ ${v.name}`);
+}
+
+// --- Part 2: signing input -------------------------------------------------
+console.log('\nSigning-input vectors:');
+for (const v of signingInputVectors) {
+  let si: string;
+  try {
+    si = jwsSigningInput(encodeProtectedHeader(v.header), v.scope);
+  } catch (err) {
+    fail(`${v.name} — threw: ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+  if (sha256Of(si) !== v.expectedSha256) {
+    fail(`${v.name} — signing-input sha256 mismatch (expected ${v.expectedSha256}, got ${sha256Of(si)})`);
+    continue;
+  }
+  console.log(`  ✓ ${v.name}`);
+}
+
+// --- Part 3: example corpus ------------------------------------------------
+console.log('\nExample corpus signature envelopes:');
+const examplesDir = path.join(__dirname, '..', 'examples');
+let checked = 0;
+for (const name of fs.readdirSync(examplesDir, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name).sort()) {
+  const dir = path.join(examplesDir, name);
+  const manifestPath = path.join(dir, 'manifest.json');
+  if (!fs.existsSync(manifestPath)) continue;
+
+  let manifest: any;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (err) {
+    fail(`${name} — manifest parse error: ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+  const sigRel = manifest.security?.signatures;
+  if (typeof sigRel !== 'string' || !fs.existsSync(path.join(dir, sigRel))) continue;
+
+  let sigFile: any;
+  try {
+    sigFile = JSON.parse(fs.readFileSync(path.join(dir, sigRel), 'utf8'));
+  } catch (err) {
+    fail(`${name} — signatures.json parse error: ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+
+  for (const s of Array.isArray(sigFile.signatures) ? sigFile.signatures : []) {
+    const id = s?.id ?? '(unnamed)';
+    for (const removed of REMOVED_SIGNATURE_FIELDS) {
+      if (s != null && s[removed] !== undefined) {
+        fail(`${name} signature "${id}" — carries removed bespoke field "${removed}" (must migrate to the JWS envelope)`);
+      }
+    }
+    // The signing certificate lives in the protected-header x5c; an unsigned copy
+    // on the advisory signer block is a removed identity field (the schema's
+    // shared `person` base leaves `signer` open, so this is enforced here).
+    for (const removed of ['certificate', 'keyId']) {
+      if (s?.signer != null && s.signer[removed] !== undefined) {
+        fail(`${name} signature "${id}" — signer carries removed field "${removed}" (identity comes from the protected-header x5c subject)`);
+      }
+    }
+    if (typeof s?.protected !== 'string' || typeof s?.signature !== 'string') {
+      fail(`${name} signature "${id}" — missing JWS "protected"/"signature" members`);
+      continue;
+    }
+    if (s.scope == null) {
+      fail(`${name} signature "${id}" — missing detached "scope" payload member`);
+      continue;
+    }
+    try {
+      base64urlDecode(s.signature); // structural base64url check (not verification)
+      const header = decodeProtectedHeader(s.protected);
+      validateProtectedHeader(header);
+      jwsSigningInput(s.protected, s.scope); // reconstructs without error
+    } catch (err) {
+      fail(`${name} signature "${id}" — ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+    console.log(`  ✓ ${name} signature "${id}"`);
+    checked++;
+  }
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} failure(s). JWS-envelope check failed.`);
+  process.exit(1);
+}
+console.log(`\nAll envelope vectors verified; ${checked} example signature envelope(s) checked.`);

--- a/scripts/check-manifest-projection.ts
+++ b/scripts/check-manifest-projection.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Enforcing gate for the signed manifest projection (Security Extension §9.7)
+ * and the scoped-signature serialization (§9.5).
+ *
+ * Part 1 — Projection known-answer vectors: asserts the projector reproduces each
+ *   hand-specified canonical JCS and its independently-computed sha256
+ *   (scripts/kat/manifest-projection-vectors.ts). The expected bytes and hash are
+ *   produced by an out-of-band serializer, so a transform/serializer bug is
+ *   caught against an independent oracle, not snapshotted.
+ *
+ * Part 2 — Scope serialization vectors: pins the existing `JCS(scope)` signing
+ *   construction (which previously had no test) before/while `scope.manifest`
+ *   extends it.
+ *
+ * Part 3 — Error vectors: asserts the projector rejects the inputs it must
+ *   (pending id, malformed hash, duplicate extension id).
+ *
+ * Part 4 — Example corpus: enforces the coverage policy — a `frozen`/`published`
+ *   document's signatures MUST carry `scope.manifest`, and every stored
+ *   `scope.manifest` MUST equal the projection recomputed from the manifest (and
+ *   `scope.documentId` MUST equal `manifest.id`).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { jcsOf } from './lib/canonicalize.js';
+import { projectManifest, projectManifestToJcs } from './lib/manifest-projection.js';
+import { projectionVectors, scopeVectors, errorVectors } from './kat/manifest-projection-vectors.js';
+
+let failures = 0;
+const fail = (msg: string): void => {
+  console.log(`  ✗ ${msg}`);
+  failures++;
+};
+
+const sha256Of = (s: string): string => 'sha256:' + crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+
+/** States in which a signature MUST cover the manifest projection (§9.7). */
+const COVERAGE_REQUIRED_STATES = new Set(['frozen', 'published']);
+
+// --- Part 1: projection known-answer vectors -------------------------------
+console.log('Manifest-projection known-answer vectors:');
+for (const v of projectionVectors) {
+  let jcs: string;
+  try {
+    jcs = projectManifestToJcs(v.manifest);
+  } catch (err) {
+    fail(`${v.name} — threw: ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+  if (jcs !== v.expectedJcs) {
+    fail(`${v.name} — canonical JCS mismatch`);
+    console.log(`      expected ${v.expectedJcs}`);
+    console.log(`      actual   ${jcs}`);
+    continue;
+  }
+  if (sha256Of(jcs) !== v.expectedSha256) {
+    fail(`${v.name} — sha256 mismatch (expected ${v.expectedSha256}, got ${sha256Of(jcs)})`);
+    continue;
+  }
+  console.log(`  ✓ ${v.name}`);
+}
+
+// --- Part 2: scope serialization vectors -----------------------------------
+console.log('\nScope serialization vectors:');
+for (const v of scopeVectors) {
+  let jcs: string;
+  try {
+    jcs = jcsOf(v.scope);
+  } catch (err) {
+    fail(`${v.name} — threw: ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+  if (jcs !== v.expectedJcs) {
+    fail(`${v.name} — JCS(scope) mismatch`);
+    console.log(`      expected ${v.expectedJcs}`);
+    console.log(`      actual   ${jcs}`);
+    continue;
+  }
+  if (sha256Of(jcs) !== v.expectedSha256) {
+    fail(`${v.name} — sha256 mismatch (expected ${v.expectedSha256}, got ${sha256Of(jcs)})`);
+    continue;
+  }
+  console.log(`  ✓ ${v.name}`);
+}
+
+// --- Part 3: error vectors -------------------------------------------------
+console.log('\nProjection error vectors:');
+for (const v of errorVectors) {
+  try {
+    projectManifest(v.manifest);
+    fail(`${v.name} — expected an error containing "${v.expectedError}", but none was thrown`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes(v.expectedError)) {
+      fail(`${v.name} — error "${msg}" does not contain "${v.expectedError}"`);
+    } else {
+      console.log(`  ✓ ${v.name}`);
+    }
+  }
+}
+
+// --- Part 4: example corpus ------------------------------------------------
+console.log('\nExample corpus manifest coverage:');
+const examplesDir = path.join(__dirname, '..', 'examples');
+let covered = 0;
+let skipped = 0;
+for (const name of fs.readdirSync(examplesDir, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name).sort()) {
+  const dir = path.join(examplesDir, name);
+  const manifestPath = path.join(dir, 'manifest.json');
+  if (!fs.existsSync(manifestPath)) continue;
+
+  const manifestText = fs.readFileSync(manifestPath, 'utf8');
+  let manifest: any;
+  try {
+    manifest = JSON.parse(manifestText);
+  } catch (err) {
+    fail(`${name} — manifest parse error: ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+
+  const sigRel = manifest.security?.signatures;
+  if (typeof sigRel !== 'string' || !fs.existsSync(path.join(dir, sigRel))) {
+    continue; // no signatures part to check
+  }
+  if (manifest.id === 'pending') {
+    console.log(`  - ${name} (id pending — draft, skipped)`);
+    skipped++;
+    continue;
+  }
+
+  let expectedProjectionJcs: string;
+  let sig: any;
+  try {
+    expectedProjectionJcs = projectManifestToJcs(manifestText);
+    sig = JSON.parse(fs.readFileSync(path.join(dir, sigRel), 'utf8'));
+  } catch (err) {
+    fail(`${name} — ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+
+  const requireCoverage = COVERAGE_REQUIRED_STATES.has(manifest.state);
+  const signatures: any[] = Array.isArray(sig.signatures) ? sig.signatures : [];
+  for (const s of signatures) {
+    const id = s?.id ?? '(unnamed)';
+    const scope = s?.scope;
+    const hasManifest = scope != null && scope.manifest !== undefined;
+
+    if (requireCoverage && !hasManifest) {
+      fail(`${name} signature "${id}" — document is ${manifest.state} but the signature does not cover the manifest (scope.manifest absent)`);
+      continue;
+    }
+    if (scope != null) {
+      if (typeof scope.documentId === 'string' && scope.documentId !== manifest.id) {
+        fail(`${name} signature "${id}" — scope.documentId (${scope.documentId}) does not match manifest.id`);
+      }
+      if (hasManifest) {
+        const storedJcs = jcsOf(scope.manifest);
+        if (storedJcs !== expectedProjectionJcs) {
+          fail(`${name} signature "${id}" — scope.manifest does not match the projection recomputed from the manifest`);
+          console.log(`      expected ${expectedProjectionJcs}`);
+          console.log(`      stored   ${storedJcs}`);
+        }
+      }
+    }
+  }
+  console.log(`  ✓ ${name} (${manifest.state}; ${signatures.length} signature(s))`);
+  covered++;
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} failure(s). Manifest-projection check failed.`);
+  process.exit(1);
+}
+console.log(`\nAll projection/scope vectors verified; ${covered} signed example(s) checked, ${skipped} pending/skipped.`);

--- a/scripts/check-trust-state.ts
+++ b/scripts/check-trust-state.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Enforcing gate for the signature-state production rules (Security Extension
+ * §3.8) — the 3.2a-ii trust core.
+ *
+ * Part 1 — Production-rule vectors: `evaluateSignatureState` reproduces each
+ *   hand-derived state across every precedence rule and collision.
+ *
+ * Part 2 — Real-ES256 grounding: an ephemeral P-256 key signs a REAL JWS signing
+ *   input (built by the 3.2a-i envelope helpers) and the signature verifies;
+ *   tampering one byte makes it fail. This grounds the abstract `signatureVerifies`
+ *   input in an actual ES256 operation — no committed key, no new dependency.
+ *   (The chain/trust-store/revocation inputs stay abstract: a spec-repo gate
+ *   cannot ship a trust anchor or run OCSP; those are normative verifier
+ *   obligations, see §3.9/§7.4.)
+ */
+
+import * as crypto from 'crypto';
+import { evaluateSignatureState, type SignatureStateInputs } from './lib/signature-state.js';
+import { trustStateVectors } from './kat/trust-state-vectors.js';
+import { encodeProtectedHeader, jwsSigningInput } from './lib/jws-envelope.js';
+
+let failures = 0;
+const fail = (msg: string): void => {
+  console.log(`  ✗ ${msg}`);
+  failures++;
+};
+
+// --- Part 1: production-rule vectors --------------------------------------
+console.log('Signature-state production-rule vectors:');
+for (const vec of trustStateVectors) {
+  const got = evaluateSignatureState(vec.inputs);
+  if (got !== vec.expected) {
+    fail(`${vec.name} — expected ${vec.expected}, got ${got}`);
+    continue;
+  }
+  console.log(`  ✓ ${vec.name} → ${got}`);
+}
+
+// Defence-in-depth: every state in the vocabulary must be reachable (no vector
+// table that silently stops exercising a state).
+const REACHABLE = new Set(trustStateVectors.map((vec) => vec.expected));
+for (const state of ['valid', 'invalid', 'expired', 'revoked', 'untrusted', 'unknown']) {
+  if (!REACHABLE.has(state as never)) fail(`state "${state}" is never exercised by a vector`);
+}
+
+// --- Part 2: real-ES256 grounding -----------------------------------------
+console.log('\nReal-ES256 grounding (ephemeral key, no committed material):');
+const ground = (): void => {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+  const protectedHeader = encodeProtectedHeader({ alg: 'ES256', b64: false, crit: ['b64'] });
+  const scope = { documentId: 'sha256:' + 'a'.repeat(64) };
+  const signingInput = Buffer.from(jwsSigningInput(protectedHeader, scope), 'utf8');
+
+  // ES256 = ECDSA P-256 + SHA-256 with the raw P-1363 (R||S) encoding JOSE uses.
+  const signature = crypto.sign('sha256', signingInput, { key: privateKey, dsaEncoding: 'ieee-p1363' });
+  const verifies = crypto.verify('sha256', signingInput, { key: publicKey, dsaEncoding: 'ieee-p1363' }, signature);
+
+  const base: SignatureStateInputs = {
+    headerConsistent: true,
+    signatureVerifies: verifies,
+    chainResult: 'anchored',
+    revocationStatus: 'good',
+    signingTimeWithinValidity: true,
+    certCurrentlyExpired: false,
+    referenceTimeTrusted: false,
+  };
+  if (!verifies) {
+    fail('a freshly-signed ES256 JWS signing input did not verify');
+  } else if (evaluateSignatureState(base) !== 'valid') {
+    fail(`a real verifying signature with all-good inputs did not evaluate to valid`);
+  } else {
+    console.log('  ✓ real ES256 signature verifies → valid');
+  }
+
+  // Tamper one byte of the signing input — the same signature must NOT verify,
+  // and the state must become invalid.
+  const tampered = Buffer.from(signingInput);
+  tampered[tampered.length - 1] ^= 0x01;
+  const tamperVerifies = crypto.verify('sha256', tampered, { key: publicKey, dsaEncoding: 'ieee-p1363' }, signature);
+  if (tamperVerifies) {
+    fail('a tampered signing input still verified against the original signature');
+  } else if (evaluateSignatureState({ ...base, signatureVerifies: false }) !== 'invalid') {
+    fail('a non-verifying signature did not evaluate to invalid');
+  } else {
+    console.log('  ✓ tampered input fails verification → invalid');
+  }
+};
+try {
+  ground();
+} catch (err) {
+  fail(`real-ES256 grounding threw: ${err instanceof Error ? err.message : String(err)}`);
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} failure(s). Trust-state check failed.`);
+  process.exit(1);
+}
+console.log(`\nAll ${trustStateVectors.length} production-rule vectors verified; real-ES256 grounding passed.`);

--- a/scripts/kat/jws-envelope-vectors.ts
+++ b/scripts/kat/jws-envelope-vectors.ts
@@ -1,0 +1,95 @@
+/**
+ * Known-answer test vectors for the detached-JWS signature envelope
+ * (Security Extension §3.3).
+ *
+ * `headerVectors` pin the reference protected-header encoding (header object →
+ * base64url). `signingInputVectors` pin the full signing-input construction —
+ * `BASE64URL(protected) || '.' || JCS(scope)` (RFC 7797 detached, b64:false) —
+ * against an independent SHA-256 oracle (Python base64/json/hashlib, not this
+ * repo's code), so a construction or encoding bug is caught, not snapshotted.
+ *
+ * These vectors exercise the ENVELOPE only (3.2a-i): no certificate is parsed
+ * and no signature is verified — the `x5c`/`x5t#S256` values are clearly-fake
+ * placeholders, and trust semantics are out of scope until the trust core.
+ */
+
+const DOC_ID = 'sha256:66db6e3c227d306b57068a4fa5e779e3a4b2ab74c9cb6320ecd57ddf280c2b86';
+const DOC_CONTENT = 'sha256:dac719a7afeb6b8bfb05fa673154f3a840ba8554348a2c085859889abe240bb7';
+
+/** Clearly-fake, non-verifying cert material for envelope-shape vectors. */
+const X5C_PLACEHOLDER = 'MIIBixUNVERIFIEDplaceholderDERcertificateBASE64FORILLUSTRATIONxw==';
+const X5T_PLACEHOLDER = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+export interface HeaderVector {
+  name: string;
+  description: string;
+  header: Record<string, unknown>;
+  /** base64url of the RFC 8785 (JCS) serialization of `header`. */
+  expectedProtected: string;
+}
+
+export interface SigningInputVector {
+  name: string;
+  description: string;
+  /** The protected header is derived from this object via the reference encoder. */
+  header: Record<string, unknown>;
+  /** The readable scope sibling whose JCS is the detached payload. */
+  scope: unknown;
+  /** sha256 of the UTF-8 signing input (computed out-of-band). */
+  expectedSha256: string;
+}
+
+export const headerVectors: HeaderVector[] = [
+  {
+    name: 'minimal-es256',
+    description: 'The smallest valid header: alg + the mandatory b64:false / crit:["b64"].',
+    header: { alg: 'ES256', b64: false, crit: ['b64'] },
+    expectedProtected: 'eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19',
+  },
+  {
+    name: 'minimal-eddsa',
+    description: 'A different algorithm in the same minimal header shape.',
+    header: { alg: 'EdDSA', b64: false, crit: ['b64'] },
+    expectedProtected: 'eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19',
+  },
+];
+
+export const signingInputVectors: SigningInputVector[] = [
+  {
+    name: 'min-content-only',
+    description: 'Minimal header + a content-only scope (documentId alone).',
+    header: { alg: 'ES256', b64: false, crit: ['b64'] },
+    scope: { documentId: DOC_ID },
+    expectedSha256: 'sha256:5f8b3603411b3b56488d878ed8ffe8423669346a60ae325e5704c8696bbc2ffb',
+  },
+  {
+    name: 'full-manifest-covering',
+    description: 'A full JAdES-inspired header (x5c/x5t#S256/sigT) + a manifest-covering scope — the signed-document case.',
+    header: {
+      alg: 'ES256',
+      b64: false,
+      crit: ['b64'],
+      sigT: '2025-01-15T10:00:00Z',
+      x5c: [X5C_PLACEHOLDER],
+      'x5t#S256': X5T_PLACEHOLDER,
+    },
+    scope: {
+      documentId: DOC_ID,
+      manifest: {
+        cdx: '0.1',
+        state: 'frozen',
+        content: { path: 'content/document.json', hash: DOC_CONTENT },
+        extensions: [{ id: 'cdx.security', version: '0.1', required: true }],
+        lineage: { parent: null, version: 1 },
+      },
+    },
+    expectedSha256: 'sha256:714cfbb574c69a2d5f965c6d0d6ab5699d67f7d13becff3a1de82dae331d2688',
+  },
+  {
+    name: 'eddsa-sha384-content-only',
+    description: 'EdDSA + a sha384 document id, confirming alg-agility and a longer hash flow through the construction unchanged.',
+    header: { alg: 'EdDSA', b64: false, crit: ['b64'] },
+    scope: { documentId: `sha384:${'a'.repeat(96)}` },
+    expectedSha256: 'sha256:144dee61769761a1914a1a793781ac2736064bf89b598c0a34f88e271effb31f',
+  },
+];

--- a/scripts/kat/manifest-projection-vectors.ts
+++ b/scripts/kat/manifest-projection-vectors.ts
@@ -1,0 +1,156 @@
+/**
+ * Known-answer test (KAT) vectors for the signed manifest projection and the
+ * scoped-signature serialization.
+ *
+ * As with the document-ID vectors, each `expectedJcs` is the canonical RFC 8785
+ * (JCS) byte string a faithful projector/serializer MUST produce, and
+ * `expectedSha256` is the SHA-256 of those exact bytes computed by an
+ * independent serializer (Python's `json` + `hashlib`, NOT this repo's
+ * `canonicalize` package). The gate (check-manifest-projection.ts) asserts the
+ * implementation reproduces BOTH — so a transform or serializer bug is caught
+ * against an independent oracle, not snapshotted.
+ *
+ * Repeated-character hashes are built with `sha()` so digest lengths are exact
+ * (64 hex for sha256) and identical between a vector's input and its expected
+ * output; the `expectedSha256` anchors the true structure regardless.
+ *
+ * `scopeVectors` pin the EXISTING `JCS(scope)` signing construction
+ * (spec/extensions/security/README.md §9.5) — which until now had no
+ * known-answer test at all — before `scope.manifest` extends it.
+ */
+
+/** A repeated-character content hash of the exact length sha256 requires. */
+const sha = (c: string): string => `sha256:${c.repeat(64)}`;
+
+/** The real signed-document corpus hashes (so V1 mirrors the on-disk example). */
+const DOC_ID = 'sha256:66db6e3c227d306b57068a4fa5e779e3a4b2ab74c9cb6320ecd57ddf280c2b86';
+const DOC_CONTENT = 'sha256:dac719a7afeb6b8bfb05fa673154f3a840ba8554348a2c085859889abe240bb7';
+
+export interface ProjectionVector {
+  name: string;
+  description: string;
+  /** Raw JSON text of a manifest.json (the projector's input contract). */
+  manifest: string;
+  /** Hand-specified canonical JCS of the projection the manifest yields. */
+  expectedJcs: string;
+  /** sha256 of the UTF-8 bytes of expectedJcs (computed out-of-band). */
+  expectedSha256: string;
+}
+
+export interface ScopeVector {
+  name: string;
+  description: string;
+  /** A signature `scope` object whose JCS bytes are what a signature signs. */
+  scope: unknown;
+  expectedJcs: string;
+  expectedSha256: string;
+}
+
+export interface ErrorVector {
+  name: string;
+  description: string;
+  manifest: string;
+  /** Substring the thrown CanonicalizationError message must contain. */
+  expectedError: string;
+}
+
+export const projectionVectors: ProjectionVector[] = [
+  {
+    name: 'signed-document-corpus',
+    description:
+      'The signed-document manifest: id/created/modified/hashAlgorithm/security/metadata and content.compression all drop; content{path,hash} + extensions + lineage(parent:null) bind.',
+    manifest: `{"cdx":"0.1","id":"${DOC_ID}","state":"frozen","hashAlgorithm":"sha256","created":"2025-01-10T08:00:00Z","modified":"2025-01-15T14:22:00Z","content":{"path":"content/document.json","hash":"${DOC_CONTENT}","compression":"zstd"},"security":{"signatures":"security/signatures.json","encryption":null},"extensions":[{"id":"cdx.security","version":"0.1","required":true}],"metadata":{"dublinCore":"metadata/dublin-core.json"},"lineage":{"parent":null,"version":1}}`,
+    expectedJcs: `{"cdx":"0.1","content":{"hash":"${DOC_CONTENT}","path":"content/document.json"},"extensions":[{"id":"cdx.security","required":true,"version":"0.1"}],"lineage":{"parent":null,"version":1},"state":"frozen"}`,
+    expectedSha256: 'sha256:e0a53f678feb2eddf03e14610c336cfcbf201d9ceccc46a6692faf6e505d66f0',
+  },
+  {
+    name: 'presentation-and-default',
+    description:
+      'presentation[] is sorted by JCS (paginated before responsive) and only the default entry carries default:true; a default:false is dropped (no default-value materialization).',
+    manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"published","content":{"path":"content/document.json","hash":"${sha('2')}"},"presentation":[{"type":"responsive","path":"presentation/responsive.json","hash":"${sha('4')}","default":false},{"type":"paginated","path":"presentation/paginated.json","hash":"${sha('3')}","default":true}]}`,
+    expectedJcs: `{"cdx":"0.1","content":{"hash":"${sha('2')}","path":"content/document.json"},"presentation":[{"default":true,"hash":"${sha('3')}","path":"presentation/paginated.json","type":"paginated"},{"hash":"${sha('4')}","path":"presentation/responsive.json","type":"responsive"}],"state":"published"}`,
+    expectedSha256: 'sha256:1d912c4633e1c65d26df8808455fd239340c7f7638415599051bbc9b56c05b85',
+  },
+  {
+    name: 'extensions-config-required-only',
+    description:
+      'config binds for the required extension (cdx.security) and is dropped for the non-required one (cdx.academic); entries sort by JCS (security first).',
+    manifest: `{"cdx":"0.1","id":"${sha('5')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('6')}"},"extensions":[{"id":"cdx.academic","version":"0.2","required":false,"config":{"numbering":"academic/numbering.json"}},{"id":"cdx.security","version":"0.1","required":true,"config":{"policy":"strict"}}]}`,
+    expectedJcs: `{"cdx":"0.1","content":{"hash":"${sha('6')}","path":"content/document.json"},"extensions":[{"config":{"policy":"strict"},"id":"cdx.security","required":true,"version":"0.1"},{"id":"cdx.academic","required":false,"version":"0.2"}],"state":"frozen"}`,
+    expectedSha256: 'sha256:ea799b1b6f03b7f4fba5dfe01a06381cefd10e802af76cbe664f57c296f9a02a',
+  },
+  {
+    name: 'minimal-no-optionals',
+    description: 'Only the always-present fields; absent presentation/extensions/lineage are omitted, never null-materialized.',
+    manifest: `{"cdx":"0.1","id":"${sha('7')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('8')}"}}`,
+    expectedJcs: `{"cdx":"0.1","content":{"hash":"${sha('8')}","path":"content/document.json"},"state":"frozen"}`,
+    expectedSha256: 'sha256:711be22dd3851024d9d2cf761c6b32d5e72707aa50fd675b2db3e103d666fc1d',
+  },
+  {
+    name: 'lineage-with-ancestors',
+    description: 'lineage binds verbatim; the ancestors array preserves its authored (nearest-first) order while object keys sort.',
+    manifest: `{"cdx":"0.1","id":"${sha('9')}","state":"published","content":{"path":"content/document.json","hash":"${sha('a')}"},"lineage":{"version":3,"depth":3,"parent":"${sha('b')}","ancestors":["${sha('c')}","${sha('d')}"]}}`,
+    expectedJcs: `{"cdx":"0.1","content":{"hash":"${sha('a')}","path":"content/document.json"},"lineage":{"ancestors":["${sha('c')}","${sha('d')}"],"depth":3,"parent":"${sha('b')}","version":3},"state":"published"}`,
+    expectedSha256: 'sha256:7c9e3d98dcc4b7977860156c35b58995046c64a3c8b0067c5dcf79e61d8dc4d1',
+  },
+];
+
+export const scopeVectors: ScopeVector[] = [
+  {
+    name: 'scope-content-only',
+    description: 'A content-only scope binds just the document ID — the legacy/default coverage.',
+    scope: { documentId: DOC_ID },
+    expectedJcs: `{"documentId":"${DOC_ID}"}`,
+    expectedSha256: 'sha256:8b63e569bdcc02bde3ae3a9669ec18c0aa7084027ea0f808d521a437f0b434c9',
+  },
+  {
+    name: 'scope-with-layouts',
+    description: 'A scope binding the document ID plus precise-layout file hashes (visual attestation).',
+    scope: { documentId: sha('1'), layouts: { 'presentation/layouts/letter.json': sha('2') } },
+    expectedJcs: `{"documentId":"${sha('1')}","layouts":{"presentation/layouts/letter.json":"${sha('2')}"}}`,
+    expectedSha256: 'sha256:e6e0c5b763077a3e8a0eb16688f76e2f9fdea6351095d61b14fa02528ee6d7be',
+  },
+  {
+    name: 'scope-with-manifest',
+    description: 'A manifest-covering scope: documentId + the signed-document projection. These are the bytes a frozen manifest-covering signature signs.',
+    scope: {
+      documentId: DOC_ID,
+      manifest: {
+        cdx: '0.1',
+        state: 'frozen',
+        content: { path: 'content/document.json', hash: DOC_CONTENT },
+        extensions: [{ id: 'cdx.security', version: '0.1', required: true }],
+        lineage: { parent: null, version: 1 },
+      },
+    },
+    expectedJcs: `{"documentId":"${DOC_ID}","manifest":{"cdx":"0.1","content":{"hash":"${DOC_CONTENT}","path":"content/document.json"},"extensions":[{"id":"cdx.security","required":true,"version":"0.1"}],"lineage":{"parent":null,"version":1},"state":"frozen"}}`,
+    expectedSha256: 'sha256:2c9949b501880073f40de525e76e92558fd7a601479598d9051c9ad6b0159b30',
+  },
+];
+
+export const errorVectors: ErrorVector[] = [
+  {
+    name: 'pending-id-forbidden',
+    description: 'A draft manifest (id:"pending") has no fixed identity, so a projection over it is forbidden.',
+    manifest: `{"cdx":"0.1","id":"pending","state":"draft","content":{"path":"content/document.json","hash":"${sha('1')}"}}`,
+    expectedError: 'pending',
+  },
+  {
+    name: 'malformed-content-hash',
+    description: 'A content hash that is not a well-formed algorithm:hexdigest is rejected.',
+    manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"sha256:1234"}}`,
+    expectedError: 'malformed',
+  },
+  {
+    name: 'duplicate-extension-id',
+    description: 'Two extensions with the same id make the projection ambiguous and are rejected.',
+    manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"extensions":[{"id":"cdx.security","version":"0.1","required":true},{"id":"cdx.security","version":"0.2","required":false}]}`,
+    expectedError: 'duplicate extension id',
+  },
+  {
+    name: 'unknown-state-rejected',
+    description: 'A state outside the lifecycle enum fails closed rather than binding a bogus state into a signature.',
+    manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"archived","content":{"path":"content/document.json","hash":"${sha('2')}"}}`,
+    expectedError: 'manifest.state must be one of',
+  },
+];

--- a/scripts/kat/trust-state-vectors.ts
+++ b/scripts/kat/trust-state-vectors.ts
@@ -1,0 +1,65 @@
+/**
+ * Known-answer vectors for the signature-state production rules
+ * (Security Extension §3.8). Each `expected` state is hand-derived from the
+ * §3.8 precedence — the independent oracle is the written rule table, so a bug
+ * in `evaluateSignatureState` is caught against it, not snapshotted.
+ *
+ * Vectors cover one case per precedence rule, the precedence collisions that
+ * matter (which state wins when several conditions hold), and the trusted-time
+ * cap behaviour (an untrusted `sigT` window-violation is ignored; only a trusted
+ * clock promotes it to `invalid`).
+ */
+
+import type { SignatureStateInputs, SignatureState } from '../lib/signature-state.js';
+
+export interface TrustStateVector {
+  name: string;
+  description: string;
+  inputs: SignatureStateInputs;
+  expected: SignatureState;
+}
+
+/** All-good baseline (→ valid); vectors override only the fields they exercise. */
+const OK: SignatureStateInputs = {
+  headerConsistent: true,
+  signatureVerifies: true,
+  chainResult: 'anchored',
+  revocationStatus: 'good',
+  signingTimeWithinValidity: true,
+  certCurrentlyExpired: false,
+  referenceTimeTrusted: false,
+};
+
+const v = (over: Partial<SignatureStateInputs>): SignatureStateInputs => ({ ...OK, ...over });
+
+export const trustStateVectors: TrustStateVector[] = [
+  { name: 'valid', description: 'Everything verifies, anchors, not revoked, in validity.', inputs: v({}), expected: 'valid' },
+
+  // Rule 1 — invalid floor.
+  { name: 'invalid-bad-signature', description: 'JWS does not verify under the leaf key.', inputs: v({ signatureVerifies: false }), expected: 'invalid' },
+  { name: 'invalid-bad-header', description: 'Header inconsistent (e.g. x5t#S256 does not match x5c[0], or crit malformed).', inputs: v({ headerConsistent: false }), expected: 'invalid' },
+
+  // Rule 2 — signed outside validity, proven by a trusted clock.
+  { name: 'invalid-signed-outside-validity-trusted', description: 'A validated timestamp shows the cert was outside its validity when it signed.', inputs: v({ referenceTimeTrusted: true, signingTimeWithinValidity: false }), expected: 'invalid' },
+
+  // Rules 3–4 — trust path.
+  { name: 'unknown-chain', description: 'The chain could not be evaluated.', inputs: v({ chainResult: 'unknown' }), expected: 'unknown' },
+  { name: 'untrusted-self-signed', description: 'No path to a configured anchor (e.g. the self-signed signed-document example).', inputs: v({ chainResult: 'untrusted' }), expected: 'untrusted' },
+
+  // Rules 5–6 — revocation (chain anchored).
+  { name: 'revoked', description: 'The certificate is revoked.', inputs: v({ revocationStatus: 'revoked' }), expected: 'revoked' },
+  { name: 'unknown-revocation', description: 'Revocation indeterminate (unreachable responder, or stapled response under an untrusted clock).', inputs: v({ revocationStatus: 'unknown' }), expected: 'unknown' },
+
+  // Rule 7 — expiry.
+  { name: 'expired', description: 'Legitimately signed, but the certificate has since expired.', inputs: v({ certCurrentlyExpired: true }), expected: 'expired' },
+
+  // Precedence collisions.
+  { name: 'invalid-beats-untrusted', description: 'A forged signature is invalid even on an unanchored chain.', inputs: v({ signatureVerifies: false, chainResult: 'untrusted' }), expected: 'invalid' },
+  { name: 'untrusted-beats-revoked', description: 'Without an anchored chain, a "revoked" status is not trustworthy → untrusted.', inputs: v({ chainResult: 'untrusted', revocationStatus: 'revoked' }), expected: 'untrusted' },
+  { name: 'untrusted-beats-expired', description: 'An unanchored chain is untrusted regardless of expiry.', inputs: v({ chainResult: 'untrusted', certCurrentlyExpired: true }), expected: 'untrusted' },
+  { name: 'revoked-beats-expired', description: 'Revocation outranks expiry.', inputs: v({ revocationStatus: 'revoked', certCurrentlyExpired: true }), expected: 'revoked' },
+
+  // Trusted-time cap: an untrusted sigT window-violation is ignored (rule 2 does
+  // not fire); the currently-valid cert still yields valid.
+  { name: 'untrusted-time-ignores-sigT-window', description: 'sigT claims out-of-window but is untrusted; cert is currently valid → valid (rule 2 needs a trusted clock).', inputs: v({ referenceTimeTrusted: false, signingTimeWithinValidity: false }), expected: 'valid' },
+];

--- a/scripts/lib/canonicalize.ts
+++ b/scripts/lib/canonicalize.ts
@@ -70,7 +70,7 @@ export function algorithmOf(value: string): string {
 }
 
 /** True iff `h` is a well-formed `algorithm:hexdigest` of the right length. */
-function isValidContentHash(h: unknown): h is string {
+export function isValidContentHash(h: unknown): h is string {
   if (typeof h !== 'string') return false;
   const idx = h.indexOf(':');
   if (idx <= 0) return false;
@@ -658,7 +658,7 @@ function rewriteContentAnchor(value: string, map: Map<string, string>): string {
 // Stored-byte invariant validation (§4.3.2) — validate, never normalize
 // ---------------------------------------------------------------------------
 
-function validateStoredByteInvariants(value: unknown): void {
+export function validateStoredByteInvariants(value: unknown): void {
   if (typeof value === 'string') {
     checkString(value);
   } else if (typeof value === 'number') {
@@ -708,7 +708,7 @@ function isWellFormedUnicode(s: string): boolean {
 // Small helpers
 // ---------------------------------------------------------------------------
 
-function isPlainObject(v: unknown): v is Record<string, unknown> {
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
@@ -732,7 +732,7 @@ function normalizePath(p: string): string {
 }
 
 /** JCS-serialize a value, throwing rather than returning `undefined`. */
-function jcsOf(value: unknown): string {
+export function jcsOf(value: unknown): string {
   const s = canonicalize(value);
   if (typeof s !== 'string') {
     throw new CanonicalizationError(`value could not be JCS-serialized: ${JSON.stringify(value)}`);

--- a/scripts/lib/jws-envelope.ts
+++ b/scripts/lib/jws-envelope.ts
@@ -1,0 +1,136 @@
+/**
+ * Reference helpers for the CDX detached-JWS signature envelope (Security
+ * Extension §3.3). A CDX signature is a flattened JWS (RFC 7515) JSON
+ * Serialization with an **unencoded, detached** payload (RFC 7797, `b64:false`):
+ * the signed payload is `JCS(scope)` — the same canonical bytes the document-ID
+ * and manifest-projection machinery already produce — while the readable `scope`
+ * object is carried as a sibling member and is NOT part of the JOSE object.
+ *
+ * This is a JWS profiled toward JAdES (ETSI TS 119 182-1): the signed protected
+ * header binds `alg`, `x5c`, `x5t#S256` and `sigT`. It deliberately does NOT
+ * claim a JAdES baseline conformance level (B-B/B-T/B-LT/B-LTA): it omits `sigD`
+ * (the detached payload is reconstructed as `JCS(scope)` per §3.3, not via a
+ * JAdES `sigD` descriptor) and the long-term-validation properties land later.
+ *
+ * 3.2a-i (this increment) defines the ENVELOPE only — the construction of the
+ * signed bytes and the header shape. It establishes NO trust semantics: a
+ * verifier MUST NOT report a signature `valid` until the trust core is specified.
+ * This module accordingly does not validate certificate chains, trust anchors,
+ * revocation, or the cryptographic signature itself.
+ *
+ * Critical discipline (opposite of the repo's JCS-recompute rule): the JWS
+ * protected header is signed as its EXACT stored bytes — JOSE does not
+ * canonicalize it. The stored `protected` base64url string is authoritative; it
+ * must never be decoded-and-re-encoded to derive the signed bytes. (The detached
+ * payload, by contrast, IS recomputed as `JCS(scope)`.) `encodeProtectedHeader`
+ * exists only to *produce* a header deterministically; verification consumes the
+ * stored string via `jwsSigningInput`.
+ */
+
+import { jcsOf } from './canonicalize.js';
+
+/** Thrown for a malformed JWS envelope or protected header. */
+export class JwsEnvelopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JwsEnvelopeError';
+  }
+}
+
+/** Signature algorithms (mirrors security.schema.json `signatureAlgorithm`). */
+export const SUPPORTED_ALGS: ReadonlySet<string> = new Set([
+  'ES256',
+  'ES384',
+  'EdDSA',
+  'PS256',
+  'ML-DSA-65',
+]);
+
+// ---------------------------------------------------------------------------
+// base64url (RFC 7515 §2 — no padding)
+// ---------------------------------------------------------------------------
+
+export function base64url(bytes: Buffer | string): string {
+  const buf = typeof bytes === 'string' ? Buffer.from(bytes, 'utf8') : bytes;
+  return buf.toString('base64url');
+}
+
+export function base64urlDecode(value: string): Buffer {
+  if (!/^[A-Za-z0-9_-]*$/.test(value)) {
+    throw new JwsEnvelopeError(`value is not base64url: ${JSON.stringify(value)}`);
+  }
+  return Buffer.from(value, 'base64url');
+}
+
+// ---------------------------------------------------------------------------
+// Protected header
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministically encode a protected header to its base64url string. The
+ * reference encoding serializes with RFC 8785 (JCS) so the bytes are stable
+ * across producers; once produced, the *string* is authoritative (a verifier
+ * uses the stored value, never a re-encoding — see module header).
+ */
+export function encodeProtectedHeader(header: Record<string, unknown>): string {
+  return base64url(jcsOf(header));
+}
+
+/** Decode a stored protected header string to its JSON object. */
+export function decodeProtectedHeader(protectedB64url: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(base64urlDecode(protectedB64url).toString('utf8'));
+  } catch (err) {
+    throw new JwsEnvelopeError(`protected header is not valid base64url JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new JwsEnvelopeError('protected header is not a JSON object');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Validate the SHAPE of a decoded protected header against the JAdES-inspired
+ * profile (§3.3). This checks structure only — it establishes no trust and does
+ * not parse `x5c` as a real certificate (that is the trust core's job).
+ */
+export function validateProtectedHeader(header: Record<string, unknown>): void {
+  const alg = header.alg;
+  if (typeof alg !== 'string' || !SUPPORTED_ALGS.has(alg)) {
+    throw new JwsEnvelopeError(`protected header "alg" must be one of: ${[...SUPPORTED_ALGS].join(', ')}`);
+  }
+  // Unencoded detached payload (RFC 7797): b64 MUST be false and MUST be the
+  // sole `crit` member. A registered JOSE/JAdES param (e.g. sigT) MUST NOT be in
+  // crit (RFC 7515 §4.1.11).
+  if (header.b64 !== false) {
+    throw new JwsEnvelopeError('protected header "b64" must be false (unencoded detached payload)');
+  }
+  if (!Array.isArray(header.crit) || header.crit.length !== 1 || header.crit[0] !== 'b64') {
+    throw new JwsEnvelopeError('protected header "crit" must be exactly ["b64"]');
+  }
+  // Signing certificate chain (base64 DER, leaf-first) + its JAdES thumbprint.
+  if (!Array.isArray(header.x5c) || header.x5c.length === 0 || !header.x5c.every((c) => typeof c === 'string' && c.length > 0)) {
+    throw new JwsEnvelopeError('protected header "x5c" must be a non-empty array of base64 DER certificate strings');
+  }
+  if (typeof header['x5t#S256'] !== 'string' || header['x5t#S256'].length === 0) {
+    throw new JwsEnvelopeError('protected header "x5t#S256" (signing-certificate thumbprint) must be present');
+  }
+  if (typeof header.sigT !== 'string' || header.sigT.length === 0) {
+    throw new JwsEnvelopeError('protected header "sigT" (signing time) must be present');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Signing input (RFC 7797 §3 — unencoded payload)
+// ---------------------------------------------------------------------------
+
+/**
+ * The JWS signing input for an unencoded, detached payload:
+ *   ASCII(BASE64URL(UTF8(protected)) || '.') || JCS(scope)
+ * `protectedB64url` is the STORED header string (authoritative bytes); `scope`
+ * is the readable sibling object whose `JCS(scope)` IS the detached payload.
+ */
+export function jwsSigningInput(protectedB64url: string, scope: unknown): string {
+  return `${protectedB64url}.${jcsOf(scope)}`;
+}

--- a/scripts/lib/manifest-projection.ts
+++ b/scripts/lib/manifest-projection.ts
@@ -1,0 +1,199 @@
+/**
+ * Reference projector for the CDX signed **manifest projection**.
+ *
+ * A signature today binds only the document ID (the content hash), so the
+ * manifest itself — its lifecycle state, the content/presentation part hashes,
+ * the required-extension set, and the lineage — is unauthenticated: an attacker
+ * can alter any of it without breaking a signature. The manifest projection is
+ * the canonical, signable representation of those security-relevant manifest
+ * declarations; a scoped signature covers it via `scope.manifest`
+ * (spec/extensions/security/README.md §9.7).
+ *
+ * Like ./canonicalize.ts (the document-ID canonicalizer) this is a *shared
+ * library*: the example/KAT checks and any signing/verifying tooling resolve the
+ * projection through this one module, so they cannot drift. It deliberately
+ * reuses canonicalize.ts's primitives — strict parsing (duplicate-key
+ * rejection), the pinned RFC 8785 (JCS) serializer, and the stored-byte
+ * invariants — so the projection's bytes obey the exact same rules as the
+ * document ID's.
+ *
+ * The projection is an explicit *transform* of `manifest.json`; the stored file
+ * is never modified. It is **envelope-agnostic**: the bytes `serializeProjection`
+ * produces are the payload a future signature envelope (the increment that
+ * fixes the trust-anchor model) signs, independent of how that envelope is
+ * shaped.
+ *
+ * What the projection BINDS: `cdx` (spec version), `state`, the content part
+ * `{path, hash}`, the `presentation[]` declaration (`{type, path, hash}` plus the
+ * default-selection flag), the `extensions[]` set (`{id, version, required}`,
+ * plus `config` for a required extension), and `lineage` verbatim.
+ *
+ * What it does NOT bind (negative coverage, by design — see the spec §9.8):
+ *  - The document ID / content semantics — carried separately by
+ *    `scope.documentId` (the projection never repeats it).
+ *  - Embedded fonts and other non-content assets (excluded from the document ID
+ *    by design; a later increment may bind them).
+ *  - The *bytes* of path-only parts (metadata, provenance, phantoms,
+ *    annotations) and of the `security` block — only `content` and
+ *    `presentation[]` carry hashes in the manifest.
+ *  - The set of signatures itself (anti-strip/anti-downgrade is a later
+ *    increment).
+ *  - Administrative fields with no integrity meaning: `created`, `modified`,
+ *    `hashAlgorithm` (redundant with the document-ID prefix).
+ */
+
+import {
+  parseStrictJson,
+  jcsOf,
+  validateStoredByteInvariants,
+  isPlainObject,
+  isValidContentHash,
+  CanonicalizationError,
+} from './canonicalize.js';
+
+/**
+ * The manifest lifecycle states (mirrors manifest.schema.json). The projector
+ * validates `state` against this set so a bogus state fails closed here rather
+ * than being bound into a signature — the reference library does not assume the
+ * manifest was schema-validated upstream.
+ */
+const MANIFEST_STATES = new Set(['draft', 'review', 'frozen', 'published']);
+
+/** Order two already-projected array elements by their JCS serialization. */
+function byJcs(a: unknown, b: unknown): number {
+  const ja = jcsOf(a);
+  const jb = jcsOf(b);
+  return ja < jb ? -1 : ja > jb ? 1 : 0;
+}
+
+/**
+ * Build the canonical manifest projection from the raw text of `manifest.json`.
+ * Returns a plain object; serialize it with `serializeProjection` to obtain the
+ * signable bytes.
+ *
+ * Throws `CanonicalizationError` when the manifest cannot yield a projection —
+ * notably when `id` is `"pending"` (a draft has no fixed document identity, so a
+ * projection over it would be meaningless and is forbidden).
+ */
+export function projectManifest(manifestText: string): Record<string, unknown> {
+  const manifest = parseStrictJson(manifestText);
+  if (!isPlainObject(manifest)) {
+    throw new CanonicalizationError('manifest is not a JSON object');
+  }
+
+  // A projection is only defined once the document identity is fixed. A draft
+  // carries `id: "pending"` (07 §5.3) and is never signed; forbid it explicitly
+  // rather than project an unstable manifest.
+  if (manifest.id === 'pending') {
+    throw new CanonicalizationError('manifest id is "pending"; a manifest projection is undefined until the document id is assigned');
+  }
+
+  const projection: Record<string, unknown> = {};
+
+  // --- cdx (spec version) — always present (manifest required field) ---------
+  if (typeof manifest.cdx !== 'string') {
+    throw new CanonicalizationError('manifest.cdx must be a string');
+  }
+  projection.cdx = manifest.cdx;
+
+  // --- state (lifecycle) — always present ------------------------------------
+  if (typeof manifest.state !== 'string' || !MANIFEST_STATES.has(manifest.state)) {
+    throw new CanonicalizationError(`manifest.state must be one of: ${[...MANIFEST_STATES].join(', ')}`);
+  }
+  projection.state = manifest.state;
+
+  // --- content {path, hash} — always present; the content file's integrity ----
+  const content = manifest.content;
+  if (!isPlainObject(content) || typeof content.path !== 'string' || typeof content.hash !== 'string') {
+    throw new CanonicalizationError('manifest.content must be an object with string path and hash');
+  }
+  if (!isValidContentHash(content.hash)) {
+    throw new CanonicalizationError(`manifest.content.hash "${content.hash}" is malformed`);
+  }
+  projection.content = { path: content.path, hash: content.hash };
+
+  // --- presentation[] (optional) — the presentation *declaration* -------------
+  // Binds each presentation manifest's {type, path, hash} plus which one is the
+  // default. This authenticates the manifest's selection of presentation parts;
+  // it does NOT attest visual rendering (precise-layout attestation remains the
+  // separate `scope.layouts` mechanism). The array is author-ordered, so it is
+  // sorted by JCS to a canonical order; the default-selection is bound as a flag
+  // present only on the default entry (no default-value materialization).
+  const presentation = manifest.presentation;
+  if (Array.isArray(presentation) && presentation.length > 0) {
+    const items = presentation.map((entry) => {
+      if (!isPlainObject(entry) || typeof entry.type !== 'string' || typeof entry.path !== 'string' || typeof entry.hash !== 'string') {
+        throw new CanonicalizationError('each manifest.presentation[] entry must have string type, path and hash');
+      }
+      if (!isValidContentHash(entry.hash)) {
+        throw new CanonicalizationError(`presentation "${entry.path}" has a malformed hash "${entry.hash}"`);
+      }
+      const projected: Record<string, unknown> = { type: entry.type, path: entry.path, hash: entry.hash };
+      if (entry.default === true) projected.default = true;
+      return projected;
+    });
+    items.sort(byJcs);
+    for (let i = 1; i < items.length; i++) {
+      if (jcsOf(items[i]) === jcsOf(items[i - 1])) {
+        throw new CanonicalizationError('duplicate manifest.presentation[] entry');
+      }
+    }
+    projection.presentation = items;
+  }
+
+  // --- extensions[] (optional) — the required-extension set -------------------
+  // Binds {id, version, required}. `config` is bound only for a *required*
+  // extension: a required extension's configuration can change how the document
+  // is interpreted, so it is part of what a signature must attest; a
+  // non-required extension's config is advisory and left out.
+  const extensions = manifest.extensions;
+  if (Array.isArray(extensions) && extensions.length > 0) {
+    const seen = new Set<string>();
+    const items = extensions.map((entry) => {
+      if (!isPlainObject(entry) || typeof entry.id !== 'string' || typeof entry.version !== 'string' || typeof entry.required !== 'boolean') {
+        throw new CanonicalizationError('each manifest.extensions[] entry must have a string id, string version and boolean required');
+      }
+      if (seen.has(entry.id)) {
+        throw new CanonicalizationError(`duplicate extension id "${entry.id}"`);
+      }
+      seen.add(entry.id);
+      const projected: Record<string, unknown> = { id: entry.id, version: entry.version, required: entry.required };
+      if (entry.required === true && entry.config !== undefined) {
+        projected.config = entry.config; // semantics-affecting config of a required extension
+      }
+      return projected;
+    });
+    items.sort(byJcs);
+    projection.extensions = items;
+  }
+
+  // --- lineage (optional) — bound verbatim -----------------------------------
+  // The whole lineage object (parent, ancestors, version, depth, branch,
+  // mergedFrom, note) is security-relevant provenance, so it is bound as
+  // authored. Explicit `null` (e.g. `parent: null`) is preserved; an absent
+  // lineage is omitted (absent ≠ a present lineage with null fields).
+  if (manifest.lineage !== undefined && manifest.lineage !== null) {
+    if (!isPlainObject(manifest.lineage)) {
+      throw new CanonicalizationError('manifest.lineage must be an object');
+    }
+    projection.lineage = manifest.lineage;
+  }
+
+  // The projected bytes obey the same stored-byte invariants as the document ID
+  // (NFC, well-formed Unicode, safe integers) — validate, never normalize.
+  validateStoredByteInvariants(projection);
+
+  return projection;
+}
+
+/** Serialize a projection to its canonical RFC 8785 (JCS) bytes — the signable form. */
+export function serializeProjection(projection: unknown): string {
+  return jcsOf(projection);
+}
+
+/**
+ * Convenience: project `manifest.json` text straight to its canonical JCS bytes.
+ */
+export function projectManifestToJcs(manifestText: string): string {
+  return serializeProjection(projectManifest(manifestText));
+}

--- a/scripts/lib/signature-state.ts
+++ b/scripts/lib/signature-state.ts
@@ -1,0 +1,98 @@
+/**
+ * Reference signature-state evaluator for the CDX security extension
+ * (Security Extension §3.8). This turns the `signatureState` vocabulary
+ * (`valid|invalid|expired|revoked|untrusted|unknown`) from a meaning table into
+ * executable **production rules**.
+ *
+ * It is a pure function of the ABSTRACT verdicts a real verifier computes — it
+ * runs no PKI itself (no chain building, no trust store, no OCSP). A spec-repo
+ * gate cannot run real PKI; what it CAN do is pin, once and unambiguously, how a
+ * conformant verifier must combine those verdicts into a state, so two
+ * implementations cannot disagree on the outcome given the same observations.
+ *
+ * The inputs are bound to observable facts by the normative *derivation rules*
+ * in §3.9 (trust anchoring) and §7.4 (revocation), which are the load-bearing
+ * half of the contract: e.g. a chain with no path to a configured trust anchor
+ * (including a self-signed chain) yields `chainResult: 'untrusted'`, and under an
+ * untrusted reference clock a *stapled* revocation response yields
+ * `revocationStatus: 'unknown'`.
+ */
+
+export type SignatureState = 'valid' | 'invalid' | 'expired' | 'revoked' | 'untrusted' | 'unknown';
+
+export interface SignatureStateInputs {
+  /**
+   * The signed protected header is well-formed and self-consistent: `alg` is
+   * supported, `b64` is false, `crit` is exactly `["b64"]`, `x5c` is present, the
+   * signed `x5t#S256` equals BASE64URL(SHA-256(DER(x5c[0]))), and `sigT` is
+   * well-formed and not in the future relative to the reference time (§3.10).
+   */
+  headerConsistent: boolean;
+  /** The JWS signature verifies under the public key of the leaf certificate x5c[0]. */
+  signatureVerifies: boolean;
+  /**
+   * The result of validating the x5c chain against the verifier-configured trust
+   * store (§3.9): `anchored` (a path to a configured anchor), `untrusted` (no such
+   * path — including self-signed), or `unknown` (the chain could not be evaluated).
+   */
+  chainResult: 'anchored' | 'untrusted' | 'unknown';
+  /**
+   * Certificate revocation status (§7.4): `good`, `revoked`, or `unknown`
+   * (indeterminate — e.g. an unreachable responder, or a stapled response whose
+   * freshness cannot be established under an untrusted clock).
+   */
+  revocationStatus: 'good' | 'revoked' | 'unknown';
+  /** The reference time (a validated timestamp if present, else `sigT`) lies within [notBefore, notAfter]. */
+  signingTimeWithinValidity: boolean;
+  /** The certificate is expired relative to the verification-time clock (now > notAfter). */
+  certCurrentlyExpired: boolean;
+  /**
+   * The reference time came from a validated trusted timestamp rather than the
+   * self-asserted `sigT`. Always false until timestamp validation is specified
+   * (a later increment); a forward-compatible hook.
+   */
+  referenceTimeTrusted: boolean;
+}
+
+/**
+ * Evaluate a single signature's state (§3.8). The result is per-signature and
+ * carries NO meaning about the completeness of the signature set (anti-strip /
+ * anti-downgrade is a separate, later concern).
+ *
+ * Precedence (first match wins):
+ *  1. bad header or non-verifying signature                          → invalid
+ *  2. signed outside the cert's validity, provable via trusted time  → invalid
+ *  3. chain could not be evaluated                                   → unknown
+ *  4. chain does not anchor to a trust store                         → untrusted
+ *  5. certificate revoked                                            → revoked
+ *  6. revocation indeterminate                                       → unknown
+ *  7. certificate expired at verification time                       → expired
+ *  8. otherwise                                                      → valid
+ */
+export function evaluateSignatureState(i: SignatureStateInputs): SignatureState {
+  // The signature itself must be a real, well-formed signature before anything
+  // about trust is meaningful — a forged/corrupt signature is `invalid`, never
+  // merely `untrusted`.
+  if (!i.headerConsistent || !i.signatureVerifies) return 'invalid';
+
+  // Signed outside the certificate's own lifetime, and a trusted clock proves
+  // it: the signature was never legitimately produced. (Cannot fire until a
+  // validated-timestamp path exists, since reference time is otherwise untrusted.)
+  if (i.referenceTimeTrusted && !i.signingTimeWithinValidity) return 'invalid';
+
+  // Trust path. Revocation is only meaningful relative to an anchored chain, so
+  // an unevaluable or unanchored chain is decided here, before revocation.
+  if (i.chainResult === 'unknown') return 'unknown';
+  if (i.chainResult === 'untrusted') return 'untrusted';
+
+  // Revocation (chain is anchored). `unknown` MUST NOT be reported as `valid`.
+  if (i.revocationStatus === 'revoked') return 'revoked';
+  if (i.revocationStatus === 'unknown') return 'unknown';
+
+  // Validity window. A currently-expired (but legitimately-signed) certificate is
+  // `expired`; a validated timestamp — specified later — is what would let a
+  // richer profile keep this `valid`.
+  if (i.certCurrentlyExpired) return 'expired';
+
+  return 'valid';
+}

--- a/spec/core/07-state-machine.md
+++ b/spec/core/07-state-machine.md
@@ -287,20 +287,22 @@ Frozen documents can accumulate signatures without changing content:
 {
   "signatures": [
     {
-      "signedAt": "2025-01-10T08:00:00Z",
-      "signer": "Alice",
-      "documentId": "sha256:abc123..."
+      "id": "sig-1",
+      "protected": "eyJhbGci...",
+      "signature": "MEUCIQ...",
+      "scope": { "documentId": "sha256:abc123..." }
     },
     {
-      "signedAt": "2025-01-11T14:00:00Z",
-      "signer": "Bob",
-      "documentId": "sha256:abc123..."
+      "id": "sig-2",
+      "protected": "eyJhbGci...",
+      "signature": "MGQCMA...",
+      "scope": { "documentId": "sha256:abc123..." }
     }
   ]
 }
 ```
 
-All signatures reference the same document ID.
+All signatures reference the same document ID. See the Security Extension §3.3 for the signature envelope.
 
 ## 7. Annotation Layer
 

--- a/spec/extensions/security/README.md
+++ b/spec/extensions/security/README.md
@@ -88,7 +88,7 @@ This is a JWS profiled toward **JAdES** ([ETSI TS 119 182-1](https://www.etsi.or
 }
 ```
 
-> **Trust model status.** This version specifies the signature **envelope** only — the structure of the signed bytes. It does **not** yet specify a trust model (trust anchor, certificate-chain validation, revocation, or signature verification). A verifier MUST NOT report a signature as `valid` on the basis of this section alone; the trust model is specified in a subsequent version.
+> **Trust model status.** The X.509 certificate-chain trust model is specified in sections 3.7–3.10 and 7.4: a verifier validates the `x5c` chain to a verifier-configured trust store, checks revocation and validity, and assigns a state (section 3.8). The `keyId` and WebAuthn credential paths, and timestamp-based long-term validation, are specified in subsequent versions.
 
 ### 3.4 Signature Entry Fields
 
@@ -108,7 +108,7 @@ This is a JWS profiled toward **JAdES** ([ETSI TS 119 182-1](https://www.etsi.or
 | `alg` | Yes | Signature algorithm (section 3.2) |
 | `b64` | Yes | MUST be `false` — the payload is unencoded (RFC 7797) |
 | `crit` | Yes | MUST be exactly `["b64"]` (a registered parameter such as `sigT` MUST NOT appear here) |
-| `x5c` | Yes | Signing certificate chain, base64 DER, leaf-first |
+| `x5c` | Yes | Signing certificate chain — standard base64 (RFC 4648 §4, padded; not base64url) of each certificate's DER, leaf-first |
 | `x5t#S256` | Yes | base64url SHA-256 thumbprint of the signing certificate |
 | `sigT` | Yes | Signing time (ISO 8601 UTC), replacing the former unsigned `signedAt` |
 
@@ -151,27 +151,55 @@ For non-repudiation, signatures can include trusted timestamps:
 
 ### 3.7 Signature Verification
 
-To verify a signature:
+To verify a signature and assign it a state (section 3.8):
 
 1. Extract the document ID from the manifest and recompute it from the content (integrity)
 2. If the document state is `frozen` or `published`, require that every signature covers the manifest projection (Section 9.8); reject the document otherwise
-3. For each signature:
-   a. Decode the `protected` header and check its shape (section 3.4): `alg` supported, `b64` false, `crit` exactly `["b64"]`, and `x5c`/`x5t#S256`/`sigT` present
-   b. Reconstruct the detached payload as `JCS(scope)` from the `scope` member, and the signing input as `protected + "." + JCS(scope)`
-   c. Verify `scope.documentId` matches the top-level `documentId`, and when `scope.manifest`/`scope.layouts` are present perform the scoped checks (section 9.5)
-   d. **Trust evaluation — deferred.** Validating the `x5c` chain to a trust anchor, checking certificate validity and revocation, and verifying the JWS signature against the certified key are specified in a subsequent version. Until then a verifier MUST NOT report a signature as `valid`
-4. Report verification results
+3. For each signature, compute the inputs to the state rules:
+   a. **Header consistency.** Decode the `protected` header and check (section 3.4): `alg` supported; `b64` false; `crit` exactly `["b64"]`; `x5c` present; the signed `x5t#S256` equals the leaf-certificate thumbprint (section 3.10); and `sigT` well-formed and not after the reference time. A failure makes the state `invalid`
+   b. **Signature.** Reconstruct the detached payload as `JCS(scope)` from the `scope` member and the signing input as `protected + "." + JCS(scope)`; verify the JWS signature under the public key of the leaf certificate `x5c[0]`. A failure makes the state `invalid`
+   c. **Scope.** Verify `scope.documentId` matches the top-level `documentId`, and when `scope.manifest`/`scope.layouts` are present perform the scoped checks (section 9.5)
+   d. **Trust path.** Validate the `x5c` chain against the verifier's trust store (section 3.9), yielding `anchored`, `untrusted`, or `unknown`
+   e. **Revocation and validity.** Determine the certificate's revocation status and validity window (section 7.4)
+4. Combine these inputs into a state using the production rules of section 3.8, and report it
+
+This per-signature state carries no meaning about the completeness of the signature *set*; detecting a stripped or downgraded set is a separate, later concern (Section 9.8).
 
 ### 3.8 Signature States
 
-| State | Meaning |
-|-------|---------|
-| `valid` | Signature verifies, certificate valid |
-| `invalid` | Signature does not verify |
-| `expired` | Certificate has expired |
-| `revoked` | Certificate has been revoked |
-| `untrusted` | Certificate chain not trusted |
-| `unknown` | Cannot determine validity |
+A verifier MUST assign each signature exactly one state. The inputs are the verdicts computed in section 3.7 step 3; each is bound to an observable fact by the derivation rules in sections 3.9 (trust path) and 7.4 (revocation).
+
+**Production rules (first match wins):**
+
+| # | Condition | State |
+|---|-----------|-------|
+| 1 | Header inconsistent, or the signature does not verify under `x5c[0]` | `invalid` |
+| 2 | A trusted timestamp shows the certificate was outside its validity when it signed | `invalid` |
+| 3 | The chain could not be evaluated | `unknown` |
+| 4 | The chain does not anchor to the trust store | `untrusted` |
+| 5 | The certificate is revoked | `revoked` |
+| 6 | Revocation could not be determined | `unknown` |
+| 7 | The certificate is expired at verification time | `expired` |
+| 8 | Otherwise | `valid` |
+
+A verifier MUST NOT report `valid` for a signature whose chain does not anchor (`untrusted`) or whose revocation could not be confirmed (`unknown`). For any security decision a verifier MUST treat `unknown` as non-acceptance — no weaker than `untrusted` — and MUST NOT fail open. Because the `x5c` chain and any stapled revocation material are document-supplied, their incompleteness MUST NOT downgrade an otherwise-determinable adverse verdict: a verifier SHOULD obtain the missing material independently (fetch the intermediate, query the issuer's OCSP/CRL) rather than let a withheld intermediate or omitted revocation response turn a `revoked` or `untrusted` ground truth into a softer `unknown`.
+
+Rule 2 cannot fire until timestamp validation is specified (a subsequent version): until then the reference time is the self-asserted `sigT`, which is untrusted, so a `sigT` falling outside the certificate validity window is ignored rather than taken as proof of out-of-window signing. While the reference time is untrusted, a verifier MUST NOT present `sigT` as an attested signing time, and SHOULD warn when a signature reports `valid` yet its asserted `sigT` falls outside the certificate validity window.
+
+### 3.9 Trust Anchors
+
+A signature is trustworthy only relative to a **trust anchor the verifier configures** — never material supplied by the document. The only certificate material in the archive is the `x5c` chain in the (attacker-controllable) signature itself; treating it as self-authorizing is the defeat this section closes: otherwise an attacker self-signs a certificate naming any subject, signs the genuine content, and a verifier reports `valid`.
+
+- A verifier MUST validate the `x5c` chain (leaf `x5c[0]` to a root) against a **verifier-configured trust store** — a set of trusted root certificates, or an equivalent trusted-list policy — supplied by the verifier's deployment. The trust store MUST NOT be derived from the document.
+- **Derivation rule (normative).** If the chain has a valid path to a configured anchor, `chainResult` is `anchored`. If it has no such path — including a self-signed certificate, or a chain rooted at an untrusted CA — `chainResult` is `untrusted`. If the path cannot be evaluated (e.g. a required intermediate is unavailable), `chainResult` is `unknown`.
+- A document MAY carry a trust-policy hint, but it is advisory: the authoritative anchor is always verifier-side.
+
+### 3.10 Identity Authority
+
+The authoritative signer identity is the **subject** (and subject-alternative names) of the validated leaf certificate `x5c[0]` — not any document-supplied field.
+
+- A verifier MUST NOT treat `signer.name`, `signer.email`, or any other `signer` field as authenticated, and MUST NOT present them as the signer's identity in preference to the certificate subject. (Forging `signer.name` is otherwise free.)
+- The signing certificate is already bound by the signature: `x5c` is part of the signed protected header (section 3.4), so substituting any certificate changes the signing input and breaks verification (rule 1). The header additionally carries `x5t#S256`, which MUST equal `BASE64URL(SHA-256(DER(x5c[0])))` — the unpadded base64url SHA-256 of the DER bytes `x5c[0]` decodes to — as a JAdES-conformant, fail-fast consistency check identifying the leaf certificate. A verifier MUST reject (`invalid`) a signature whose `x5t#S256` does not match `x5c[0]`.
 
 ## 4. Encryption
 
@@ -349,12 +377,19 @@ Recommendations:
 - Support multiple valid certificates during rotation
 - Maintain audit trail of key changes
 
-### 7.4 Revocation
+### 7.4 Revocation and Validity (Verifier Obligations)
 
-If a signing key is compromised:
+For the signing-key owner, if a key is compromised:
 1. Revoke the certificate (publish to CRL or OCSP)
-2. Re-sign documents with new key if needed
-3. Document the revocation in audit trail
+2. Re-sign documents with a new key if needed
+3. Record the revocation in the audit trail
+
+A **verifier** MUST, for each signature — this is what makes revocation meaningful (section 3.8):
+- Check the certificate validity window; the certificate is expired when the verification-time clock is past `notAfter`.
+- Determine revocation status via OCSP or a CRL — online against the issuing CA, or from revocation material stapled with the signature — yielding `good`, `revoked`, or `unknown`.
+- **Derivation rule (normative).** A `good`/`revoked` determination requires a trusted assessment time. Until timestamp validation is specified, the reference time is the untrusted `sigT`, so a **stapled** OCSP/CRL response — whose freshness window cannot then be established — MUST be treated as `unknown`, never `good`. An online check against a live responder (which carries its own trusted clock) MAY yield `good`/`revoked`.
+
+A verifier that cannot perform these checks MUST NOT report `valid` (section 3.8). Long-term validation — verifying offline after the certificate expires, using stapled revocation material bound to a validated timestamp — is specified in a subsequent version.
 
 ## 8. Security Considerations
 
@@ -378,6 +413,14 @@ Implementations MUST use constant-time comparison for cryptographic operations.
 ### 8.4 Side-Channel Attacks
 
 Use well-audited cryptographic libraries that protect against side-channel attacks.
+
+### 8.5 Trust Model Scope and Limits
+
+This extension specifies an **X.509 trust model**: a signature is trustworthy only if its `x5c` chain validates to a verifier-configured trust store (section 3.9). The format is *aligned* with the JAdES/eIDAS model but is **not** CMS/PAdES wire-conformant — it does not interoperate with PDF signature verifiers, and the signer-identity, algorithm, and certificate bindings are enforced as **verifier obligations** (sections 3.7–3.10), not as signed CMS attributes.
+
+The conformance gates in this repository check the *structure* of signatures and the *production rules* that map verification verdicts to states (section 3.8); they cannot, and do not, execute a real trust store, certificate-path validation, or revocation lookup. Those are normative obligations a conforming verifier MUST perform and that an external conformance suite can target. A green build does not certify cryptographic verification.
+
+Each signature's state is **per-signature**: it does not attest that the signature *set* is complete. An attacker may still strip or downgrade signatures; binding the set against that is a subsequent version.
 
 ## 9. Scoped Signatures
 

--- a/spec/extensions/security/README.md
+++ b/spec/extensions/security/README.md
@@ -36,16 +36,19 @@ To use this extension, declare it in the manifest:
 
 ### 3.1 Signature Model
 
-Signatures bind to the document ID (content hash), not the raw file bytes:
+A signature covers an explicit, signed **scope** of what it attests. The scope always binds the document ID (the content hash); a scoped signature additionally binds the **manifest projection** (Section 9.7) and/or precise-layout hashes (Section 9.3):
 
 ```
-Signature = Sign(PrivateKey, DocumentID)
+content-only:   Signature = Sign(PrivateKey, DocumentID)
+scoped:         Signature = Sign(PrivateKey, JCS(scope))
 ```
 
 This means:
 - Signatures verify document content integrity
 - Multiple signatures can attest to the same content
 - Re-packaging doesn't invalidate signatures (only content changes do)
+
+The document ID binds the document's semantic content only. It does **not** bind the rest of the manifest — the lifecycle state, the content and presentation part hashes, the required-extension set, or the lineage — so a content-only signature leaves those unauthenticated. To authenticate them, a signature covers the **manifest projection** (Section 9.7). A signature on a `frozen` or `published` document MUST cover the manifest projection (Section 9.8).
 
 ### 3.2 Supported Algorithms
 
@@ -141,13 +144,14 @@ To verify a signature:
 
 1. Extract document ID from manifest
 2. Recompute document ID from content (verify integrity)
-3. For each signature:
+3. If the document state is `frozen` or `published`, require that every signature covers the manifest projection (Section 9.8); reject the document otherwise
+4. For each signature:
    a. Decode the signature value
    b. If `scope` is absent: verify signature over document ID using signer's public key
-   c. If `scope` is present: verify using scoped signature algorithm (see section 9.5)
+   c. If `scope` is present: verify using the scoped signature algorithm (see section 9.5), which recomputes and checks the manifest projection when `scope.manifest` is present
    d. If certificate present, validate certificate chain
    e. If timestamp present, verify timestamp token
-4. Report verification results
+5. Report verification results
 
 ### 3.8 Signature States
 
@@ -415,9 +419,10 @@ The `scope` object is serialized using JCS ([RFC 8785](https://www.rfc-editor.or
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `documentId` | string | Yes | Content hash (MUST match top-level `documentId`) |
+| `manifest` | object | Conditional | The manifest projection (Section 9.7). REQUIRED on a `frozen` or `published` document; otherwise optional. |
 | `layouts` | object | No | Map of layout path → layout file hash. Attests visual appearance. |
 
-The `scope` object is extensible — future fields can be added (e.g., `metadata`, `assets`) without breaking existing signatures.
+The `scope` object is **closed**: it is validated with `additionalProperties: false`, and a verifier MUST reject a scope carrying any member not defined here. New scope members may be introduced in future versions of this extension, but because the signature is computed over `JCS(scope)`, a signature's covered set is fixed at signing time — adding a member changes the signed bytes, so it does not retroactively extend a signature made before the member existed.
 
 ### 9.5 Verification Algorithm for Scoped Signatures
 
@@ -426,13 +431,68 @@ The verification algorithm (section 3.7) is extended to handle both legacy and s
 1. If `scope` is absent: `Verify(PublicKey, value, documentId)` — legacy content-only verification
 2. If `scope` is present:
    a. Verify `scope.documentId` matches top-level `documentId`
-   b. If `scope.layouts` is present, verify each layout path exists and its file hash matches the declared hash
-   c. Serialize `scope` with JCS
-   d. `Verify(PublicKey, value, JCS(scope))`
+   b. If `scope.manifest` is present, recompute the manifest projection from `manifest.json` (Section 9.7) and verify it equals `scope.manifest`
+   c. If `scope.layouts` is present, verify each layout path exists and its file hash matches the declared hash
+   d. Serialize `scope` with JCS
+   e. `Verify(PublicKey, value, JCS(scope))`
 
 ### 9.6 Use Case
 
 In legal contexts, a notary signs with `scope` including the letter layout, attesting: "I certify this content rendered in this exact layout." Another signer might sign content-only if appearance is not relevant to their attestation.
+
+### 9.7 Manifest Projection
+
+The document ID binds only the document's semantic content. The rest of the manifest — the lifecycle state, the content and presentation part hashes, the required-extension set, and the lineage — is otherwise unauthenticated. The **manifest projection** is the canonical, signable representation of those security-relevant manifest declarations; a signature attests them by including the projection as `scope.manifest`.
+
+The projection is a deterministic transform of `manifest.json`, serialized with JCS ([RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)) — the same canonicalization the document ID uses — so a signer and a verifier compute identical bytes. It is defined only once the document ID is fixed; a manifest whose `id` is `pending` (a draft) has no projection.
+
+**Bound fields:**
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `cdx` | `manifest.cdx` | Specification version (prevents a silent version downgrade) |
+| `state` | `manifest.state` | Lifecycle state |
+| `content` | `manifest.content` | Projected to `{path, hash}` |
+| `presentation` | `manifest.presentation[]` | Each entry projected to `{type, path, hash}`; the default entry additionally carries `default: true`. Binds the presentation *declaration* (which parts, which is default), not visual rendering — visual attestation remains `scope.layouts` (Section 9.3) |
+| `extensions` | `manifest.extensions[]` | Each entry projected to `{id, version, required}`; a required extension additionally carries its `config` |
+| `lineage` | `manifest.lineage` | Bound verbatim |
+
+**Construction rules** (mirroring the document-ID canonical form, 06 §4.3):
+
+- Absent or empty optional fields (`presentation`, `extensions`, `lineage`) are omitted, never materialized as `null` or `[]`.
+- An explicit `null` (e.g. `lineage.parent: null`) is preserved.
+- A non-default presentation carries no `default` member; the flag marks only the default entry (`default: false` is never materialized).
+- A non-required extension's `config` is omitted; a required extension's `config` is bound, because a required extension's configuration can change how the document is interpreted.
+- Arrays of declarations (`presentation`, `extensions`) are sorted by the JCS serialization of each element, so authored order is not significant; the `lineage.ancestors` order (nearest-first) is significant and preserved.
+- Keys and values obey the stored-byte invariants of 06 §4.3.2 (NFC, well-formed Unicode, safe integers).
+
+The document ID is **not** part of the projection — it is carried separately by `scope.documentId`, which a verifier already cross-checks against the top-level `documentId`.
+
+### 9.8 Coverage and Negative Coverage
+
+A signature's coverage is exactly:
+
+- The **document ID** (semantic content) — always.
+- The **manifest projection** (Section 9.7) — if and only if `scope.manifest` is present.
+- The listed **precise layouts** — if and only if `scope.layouts` is present (Section 9.3).
+
+A signature does **not** cover, in this version of the extension:
+
+- Embedded **fonts** and other non-content assets (excluded from the document ID by design).
+- The **bytes** of parts the manifest references by path only — metadata, provenance, phantoms, annotations — and of the `security` block. Only `content` and `presentation[]` carry hashes in the manifest and are bound by the projection.
+- The **set of signatures** itself: a signature cannot attest that another signature has not been removed, added, or downgraded.
+- Administrative fields with no integrity meaning: `created`, `modified`, and `hashAlgorithm` (redundant with the document-ID prefix).
+- Auxiliary `content` integrity fields (`compression`, `merkleRoot`, `blockCount`) and the advisory `presentation[]` fields (`contentHash`, `generated`): the bound `content.hash` and `presentation[].hash` are authoritative, so these subordinate fields are not separately attested.
+- A **non-required** extension's `config` (only a required extension's `config` is bound, Section 9.7), and **any manifest member not enumerated in Section 9.7**: the manifest's top-level object is not closed, so an unrecognized member is dropped from the projection rather than signed.
+
+Implementations MUST NOT represent a signature as covering anything beyond the above.
+
+**Coverage requirement.** Because a content-only signature leaves the manifest unauthenticated, the manifest projection is mandatory wherever the manifest is final:
+
+- For a document in state `frozen` or `published`, every signature MUST include `scope.manifest`, and a verifier MUST reject the document if any signature omits it.
+- For a document in state `draft` or `review`, a signature MAY be content-only; such a signature does not attest the manifest, and an implementation MUST surface that limitation rather than implying manifest coverage.
+
+> **Lifecycle downgrade.** A content-only signature binds neither the lifecycle state nor any other manifest field, so it cannot establish that a document was not `frozen` or `published`. An attacker can take a frozen document, rewrite its manifest (including `state`), and present only a content-only signature over the unchanged content. A verifier MUST NOT represent a document's state — or any manifest field — as authenticated on the strength of a content-only signature, and SHOULD warn when a document is presented this way. Binding the signature set against stripping and downgrade is addressed in a later increment.
 
 ## 10. Examples
 

--- a/spec/extensions/security/README.md
+++ b/spec/extensions/security/README.md
@@ -36,11 +36,10 @@ To use this extension, declare it in the manifest:
 
 ### 3.1 Signature Model
 
-A signature covers an explicit, signed **scope** of what it attests. The scope always binds the document ID (the content hash); a scoped signature additionally binds the **manifest projection** (Section 9.7) and/or precise-layout hashes (Section 9.3):
+A signature covers an explicit, signed **scope** of what it attests. The scope always binds the document ID (the content hash); a scoped signature additionally binds the **manifest projection** (Section 9.7) and/or precise-layout hashes (Section 9.3). A signature is a detached JWS (Section 3.3) over the canonical bytes of that scope:
 
 ```
-content-only:   Signature = Sign(PrivateKey, DocumentID)
-scoped:         Signature = Sign(PrivateKey, JCS(scope))
+Signature = JWS(signing key, JCS(scope))      // scope.documentId is always present
 ```
 
 This means:
@@ -66,6 +65,10 @@ Implementations MUST support ES256. Support for other algorithms is RECOMMENDED.
 
 Location: `security/signatures.json`
 
+Each signature is a **detached JWS** ([RFC 7515](https://www.rfc-editor.org/rfc/rfc7515), JSON Serialization) with an **unencoded** payload ([RFC 7797](https://www.rfc-editor.org/rfc/rfc7797), `b64:false`). The signed payload is `JCS(scope)`; the readable `scope` object is carried as a sibling member and is reconstructed — not stored — as the detached payload (see section 3.4). The signed protected header binds the algorithm, the signing certificate, and the signing time.
+
+This is a JWS profiled toward **JAdES** ([ETSI TS 119 182-1](https://www.etsi.org/standards)); it does not claim a JAdES baseline conformance level. It omits the JAdES `sigD` descriptor: the detached payload is reconstructed as `JCS(scope)` per this section.
+
 ```json
 {
   "version": "0.1",
@@ -73,55 +76,63 @@ Location: `security/signatures.json`
   "signatures": [
     {
       "id": "sig-1",
-      "algorithm": "ES256",
-      "signedAt": "2025-01-15T10:00:00Z",
-      "signer": {
-        "name": "Jane Doe",
-        "email": "jane@example.com",
-        "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+      "protected": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sInNpZ1QiOiIyMDI1Li4uIiwieDVjIjpbIk1JSUIuLi4iXSwieDV0I1MyNTYiOiIuLi4ifQ",
+      "signature": "MEUCIQDf9Ky7...",
+      "scope": {
+        "documentId": "sha256:3a7bd3e2..."
       },
-      "value": "MEUCIQDf9Ky7...",
-      "certificateChain": [...],
-      "timestamp": {...}
+      "signer": { "name": "Jane Doe", "email": "jane@example.com" },
+      "timestamp": {}
     }
   ]
 }
 ```
+
+> **Trust model status.** This version specifies the signature **envelope** only — the structure of the signed bytes. It does **not** yet specify a trust model (trust anchor, certificate-chain validation, revocation, or signature verification). A verifier MUST NOT report a signature as `valid` on the basis of this section alone; the trust model is specified in a subsequent version.
 
 ### 3.4 Signature Entry Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `id` | string | Yes | Unique signature identifier |
-| `algorithm` | string | Yes | Signature algorithm |
-| `signedAt` | string | Yes | ISO 8601 signing timestamp |
-| `signer` | object | Yes | Signer information |
-| `value` | string | Yes | Base64-encoded signature |
-| `certificateChain` | array | No | Certificate chain for validation |
-| `timestamp` | object | No | Trusted timestamp |
-| `scope` | object | No | Scoped signature attestation (see section 9) |
+| `protected` | string | Yes | base64url-encoded signed JWS protected header (see below) |
+| `signature` | string | Yes | base64url-encoded JWS signature |
+| `scope` | object | Yes | The detached payload — what the signature covers (see section 9) |
+| `signer` | object | No | Advisory signer display information (see section 3.5) |
+| `timestamp` | object | No | Advisory trusted timestamp (see section 3.6) |
+
+**Protected header.** The base64url-decoded `protected` member is a JSON object with these parameters:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `alg` | Yes | Signature algorithm (section 3.2) |
+| `b64` | Yes | MUST be `false` — the payload is unencoded (RFC 7797) |
+| `crit` | Yes | MUST be exactly `["b64"]` (a registered parameter such as `sigT` MUST NOT appear here) |
+| `x5c` | Yes | Signing certificate chain, base64 DER, leaf-first |
+| `x5t#S256` | Yes | base64url SHA-256 thumbprint of the signing certificate |
+| `sigT` | Yes | Signing time (ISO 8601 UTC), replacing the former unsigned `signedAt` |
+
+The signature is computed over the **signing input** `BASE64URL(UTF8(protected)) + '.' + JCS(scope)`. The protected header is signed as its exact stored bytes — a verifier MUST use the stored `protected` string and MUST NOT re-serialize the decoded header. The detached payload, by contrast, is recomputed: a verifier MUST derive it as `JCS(scope)` from the `scope` member it displays, so the bytes verified are always the bytes shown.
 
 ### 3.5 Signer Information
+
+The `signer` object carries **advisory** display information only. The authoritative signer identity is the subject of the validated signing certificate (the `x5c` chain in the protected header). A verifier MUST NOT treat these fields as authenticated and MUST NOT elevate `signer.name`/`email` above the certificate subject.
 
 ```json
 {
   "signer": {
     "name": "Jane Doe",
     "email": "jane@example.com",
-    "organization": "Acme Corporation",
-    "certificate": "-----BEGIN CERTIFICATE-----\n...",
-    "keyId": "did:web:example.com:jane"
+    "organization": "Acme Corporation"
   }
 }
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | Yes | Signer's display name |
-| `email` | string | No | Signer's email |
-| `organization` | string | No | Signer's organization |
-| `certificate` | string | No | X.509 certificate (PEM) |
-| `keyId` | string | No | Key identifier (DID, URL, etc.) |
+| `name` | string | Yes | Signer's display name (advisory) |
+| `email` | string | No | Signer's email (advisory) |
+| `organization` | string | No | Signer's organization (advisory) |
 
 ### 3.6 Trusted Timestamps
 
@@ -142,16 +153,14 @@ For non-repudiation, signatures can include trusted timestamps:
 
 To verify a signature:
 
-1. Extract document ID from manifest
-2. Recompute document ID from content (verify integrity)
-3. If the document state is `frozen` or `published`, require that every signature covers the manifest projection (Section 9.8); reject the document otherwise
-4. For each signature:
-   a. Decode the signature value
-   b. If `scope` is absent: verify signature over document ID using signer's public key
-   c. If `scope` is present: verify using the scoped signature algorithm (see section 9.5), which recomputes and checks the manifest projection when `scope.manifest` is present
-   d. If certificate present, validate certificate chain
-   e. If timestamp present, verify timestamp token
-5. Report verification results
+1. Extract the document ID from the manifest and recompute it from the content (integrity)
+2. If the document state is `frozen` or `published`, require that every signature covers the manifest projection (Section 9.8); reject the document otherwise
+3. For each signature:
+   a. Decode the `protected` header and check its shape (section 3.4): `alg` supported, `b64` false, `crit` exactly `["b64"]`, and `x5c`/`x5t#S256`/`sigT` present
+   b. Reconstruct the detached payload as `JCS(scope)` from the `scope` member, and the signing input as `protected + "." + JCS(scope)`
+   c. Verify `scope.documentId` matches the top-level `documentId`, and when `scope.manifest`/`scope.layouts` are present perform the scoped checks (section 9.5)
+   d. **Trust evaluation — deferred.** Validating the `x5c` chain to a trust anchor, checking certificate validity and revocation, and verifying the JWS signature against the certified key are specified in a subsequent version. Until then a verifier MUST NOT report a signature as `valid`
+4. Report verification results
 
 ### 3.8 Signature States
 
@@ -299,6 +308,8 @@ Principals identify who permissions apply to:
 
 Documents can be signed using hardware security keys via WebAuthn.
 
+> **Status: deferred.** WebAuthn signatures are not available in this version. A WebAuthn assertion signs over `authenticatorData || hash(clientDataJSON)` rather than the JWS signing input of Section 3.3, so it cannot produce a scoped (manifest-covering) signature, and it carries no X.509 identity for the trust model. The `webauthn` member has therefore been removed from the signature schema pending a defined WebAuthn trust-and-binding profile in a subsequent version. The structure below is retained for reference only.
+
 ### 6.2 WebAuthn Signature
 
 ```json
@@ -313,9 +324,9 @@ Documents can be signed using hardware security keys via WebAuthn.
 }
 ```
 
-### 6.3 Verification
+### 6.3 Verification (reference only)
 
-WebAuthn signatures are verified using the WebAuthn verification procedure, with the document ID as the challenge.
+When reintroduced, WebAuthn signatures would be verified using the WebAuthn verification procedure. Binding the WebAuthn challenge to the JWS signing input of Section 3.3 — a WebAuthn assertion signs `authenticatorData || hash(clientDataJSON)`, not that input — is the open issue deferred per Section 6.1.
 
 ## 7. Key Management Guidance
 
@@ -372,45 +383,38 @@ Use well-audited cryptographic libraries that protect against side-channel attac
 
 ### 9.1 Overview
 
-By default, signatures cover the document ID (semantic content) only. For use cases that require attesting to visual appearance (e.g., legal documents, notarized contracts), signatures can include an optional `scope` object that makes explicit what the signature covers.
+Every signature carries a `scope` object — the detached JWS payload — that makes explicit what it covers. The minimal scope binds the document ID (semantic content) only; for use cases that require attesting to more (the manifest state, or the visual appearance of legal documents and notarized contracts), the scope additionally binds the manifest projection (Section 9.7) and/or precise-layout hashes.
 
-### 9.2 Content-Only Signature (Default)
+### 9.2 Content-Only Signature
 
-When `scope` is absent, the signature covers semantic content only. This is backward compatible with existing signatures:
+A content-only signature has a `scope` that binds just the document ID:
 
 ```json
 {
   "id": "sig-1",
-  "algorithm": "ES256",
-  "signedAt": "2025-01-15T10:00:00Z",
-  "signer": { "name": "Jane Doe", "email": "jane@example.com" },
-  "value": "MEUCIQDf9Ky7..."
+  "protected": "eyJhbGci...",
+  "signature": "MEUCIQDf9Ky7...",
+  "scope": { "documentId": "sha256:contenthash..." }
 }
 ```
 
-Verification: `Verify(PublicKey, value, DocumentID)`
-
 ### 9.3 Scoped Signature (Content + Layout Attestation)
 
-When `scope` is present, the signature covers both content identity and additional components specified in the scope:
+A scoped signature's `scope` additionally binds the manifest projection and/or precise-layout hashes:
 
 ```json
 {
   "id": "sig-2",
-  "algorithm": "ES256",
-  "signedAt": "2025-01-15T10:00:00Z",
-  "signer": { "name": "Bob Smith", "email": "bob@example.com" },
+  "protected": "eyJhbGci...",
+  "signature": "MEYCIQCa8Bx2...",
   "scope": {
     "documentId": "sha256:contenthash...",
     "layouts": {
       "presentation/layouts/letter.json": "sha256:layouthash..."
     }
-  },
-  "value": "MEYCIQCa8Bx2..."
+  }
 }
 ```
-
-Verification: `Verify(PublicKey, value, JCS(scope))`
 
 The `scope` object is serialized using JCS ([RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)) to produce deterministic bytes for signing.
 
@@ -426,15 +430,12 @@ The `scope` object is **closed**: it is validated with `additionalProperties: fa
 
 ### 9.5 Verification Algorithm for Scoped Signatures
 
-The verification algorithm (section 3.7) is extended to handle both legacy and scoped modes:
+With `scope` always present, the scoped checks extend section 3.7 step 3:
 
-1. If `scope` is absent: `Verify(PublicKey, value, documentId)` — legacy content-only verification
-2. If `scope` is present:
-   a. Verify `scope.documentId` matches top-level `documentId`
+   a. Verify `scope.documentId` matches the top-level `documentId`
    b. If `scope.manifest` is present, recompute the manifest projection from `manifest.json` (Section 9.7) and verify it equals `scope.manifest`
    c. If `scope.layouts` is present, verify each layout path exists and its file hash matches the declared hash
-   d. Serialize `scope` with JCS
-   e. `Verify(PublicKey, value, JCS(scope))`
+   d. The JWS signature is over the signing input `BASE64URL(protected) + "." + JCS(scope)` (section 3.4); the signature's trust evaluation is deferred per section 3.7
 
 ### 9.6 Use Case
 
@@ -492,7 +493,7 @@ Implementations MUST NOT represent a signature as covering anything beyond the a
 - For a document in state `frozen` or `published`, every signature MUST include `scope.manifest`, and a verifier MUST reject the document if any signature omits it.
 - For a document in state `draft` or `review`, a signature MAY be content-only; such a signature does not attest the manifest, and an implementation MUST surface that limitation rather than implying manifest coverage.
 
-> **Lifecycle downgrade.** A content-only signature binds neither the lifecycle state nor any other manifest field, so it cannot establish that a document was not `frozen` or `published`. An attacker can take a frozen document, rewrite its manifest (including `state`), and present only a content-only signature over the unchanged content. A verifier MUST NOT represent a document's state — or any manifest field — as authenticated on the strength of a content-only signature, and SHOULD warn when a document is presented this way. Binding the signature set against stripping and downgrade is addressed in a later increment.
+> **Lifecycle downgrade.** A content-only signature binds neither the lifecycle state nor any other manifest field, so it cannot establish that a document was not `frozen` or `published`. An attacker can take a frozen document, rewrite its manifest (including `state`), and present only a content-only signature over the unchanged content. A verifier MUST NOT represent a document's state — or any manifest field — as authenticated on the strength of a content-only signature, and SHOULD warn when a document is presented this way. The per-signature JWS protected header (Section 3.3) authenticates only that one signature's own algorithm, certificate and time — not the completeness of the signature set, so a stripped or downgraded set is not yet detectable. Binding the signature set against stripping and downgrade is addressed in a later increment.
 
 ## 10. Examples
 
@@ -505,13 +506,10 @@ Implementations MUST NOT represent a signature as covering anything beyond the a
   "signatures": [
     {
       "id": "sig-1",
-      "algorithm": "ES256",
-      "signedAt": "2025-01-15T10:00:00Z",
-      "signer": {
-        "name": "Jane Doe",
-        "email": "jane@example.com"
-      },
-      "value": "MEUCIQDf9Ky7BpL5Rj9E8JH3YqKPvXxNmVhKD5bXc4Qz1A2wAiEA7HjKLm8NoPq..."
+      "protected": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sLi4ufQ",
+      "signature": "MEUCIQDf9Ky7BpL5Rj9E8JH3YqKPvXxNmVhKD5bXc4Qz1A2wAiEA7HjKLm8NoPq...",
+      "scope": { "documentId": "sha256:3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1b" },
+      "signer": { "name": "Jane Doe", "email": "jane@example.com" }
     }
   ]
 }
@@ -526,17 +524,17 @@ Implementations MUST NOT represent a signature as covering anything beyond the a
   "signatures": [
     {
       "id": "sig-1",
-      "algorithm": "ES256",
-      "signedAt": "2025-01-15T10:00:00Z",
-      "signer": { "name": "Author", "email": "author@example.com" },
-      "value": "MEUCIQDf..."
+      "protected": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sLi4ufQ",
+      "signature": "MEUCIQDf...",
+      "scope": { "documentId": "sha256:3a7bd3e2..." },
+      "signer": { "name": "Author", "email": "author@example.com" }
     },
     {
       "id": "sig-2",
-      "algorithm": "ES384",
-      "signedAt": "2025-01-16T14:30:00Z",
-      "signer": { "name": "Approver", "email": "approver@example.com" },
-      "value": "MGQCMA..."
+      "protected": "eyJhbGciOiJFUzM4NCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sLi4ufQ",
+      "signature": "MGQCMA...",
+      "scope": { "documentId": "sha256:3a7bd3e2..." },
+      "signer": { "name": "Approver", "email": "approver@example.com" }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Establishes a real trust model for CDX digital signatures, in three commits:

1. **Sign a canonical manifest projection.** A signature previously bound only the document ID, leaving the rest of the manifest (lifecycle state, part hashes, required-extension set, lineage) unauthenticated. A canonical projection of those declarations is now carried as `scope.manifest` and signed; `frozen`/`published` documents MUST cover it. Closes the unauthenticated-manifest Critical.

2. **Migrate signatures to a detached-JWS envelope.** Each signature is now a detached JWS (RFC 7515 JSON Serialization, RFC 7797 `b64:false`) over `JCS(scope)`, profiled toward JAdES. The signed protected header binds the algorithm, the signing certificate (`x5c`, `x5t#S256`) and the signing time (`sigT`) — all previously unsigned. The keyless `webauthn` path and the unsigned PEM identity fields are removed.

3. **Specify the X.509 trust core.** A verifier-configured trust store (the `x5c` chain MUST anchor to it; document-supplied material is never self-authorizing), identity authority (the certificate subject is authoritative; `signer.*` is advisory), verifier-side revocation and validity obligations, and executable `signatureState` production rules. Closes the no-trust-anchor Critical and the identity/revocation findings.

## What is enforced

New CI gates `check:manifest-projection`, `check:jws-envelope`, `check:trust-state`: known-answer vectors against independent oracles, the JWS signing-input construction, and the signature-state production rules (with a real ES256 sign/verify on an ephemeral key). All existing gates remain green. The gates check structure and the state rules, not real PKI — the certificate-path/trust-store/revocation bindings are normative verifier obligations (see security extension section 8.5).

## Deferred to subsequent changes

keyId/DID and WebAuthn credential paths; anti-strip / signature-set binding; certificate timestamp validation and the long-term-validation container; the secure-practice rewrite of the signed-document example.

## Test plan

- [ ] CI green (schema + example validation, canonicalizer, document-id, manifest-projection, jws-envelope, trust-state, sync/refs/coverage/hash-centralization, tsc, audit)
- [ ] A self-signed certificate evaluates to `untrusted`, not `valid`
- [ ] A `frozen`/`published` signature without `scope.manifest` is rejected