### PR TITLE
Phase 4.1e: close the content block model + wire extension blocks

### DIFF
--- a/examples/semantic-document/content/document.json
+++ b/examples/semantic-document/content/document.json
@@ -178,8 +178,7 @@
     },
     {
       "type": "semantic:bibliography",
-      "style": "apa",
-      "title": null
+      "style": "apa"
     }
   ]
 }

--- a/examples/semantic-document/manifest.json
+++ b/examples/semantic-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:3a93cfd7a4689cb0d32a7c598b8a5c671e3535094d7896f3041b694491f4e6d8",
+  "id": "sha256:c2fd3c181474e1925b99ccacf2a56024eaef5d0b0fc5d44262fff3dbbc5ff6e2",
   "state": "draft",
   "created": "2025-01-28T14:00:00Z",
   "modified": "2025-01-28T14:00:00Z",
@@ -13,7 +13,7 @@
   ],
   "content": {
     "path": "content/document.json",
-    "hash": "sha256:7917426dbaa20e14e72ffb2cc2723117000056de1ee7227120f52fd436e01310"
+    "hash": "sha256:92500a7583caa81dbf668930afc74c01550a6903458360c6ef030518c5e65adb"
   },
   "metadata": {
     "dublinCore": "metadata/dublin-core.json"

--- a/schemas/academic.schema.json
+++ b/schemas/academic.schema.json
@@ -5,33 +5,41 @@
   "description": "Schema for academic extension blocks and marks in a CDX document",
   "$defs": {
     "abstractBlock": {
-      "type": "object",
-      "description": "Abstract block for papers and reports",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "academic:abstract" },
-        "children": {
-          "type": "array",
-          "description": "Abstract content (paragraph blocks)"
-        },
-        "keywords": {
-          "type": "array",
-          "description": "List of keywords/key phrases",
-          "items": { "type": "string" }
-        },
-        "sections": {
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
           "type": "object",
-          "description": "Structured abstract sections",
-          "additionalProperties": {
-            "type": "array",
-            "description": "Section content (paragraph blocks)"
-          }
+          "description": "Abstract block for papers and reports",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "academic:abstract" },
+            "children": {
+              "type": "array",
+              "description": "Abstract content (paragraph blocks)",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+            },
+            "keywords": {
+              "type": "array",
+              "description": "List of keywords/key phrases",
+              "items": { "type": "string" }
+            },
+            "sections": {
+              "type": "object",
+              "description": "Structured abstract sections",
+              "additionalProperties": {
+                "type": "array",
+                "description": "Section content (paragraph blocks)",
+                "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+              }
+            }
+          },
+          "oneOf": [
+            { "required": ["children"] },
+            { "required": ["sections"] }
+          ]
         }
-      },
-      "oneOf": [
-        { "required": ["children"] },
-        { "required": ["sections"] }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "theoremVariant": {
       "type": "string",
@@ -96,71 +104,83 @@
       "enum": ["heading1", "heading2", "heading3", "heading4", "heading5", "heading6", "none"]
     },
     "theoremBlock": {
-      "type": "object",
-      "description": "Theorem-like environment block",
-      "required": ["type", "variant", "children"],
-      "properties": {
-        "type": { "const": "academic:theorem" },
-        "variant": {
-          "type": "string",
-          "description": "Variant name (built-in or custom)"
-        },
-        "id": {
-          "type": "string",
-          "description": "Unique identifier for cross-referencing"
-        },
-        "number": {
-          "type": "string",
-          "description": "Explicit number (e.g., '2.3.8')"
-        },
-        "numbering": {
-          "type": "string",
-          "description": "Numbering mode",
-          "enum": ["auto", "none"]
-        },
-        "title": {
-          "type": "string",
-          "description": "Custom title (e.g., 'Maximum Principle')"
-        },
-        "uses": {
-          "type": "array",
-          "description": "Content Anchor URIs of dependencies",
-          "items": { "type": "string" }
-        },
-        "restate": {
-          "type": "boolean",
-          "description": "If true, this is a restatement of a previously stated theorem",
-          "default": false
-        },
-        "children": {
-          "type": "array",
-          "description": "Theorem content blocks"
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Theorem-like environment block",
+          "required": ["type", "variant", "children"],
+          "properties": {
+            "type": { "const": "academic:theorem" },
+            "variant": {
+              "type": "string",
+              "description": "Variant name (built-in or custom)"
+            },
+            "id": {
+              "type": "string",
+              "description": "Unique identifier for cross-referencing"
+            },
+            "number": {
+              "type": "string",
+              "description": "Explicit number (e.g., '2.3.8')"
+            },
+            "numbering": {
+              "type": "string",
+              "description": "Numbering mode",
+              "enum": ["auto", "none"]
+            },
+            "title": {
+              "type": "string",
+              "description": "Custom title (e.g., 'Maximum Principle')"
+            },
+            "uses": {
+              "type": "array",
+              "description": "Content Anchor URIs of dependencies",
+              "items": { "type": "string" }
+            },
+            "restate": {
+              "type": "boolean",
+              "description": "If true, this is a restatement of a previously stated theorem",
+              "default": false
+            },
+            "children": {
+              "type": "array",
+              "description": "Theorem content blocks",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "proofBlock": {
-      "type": "object",
-      "description": "Proof block",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "academic:proof" },
-        "of": {
-          "type": "string",
-          "description": "Content Anchor URI to the theorem being proved"
-        },
-        "title": {
-          "type": "string",
-          "description": "Override title (default: 'Proof')"
-        },
-        "method": { "$ref": "#/$defs/proofMethod" },
-        "qed": { "$ref": "#/$defs/qedStyle" },
-        "children": {
-          "type": "array",
-          "description": "Proof content blocks"
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Proof block",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "academic:proof" },
+            "of": {
+              "type": "string",
+              "description": "Content Anchor URI to the theorem being proved"
+            },
+            "title": {
+              "type": "string",
+              "description": "Override title (default: 'Proof')"
+            },
+            "method": { "$ref": "#/$defs/proofMethod" },
+            "qed": { "$ref": "#/$defs/qedStyle" },
+            "children": {
+              "type": "array",
+              "description": "Proof content blocks",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "solution": {
       "type": "object",
@@ -175,7 +195,8 @@
         },
         "children": {
           "type": "array",
-          "description": "Solution content blocks"
+          "description": "Solution content blocks",
+          "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
         }
       },
       "additionalProperties": false
@@ -191,73 +212,88 @@
         },
         "children": {
           "type": "array",
-          "description": "Part problem statement"
+          "description": "Part problem statement",
+          "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
         },
         "hints": {
           "type": "array",
-          "description": "Part-specific hints"
+          "description": "Part-specific hints",
+          "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
         },
         "solution": { "$ref": "#/$defs/solution" }
       },
       "additionalProperties": false
     },
     "exerciseBlock": {
-      "type": "object",
-      "description": "Exercise/problem block",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "academic:exercise" },
-        "id": {
-          "type": "string",
-          "description": "Unique identifier"
-        },
-        "number": {
-          "type": "string",
-          "description": "Exercise number"
-        },
-        "difficulty": { "$ref": "#/$defs/difficulty" },
-        "children": {
-          "type": "array",
-          "description": "Problem statement (preamble if parts exist)"
-        },
-        "parts": {
-          "type": "array",
-          "description": "Multi-part sub-exercises",
-          "items": { "$ref": "#/$defs/exercisePart" }
-        },
-        "hints": {
-          "type": "array",
-          "description": "Hint paragraphs"
-        },
-        "solution": { "$ref": "#/$defs/solution" }
-      },
-      "additionalProperties": false
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Exercise/problem block",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "academic:exercise" },
+            "id": {
+              "type": "string",
+              "description": "Unique identifier"
+            },
+            "number": {
+              "type": "string",
+              "description": "Exercise number"
+            },
+            "difficulty": { "$ref": "#/$defs/difficulty" },
+            "children": {
+              "type": "array",
+              "description": "Problem statement (preamble if parts exist)",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+            },
+            "parts": {
+              "type": "array",
+              "description": "Multi-part sub-exercises",
+              "items": { "$ref": "#/$defs/exercisePart" }
+            },
+            "hints": {
+              "type": "array",
+              "description": "Hint paragraphs",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+            },
+            "solution": { "$ref": "#/$defs/solution" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
     },
     "exerciseSetBlock": {
-      "type": "object",
-      "description": "Container for grouped exercises with shared context",
-      "required": ["type", "exercises"],
-      "properties": {
-        "type": { "const": "academic:exercise-set" },
-        "id": {
-          "type": "string",
-          "description": "Unique identifier"
-        },
-        "title": {
-          "type": "string",
-          "description": "Set title"
-        },
-        "preamble": {
-          "type": "array",
-          "description": "Shared context/instructions for all exercises"
-        },
-        "exercises": {
-          "type": "array",
-          "description": "Array of exercise blocks",
-          "items": { "$ref": "#/$defs/exerciseBlock" }
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Container for grouped exercises with shared context",
+          "required": ["type", "exercises"],
+          "properties": {
+            "type": { "const": "academic:exercise-set" },
+            "id": {
+              "type": "string",
+              "description": "Unique identifier"
+            },
+            "title": {
+              "type": "string",
+              "description": "Set title"
+            },
+            "preamble": {
+              "type": "array",
+              "description": "Shared context/instructions for all exercises",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+            },
+            "exercises": {
+              "type": "array",
+              "description": "Array of exercise blocks",
+              "items": { "$ref": "#/$defs/exerciseBlock" }
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "equationLine": {
       "type": "object",
@@ -284,23 +320,28 @@
       "additionalProperties": false
     },
     "equationGroupBlock": {
-      "type": "object",
-      "description": "Multi-line equation environment",
-      "required": ["type", "lines"],
-      "properties": {
-        "type": { "const": "academic:equation-group" },
-        "environment": { "$ref": "#/$defs/equationEnvironment" },
-        "id": {
-          "type": "string",
-          "description": "Group identifier"
-        },
-        "lines": {
-          "type": "array",
-          "description": "Array of equation lines",
-          "items": { "$ref": "#/$defs/equationLine" }
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Multi-line equation environment",
+          "required": ["type", "lines"],
+          "properties": {
+            "type": { "const": "academic:equation-group" },
+            "environment": { "$ref": "#/$defs/equationEnvironment" },
+            "id": {
+              "type": "string",
+              "description": "Group identifier"
+            },
+            "lines": {
+              "type": "array",
+              "description": "Array of equation lines",
+              "items": { "$ref": "#/$defs/equationLine" }
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "algorithmParameter": {
       "type": "object",
@@ -345,55 +386,60 @@
       "additionalProperties": false
     },
     "algorithmBlock": {
-      "type": "object",
-      "description": "Algorithm block with line-numbered pseudocode",
-      "required": ["type", "lines"],
-      "properties": {
-        "type": { "const": "academic:algorithm" },
-        "id": {
-          "type": "string",
-          "description": "Unique identifier"
-        },
-        "number": {
-          "type": "string",
-          "description": "Algorithm number"
-        },
-        "title": {
-          "type": "string",
-          "description": "Algorithm name"
-        },
-        "caption": {
-          "type": "string",
-          "description": "Description caption"
-        },
-        "lineNumbering": {
-          "type": "boolean",
-          "description": "Show line numbers",
-          "default": true
-        },
-        "startLine": {
-          "type": "integer",
-          "description": "Starting line number",
-          "minimum": 1,
-          "default": 1
-        },
-        "lines": {
-          "type": "array",
-          "description": "Pseudocode lines",
-          "items": { "$ref": "#/$defs/algorithmLine" }
-        },
-        "inputs": {
-          "type": "array",
-          "description": "Input parameters",
-          "items": { "$ref": "#/$defs/algorithmParameter" }
-        },
-        "outputs": {
-          "type": "array",
-          "description": "Output description",
-          "items": { "$ref": "#/$defs/algorithmParameter" }
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Algorithm block with line-numbered pseudocode",
+          "required": ["type", "lines"],
+          "properties": {
+            "type": { "const": "academic:algorithm" },
+            "id": {
+              "type": "string",
+              "description": "Unique identifier"
+            },
+            "number": {
+              "type": "string",
+              "description": "Algorithm number"
+            },
+            "title": {
+              "type": "string",
+              "description": "Algorithm name"
+            },
+            "caption": {
+              "type": "string",
+              "description": "Description caption"
+            },
+            "lineNumbering": {
+              "type": "boolean",
+              "description": "Show line numbers",
+              "default": true
+            },
+            "startLine": {
+              "type": "integer",
+              "description": "Starting line number",
+              "minimum": 1,
+              "default": 1
+            },
+            "lines": {
+              "type": "array",
+              "description": "Pseudocode lines",
+              "items": { "$ref": "#/$defs/algorithmLine" }
+            },
+            "inputs": {
+              "type": "array",
+              "description": "Input parameters",
+              "items": { "$ref": "#/$defs/algorithmParameter" }
+            },
+            "outputs": {
+              "type": "array",
+              "description": "Output description",
+              "items": { "$ref": "#/$defs/algorithmParameter" }
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "theoremRefMark": {
       "type": "object",

--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -128,8 +128,169 @@
         {
           "if": { "properties": { "type": { "const": "admonition" } } },
           "then": { "$ref": "#/$defs/admonition" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "tableRow" } } },
+          "then": { "$ref": "#/$defs/tableRow" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "tableCell" } } },
+          "then": { "$ref": "#/$defs/tableCell" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "academic:abstract" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/abstractBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "academic:theorem" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/theoremBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "academic:proof" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/proofBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "academic:algorithm" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/algorithmBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "academic:equation-group" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/equationGroupBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "academic:exercise-set" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/exerciseSetBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "academic:exercise" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/exerciseBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "semantic:footnote" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/footnoteBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "semantic:bibliography" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/bibliographyBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "semantic:term" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/termBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "semantic:ref" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/refBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "semantic:glossary" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/glossaryBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "semantic:measurement" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/measurementBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "legal:caption" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/legal.schema.json#/$defs/captionBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "legal:signatureBlock" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/legal.schema.json#/$defs/signatureBlockBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "legal:tableOfAuthorities" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/legal.schema.json#/$defs/tableOfAuthoritiesBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:form" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/formContainer" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:textInput" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/textInputBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:textArea" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/textAreaBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:checkbox" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/checkboxBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:radioGroup" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/radioGroupBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:dropdown" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/dropdownBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:datePicker" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/datePickerBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:signature" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/signatureBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "forms:submit" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/forms.schema.json#/$defs/submitBlock" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "presentation:reference" } } },
+          "then": { "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/presentationReference" }
+        },
+        {
+          "$comment": "Open escape. Known block types are validated strictly by their branch above. An unrecognized type MUST be namespaced (per Content Blocks section 5, extension blocks MUST use a namespaced type): unknown namespaced types pass unchecked (open-world 'ignore unrecognized'), while a bare unknown type is rejected as malformed.",
+          "if": {
+            "not": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "text", "paragraph", "heading", "list", "listItem", "blockquote",
+                    "codeBlock", "image", "table", "tableRow", "tableCell", "math",
+                    "definitionList", "definitionItem", "definitionTerm", "definitionDescription",
+                    "measurement", "signature", "svg", "barcode", "figure", "figcaption",
+                    "horizontalRule", "break", "admonition",
+                    "academic:abstract", "academic:theorem", "academic:proof", "academic:algorithm",
+                    "academic:equation-group", "academic:exercise-set", "academic:exercise",
+                    "semantic:footnote", "semantic:bibliography", "semantic:term", "semantic:ref",
+                    "semantic:glossary", "semantic:measurement",
+                    "legal:caption", "legal:signatureBlock", "legal:tableOfAuthorities",
+                    "forms:form", "forms:textInput", "forms:textArea", "forms:checkbox",
+                    "forms:radioGroup", "forms:dropdown", "forms:datePicker", "forms:signature",
+                    "forms:submit", "presentation:reference"
+                  ]
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "type": { "pattern": "^[A-Za-z0-9_-]+:[A-Za-z0-9._:-]+$" }
+            }
+          }
         }
       ]
+    },
+    "blockBase": {
+      "type": "object",
+      "description": "Common identity fields shared by every block (core and extension). Block defs compose this via allOf and close with unevaluatedProperties:false, so a block is recognized by type/id/attributes in both the dispatch context and when referenced directly as a child.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Block type identifier"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique block identifier (shares the document-wide ID namespace with anchor IDs)"
+        },
+        "attributes": {
+          "$ref": "#/$defs/blockAttributes"
+        }
+      }
     },
     "blockAttributes": {
       "type": "object",
@@ -157,42 +318,49 @@
           "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/jsonLdAnnotation",
           "description": "JSON-LD semantic annotation for this block"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "textNode": {
-      "type": "object",
-      "required": ["type", "value"],
-      "properties": {
-        "type": { "const": "text" },
-        "value": {
-          "type": "string",
-          "description": "Text content"
-        },
-        "marks": {
-          "type": "array",
-          "description": "Formatting marks",
-          "items": {
-            "oneOf": [
-              {
-                "type": "string",
-                "enum": ["bold", "italic", "underline", "strikethrough", "code", "superscript", "subscript"]
-              },
-              { "$ref": "#/$defs/linkMark" },
-              { "$ref": "#/$defs/anchorMark" },
-              { "$ref": "#/$defs/mathMark" },
-              { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/citationMark" },
-              { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/footnoteMark" },
-              { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/entityMark" },
-              { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/glossaryMark" },
-              { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/theoremRefMark" },
-              { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/equationRefMark" },
-              { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/algorithmRefMark" },
-              { "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/indexMark" },
-              { "$ref": "https://cdx.dev/schemas/legal.schema.json#/$defs/legalCiteMark" }
-            ]
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "text" },
+            "value": {
+              "type": "string",
+              "description": "Text content"
+            },
+            "marks": {
+              "type": "array",
+              "description": "Formatting marks",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": ["bold", "italic", "underline", "strikethrough", "code", "superscript", "subscript"]
+                  },
+                  { "$ref": "#/$defs/linkMark" },
+                  { "$ref": "#/$defs/anchorMark" },
+                  { "$ref": "#/$defs/mathMark" },
+                  { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/citationMark" },
+                  { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/footnoteMark" },
+                  { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/entityMark" },
+                  { "$ref": "https://cdx.dev/schemas/semantic.schema.json#/$defs/glossaryMark" },
+                  { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/theoremRefMark" },
+                  { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/equationRefMark" },
+                  { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/algorithmRefMark" },
+                  { "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/indexMark" },
+                  { "$ref": "https://cdx.dev/schemas/legal.schema.json#/$defs/legalCiteMark" }
+                ]
+              }
+            }
           }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "linkMark": {
       "type": "object",
@@ -207,7 +375,8 @@
           "type": "string",
           "description": "Link title"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "anchorMark": {
       "type": "object",
@@ -219,7 +388,8 @@
           "description": "Unique anchor identifier (shares namespace with block IDs)",
           "pattern": "^[A-Za-z0-9._-]+$"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "mathMark": {
       "type": "object",
@@ -235,107 +405,144 @@
           "type": "string",
           "description": "Math content in specified format"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "paragraph": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "paragraph" },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/textNode" }
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "paragraph" },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/textNode" }
+            }
+          }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "heading": {
-      "type": "object",
-      "required": ["type", "level", "children"],
-      "properties": {
-        "type": { "const": "heading" },
-        "level": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 6,
-          "description": "Heading level"
-        },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/textNode" }
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "level", "children"],
+          "properties": {
+            "type": { "const": "heading" },
+            "level": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 6,
+              "description": "Heading level"
+            },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/textNode" }
+            }
+          }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "list": {
-      "type": "object",
-      "required": ["type", "ordered", "children"],
-      "properties": {
-        "type": { "const": "list" },
-        "ordered": {
-          "type": "boolean",
-          "description": "Whether list is ordered"
-        },
-        "start": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Starting number for ordered lists"
-        },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/listItem" }
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "ordered", "children"],
+          "properties": {
+            "type": { "const": "list" },
+            "ordered": {
+              "type": "boolean",
+              "description": "Whether list is ordered"
+            },
+            "start": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Starting number for ordered lists"
+            },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/listItem" }
+            }
+          }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "listItem": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "listItem" },
-        "checked": {
-          "type": ["boolean", "null"],
-          "description": "Checkbox state (null = not a checkbox)"
-        },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/block" }
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "listItem" },
+            "checked": {
+              "type": ["boolean", "null"],
+              "description": "Checkbox state (null = not a checkbox)"
+            },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/block" }
+            }
+          }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "blockquote": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "blockquote" },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/block" }
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "blockquote" },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/block" }
+            }
+          }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "codeBlock": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "codeBlock" },
-        "language": {
-          "type": "string",
-          "description": "Programming language identifier"
-        },
-        "highlighting": {
-          "type": "string",
-          "enum": ["none", "tokens"],
-          "description": "Highlighting mode: 'none' for plain text, 'tokens' for pre-tokenized highlighting"
-        },
-        "tokens": {
-          "type": "array",
-          "description": "Pre-tokenized syntax highlighting tokens (used when highlighting='tokens')",
-          "items": { "$ref": "#/$defs/highlightToken" }
-        },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/textNode" },
-          "maxItems": 1
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "codeBlock" },
+            "language": {
+              "type": "string",
+              "description": "Programming language identifier"
+            },
+            "highlighting": {
+              "type": "string",
+              "enum": ["none", "tokens"],
+              "description": "Highlighting mode: 'none' for plain text, 'tokens' for pre-tokenized highlighting"
+            },
+            "tokens": {
+              "type": "array",
+              "description": "Pre-tokenized syntax highlighting tokens (used when highlighting='tokens')",
+              "items": { "$ref": "#/$defs/highlightToken" }
+            },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/textNode" },
+              "maxItems": 1
+            }
+          }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "highlightToken": {
       "type": "object",
@@ -358,376 +565,492 @@
           "type": "string",
           "description": "Token text content"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "image": {
-      "type": "object",
-      "required": ["type", "src", "alt"],
-      "properties": {
-        "type": { "const": "image" },
-        "src": {
-          "type": "string",
-          "description": "Image source path or URL"
-        },
-        "alt": {
-          "type": "string",
-          "description": "Alternative text"
-        },
-        "title": {
-          "type": "string",
-          "description": "Image title/caption"
-        },
-        "width": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Width in pixels"
-        },
-        "height": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Height in pixels"
-        }
-      }
-    },
-    "table": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "table" },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/tableRow" }
-        }
-      }
-    },
-    "tableRow": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "tableRow" },
-        "header": {
-          "type": "boolean",
-          "description": "Whether row is a header row"
-        },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/tableCell" }
-        }
-      }
-    },
-    "tableCell": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "tableCell" },
-        "colspan": {
-          "type": "integer",
-          "minimum": 1,
-          "default": 1,
-          "description": "Number of columns to span"
-        },
-        "rowspan": {
-          "type": "integer",
-          "minimum": 1,
-          "default": 1,
-          "description": "Number of rows to span"
-        },
-        "align": {
-          "type": "string",
-          "enum": ["left", "center", "right"],
-          "description": "Text alignment"
-        },
-        "children": {
-          "type": "array",
-          "description": "Block-level content (typically paragraph blocks)",
-          "items": { "$ref": "#/$defs/block" }
-        }
-      }
-    },
-    "math": {
-      "type": "object",
-      "required": ["type", "display", "format", "value"],
-      "properties": {
-        "type": { "const": "math" },
-        "display": {
-          "type": "boolean",
-          "description": "Display mode (true) vs inline (false)"
-        },
-        "format": {
-          "type": "string",
-          "enum": ["latex", "mathml"],
-          "description": "Math content format"
-        },
-        "value": {
-          "type": "string",
-          "description": "Math content"
-        }
-      }
-    },
-    "horizontalRule": {
-      "type": "object",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "horizontalRule" }
-      }
-    },
-    "break": {
-      "type": "object",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "break" }
-      }
-    },
-    "definitionList": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "definitionList" },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/definitionItem" },
-          "minItems": 1
-        }
-      }
-    },
-    "definitionItem": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "definitionItem" },
-        "children": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              { "$ref": "#/$defs/definitionTerm" },
-              { "$ref": "#/$defs/definitionDescription" }
-            ]
-          },
-          "minItems": 2
-        }
-      }
-    },
-    "definitionTerm": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "definitionTerm" },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/textNode" }
-        }
-      }
-    },
-    "definitionDescription": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "definitionDescription" },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/block" }
-        }
-      }
-    },
-    "measurement": {
-      "type": "object",
-      "required": ["type", "value", "display"],
-      "properties": {
-        "type": { "const": "measurement" },
-        "value": {
-          "type": "number",
-          "description": "Numeric value"
-        },
-        "uncertainty": {
-          "type": "number",
-          "description": "Measurement uncertainty"
-        },
-        "uncertaintyNotation": {
-          "type": "string",
-          "enum": ["parenthetical", "plusminus", "range", "percent"],
-          "description": "How uncertainty is displayed"
-        },
-        "exponent": {
-          "type": "integer",
-          "description": "Power of 10 for scientific notation"
-        },
-        "unit": {
-          "type": "string",
-          "description": "Unit of measurement"
-        },
-        "display": {
-          "type": "string",
-          "description": "Human-readable display string"
-        }
-      }
-    },
-    "signature": {
-      "type": "object",
-      "required": ["type", "signatureType"],
-      "properties": {
-        "type": { "const": "signature" },
-        "signatureType": {
-          "type": "string",
-          "enum": ["handwritten", "digital", "electronic", "stamp"],
-          "description": "Type of signature"
-        },
-        "image": {
-          "type": "string",
-          "description": "Path to signature image"
-        },
-        "signer": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
           "type": "object",
+          "required": ["type", "src", "alt"],
           "properties": {
-            "name": {
+            "type": { "const": "image" },
+            "src": {
               "type": "string",
-              "description": "Signer's full name"
+              "description": "Image source path or URL"
+            },
+            "alt": {
+              "type": "string",
+              "description": "Alternative text"
             },
             "title": {
               "type": "string",
-              "description": "Professional title"
+              "description": "Image title/caption"
             },
-            "organization": {
-              "type": "string",
-              "description": "Organization name"
+            "width": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Width in pixels"
             },
-            "email": {
-              "type": "string",
-              "description": "Contact email"
+            "height": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Height in pixels"
             },
-            "id": {
-              "type": "string",
-              "description": "Unique identifier"
+            "float": {
+              "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/float",
+              "description": "Float positioning for this image (presentation extension)"
             }
           }
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "date-time",
-          "description": "ISO 8601 timestamp"
-        },
-        "purpose": {
-          "type": "string",
-          "enum": ["certification", "approval", "witness", "acknowledgment", "authorship"],
-          "description": "Purpose of the signature"
-        },
-        "digitalSignatureRef": {
-          "type": "string",
-          "description": "Reference to cryptographic signature"
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
-    "svg": {
-      "type": "object",
-      "required": ["type", "alt"],
-      "properties": {
-        "type": { "const": "svg" },
-        "src": {
-          "type": "string",
-          "description": "Path to SVG file"
-        },
-        "content": {
-          "type": "string",
-          "description": "Inline SVG content"
-        },
-        "alt": {
-          "type": "string",
-          "description": "Alternative text"
-        },
-        "title": {
-          "type": "string",
-          "description": "Title/caption"
-        },
-        "width": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Display width in pixels"
-        },
-        "height": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Display height in pixels"
-        }
-      },
-      "oneOf": [
-        { "required": ["src"] },
-        { "required": ["content"] }
-      ]
-    },
-    "barcode": {
-      "type": "object",
-      "required": ["type", "format", "data", "alt"],
-      "properties": {
-        "type": { "const": "barcode" },
-        "format": {
-          "type": "string",
-          "enum": ["qr", "datamatrix", "code128", "code39", "ean13", "ean8", "upca", "pdf417"],
-          "description": "Barcode format"
-        },
-        "data": {
-          "type": "string",
-          "description": "Encoded content"
-        },
-        "alt": {
-          "type": "string",
-          "description": "Alternative text description"
-        },
-        "errorCorrection": {
-          "type": "string",
-          "enum": ["L", "M", "Q", "H"],
-          "description": "Error correction level (QR/DataMatrix)"
-        },
-        "size": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Rendered size in pixels"
-        },
-        "quietZone": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Quiet zone size in modules"
-        }
-      }
-    },
-    "figure": {
-      "type": "object",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "figure" },
-        "numbering": {
-          "oneOf": [
-            { "type": "string", "enum": ["auto", "none"] },
-            { "type": "integer", "minimum": 1 }
-          ],
-          "description": "Figure numbering mode"
-        },
-        "children": {
-          "type": "array",
-          "description": "Figure content and optional caption",
-          "minItems": 1,
-          "maxItems": 2
-        },
-        "subfigures": {
-          "type": "array",
-          "description": "Array of subfigure objects for multi-panel figures",
-          "items": { "$ref": "#/$defs/subfigure" },
-          "minItems": 1
-        },
-        "caption": {
-          "oneOf": [
-            { "type": "string", "description": "Simple caption text" },
-            {
+    "table": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "table" },
+            "children": {
               "type": "array",
-              "description": "Rich caption with text nodes",
+              "items": { "$ref": "#/$defs/tableRow" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "tableRow": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "tableRow" },
+            "header": {
+              "type": "boolean",
+              "description": "Whether row is a header row"
+            },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/tableCell" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "tableCell": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "tableCell" },
+            "colspan": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "description": "Number of columns to span"
+            },
+            "rowspan": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "description": "Number of rows to span"
+            },
+            "align": {
+              "type": "string",
+              "enum": ["left", "center", "right"],
+              "description": "Text alignment"
+            },
+            "children": {
+              "type": "array",
+              "description": "Block-level content (typically paragraph blocks)",
+              "items": { "$ref": "#/$defs/block" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "math": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "display", "format", "value"],
+          "properties": {
+            "type": { "const": "math" },
+            "display": {
+              "type": "boolean",
+              "description": "Display mode (true) vs inline (false)"
+            },
+            "format": {
+              "type": "string",
+              "enum": ["latex", "mathml"],
+              "description": "Math content format"
+            },
+            "value": {
+              "type": "string",
+              "description": "Math content"
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "horizontalRule": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "horizontalRule" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "break": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "break" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "definitionList": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "definitionList" },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/definitionItem" },
+              "minItems": 1
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "definitionItem": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "definitionItem" },
+            "children": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  { "$ref": "#/$defs/definitionTerm" },
+                  { "$ref": "#/$defs/definitionDescription" }
+                ]
+              },
+              "minItems": 2
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "definitionTerm": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "definitionTerm" },
+            "children": {
+              "type": "array",
               "items": { "$ref": "#/$defs/textNode" }
             }
-          ],
-          "description": "Overall figure caption (used with subfigures)"
+          }
         }
-      },
-      "oneOf": [
-        { "required": ["children"] },
-        { "required": ["subfigures"] }
-      ]
+      ],
+      "unevaluatedProperties": false
+    },
+    "definitionDescription": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "definitionDescription" },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/block" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "measurement": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "value", "display"],
+          "properties": {
+            "type": { "const": "measurement" },
+            "value": {
+              "type": "number",
+              "description": "Numeric value"
+            },
+            "uncertainty": {
+              "type": "number",
+              "description": "Measurement uncertainty"
+            },
+            "uncertaintyNotation": {
+              "type": "string",
+              "enum": ["parenthetical", "plusminus", "range", "percent"],
+              "description": "How uncertainty is displayed"
+            },
+            "exponent": {
+              "type": "integer",
+              "description": "Power of 10 for scientific notation"
+            },
+            "unit": {
+              "type": "string",
+              "description": "Unit of measurement"
+            },
+            "display": {
+              "type": "string",
+              "description": "Human-readable display string"
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "signature": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "signatureType"],
+          "properties": {
+            "type": { "const": "signature" },
+            "signatureType": {
+              "type": "string",
+              "enum": ["handwritten", "digital", "electronic", "stamp"],
+              "description": "Type of signature"
+            },
+            "image": {
+              "type": "string",
+              "description": "Path to signature image"
+            },
+            "signer": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Signer's full name"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Professional title"
+                },
+                "organization": {
+                  "type": "string",
+                  "description": "Organization name"
+                },
+                "email": {
+                  "type": "string",
+                  "description": "Contact email"
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier"
+                }
+              },
+              "additionalProperties": false
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 timestamp"
+            },
+            "purpose": {
+              "type": "string",
+              "enum": ["certification", "approval", "witness", "acknowledgment", "authorship"],
+              "description": "Purpose of the signature"
+            },
+            "digitalSignatureRef": {
+              "type": "string",
+              "description": "Reference to cryptographic signature"
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "svg": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "alt"],
+          "properties": {
+            "type": { "const": "svg" },
+            "src": {
+              "type": "string",
+              "description": "Path to SVG file"
+            },
+            "content": {
+              "type": "string",
+              "description": "Inline SVG content"
+            },
+            "alt": {
+              "type": "string",
+              "description": "Alternative text"
+            },
+            "title": {
+              "type": "string",
+              "description": "Title/caption"
+            },
+            "width": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Display width in pixels"
+            },
+            "height": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Display height in pixels"
+            }
+          },
+          "oneOf": [
+            { "required": ["src"] },
+            { "required": ["content"] }
+          ]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "barcode": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "format", "data", "alt"],
+          "properties": {
+            "type": { "const": "barcode" },
+            "format": {
+              "type": "string",
+              "enum": ["qr", "datamatrix", "code128", "code39", "ean13", "ean8", "upca", "pdf417"],
+              "description": "Barcode format"
+            },
+            "data": {
+              "type": "string",
+              "description": "Encoded content"
+            },
+            "alt": {
+              "type": "string",
+              "description": "Alternative text description"
+            },
+            "errorCorrection": {
+              "type": "string",
+              "enum": ["L", "M", "Q", "H"],
+              "description": "Error correction level (QR/DataMatrix)"
+            },
+            "size": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Rendered size in pixels"
+            },
+            "quietZone": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Quiet zone size in modules"
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "figure": {
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "figure" },
+            "numbering": {
+              "oneOf": [
+                { "type": "string", "enum": ["auto", "none"] },
+                { "type": "integer", "minimum": 1 }
+              ],
+              "description": "Figure numbering mode"
+            },
+            "children": {
+              "type": "array",
+              "description": "Figure content and optional caption",
+              "minItems": 1,
+              "maxItems": 2,
+              "items": {
+                "oneOf": [
+                  { "$ref": "#/$defs/image" },
+                  { "$ref": "#/$defs/svg" },
+                  { "$ref": "#/$defs/table" },
+                  { "$ref": "#/$defs/math" },
+                  { "$ref": "#/$defs/barcode" },
+                  { "$ref": "#/$defs/figcaption" }
+                ]
+              }
+            },
+            "subfigures": {
+              "type": "array",
+              "description": "Array of subfigure objects for multi-panel figures",
+              "items": { "$ref": "#/$defs/subfigure" },
+              "minItems": 1
+            },
+            "caption": {
+              "oneOf": [
+                { "type": "string", "description": "Simple caption text" },
+                {
+                  "type": "array",
+                  "description": "Rich caption with text nodes",
+                  "items": { "$ref": "#/$defs/textNode" }
+                }
+              ],
+              "description": "Overall figure caption (used with subfigures)"
+            },
+            "float": {
+              "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/float",
+              "description": "Float positioning for this figure (presentation extension)"
+            }
+          },
+          "oneOf": [
+            { "required": ["children"] },
+            { "required": ["subfigures"] }
+          ]
+        }
+      ],
+      "unevaluatedProperties": false
     },
     "subfigure": {
       "type": "object",
@@ -759,40 +1082,53 @@
           ],
           "description": "Subfigure-specific caption"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "figcaption": {
-      "type": "object",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "figcaption" },
-        "children": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/textNode" }
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "figcaption" },
+            "children": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/textNode" }
+            }
+          }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "admonition": {
-      "type": "object",
-      "description": "Callout box for notes, warnings, tips, and other highlighted content",
-      "required": ["type", "variant", "children"],
-      "properties": {
-        "type": { "const": "admonition" },
-        "variant": {
-          "type": "string",
-          "description": "Admonition type",
-          "enum": ["note", "tip", "info", "warning", "caution", "danger", "important", "example"]
-        },
-        "title": {
-          "type": "string",
-          "description": "Custom title (defaults to variant label)"
-        },
-        "children": {
-          "type": "array",
-          "description": "Block-level content (typically paragraph blocks)",
-          "items": { "$ref": "#/$defs/block" }
+      "allOf": [
+        { "$ref": "#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Callout box for notes, warnings, tips, and other highlighted content",
+          "required": ["type", "variant", "children"],
+          "properties": {
+            "type": { "const": "admonition" },
+            "variant": {
+              "type": "string",
+              "description": "Admonition type",
+              "enum": ["note", "tip", "info", "warning", "caution", "danger", "important", "example"]
+            },
+            "title": {
+              "type": "string",
+              "description": "Custom title (defaults to variant label)"
+            },
+            "children": {
+              "type": "array",
+              "description": "Block-level content (typically paragraph blocks)",
+              "items": { "$ref": "#/$defs/block" }
+            }
+          }
         }
-      }
+      ],
+      "unevaluatedProperties": false
     }
   }
 }

--- a/schemas/forms.schema.json
+++ b/schemas/forms.schema.json
@@ -204,40 +204,47 @@
       }
     },
     "formContainer": {
-      "type": "object",
-      "description": "Form container block",
-      "required": ["type", "children"],
-      "properties": {
-        "type": { "const": "forms:form" },
-        "id": {
-          "type": "string",
-          "description": "Unique form identifier"
-        },
-        "action": {
-          "type": "string",
-          "format": "uri",
-          "description": "Form submission URL"
-        },
-        "method": {
-          "type": "string",
-          "enum": ["GET", "POST"],
-          "description": "HTTP method for submission",
-          "default": "POST"
-        },
-        "encoding": {
-          "type": "string",
-          "description": "Form encoding type",
-          "default": "application/json"
-        },
-        "children": {
-          "type": "array",
-          "description": "Form field blocks"
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Form container block",
+          "required": ["type", "children"],
+          "properties": {
+            "type": { "const": "forms:form" },
+            "id": {
+              "type": "string",
+              "description": "Unique form identifier"
+            },
+            "action": {
+              "type": "string",
+              "format": "uri",
+              "description": "Form submission URL"
+            },
+            "method": {
+              "type": "string",
+              "enum": ["GET", "POST"],
+              "description": "HTTP method for submission",
+              "default": "POST"
+            },
+            "encoding": {
+              "type": "string",
+              "description": "Form encoding type",
+              "default": "application/json"
+            },
+            "children": {
+              "type": "array",
+              "description": "Form field blocks and other content blocks",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "textInputBlock": {
       "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
         { "$ref": "#/$defs/baseFormField" },
         {
           "type": "object",
@@ -259,13 +266,14 @@
               "type": "string",
               "description": "Autocomplete hint"
             }
-          },
-          "additionalProperties": false
+          }
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "textAreaBlock": {
       "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
         { "$ref": "#/$defs/baseFormField" },
         {
           "type": "object",
@@ -283,13 +291,14 @@
               "minimum": 1,
               "description": "Maximum character length"
             }
-          },
-          "additionalProperties": false
+          }
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "checkboxBlock": {
       "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
         { "$ref": "#/$defs/baseFormField" },
         {
           "type": "object",
@@ -301,13 +310,14 @@
               "description": "Initial checked state",
               "default": false
             }
-          },
-          "additionalProperties": false
+          }
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "radioGroupBlock": {
       "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
         { "$ref": "#/$defs/baseFormField" },
         {
           "type": "object",
@@ -324,13 +334,14 @@
               "type": "string",
               "description": "Default selected value"
             }
-          },
-          "additionalProperties": false
+          }
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "dropdownBlock": {
       "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
         { "$ref": "#/$defs/baseFormField" },
         {
           "type": "object",
@@ -357,13 +368,14 @@
               "description": "Allow multiple selections",
               "default": false
             }
-          },
-          "additionalProperties": false
+          }
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "datePickerBlock": {
       "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
         { "$ref": "#/$defs/baseFormField" },
         {
           "type": "object",
@@ -388,13 +400,14 @@
               "description": "Include time selection",
               "default": false
             }
-          },
-          "additionalProperties": false
+          }
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "signatureBlock": {
       "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
         { "$ref": "#/$defs/baseFormField" },
         {
           "type": "object",
@@ -411,41 +424,33 @@
               "minimum": 50,
               "description": "Signature pad height in pixels"
             }
-          },
-          "additionalProperties": false
+          }
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "submitBlock": {
-      "type": "object",
-      "description": "Form submit button",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "forms:submit" },
-        "id": {
-          "type": "string",
-          "description": "Unique block identifier"
-        },
-        "label": {
-          "type": "string",
-          "description": "Button label",
-          "default": "Submit"
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Form submit button",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "forms:submit" },
+            "id": {
+              "type": "string",
+              "description": "Unique block identifier"
+            },
+            "label": {
+              "type": "string",
+              "description": "Button label",
+              "default": "Submit"
+            }
+          }
         }
-      },
-      "additionalProperties": false
-    },
-    "formBlock": {
-      "oneOf": [
-        { "$ref": "#/$defs/formContainer" },
-        { "$ref": "#/$defs/textInputBlock" },
-        { "$ref": "#/$defs/textAreaBlock" },
-        { "$ref": "#/$defs/checkboxBlock" },
-        { "$ref": "#/$defs/radioGroupBlock" },
-        { "$ref": "#/$defs/dropdownBlock" },
-        { "$ref": "#/$defs/datePickerBlock" },
-        { "$ref": "#/$defs/signatureBlock" },
-        { "$ref": "#/$defs/submitBlock" }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "dataFile": {
       "type": "object",

--- a/schemas/legal.schema.json
+++ b/schemas/legal.schema.json
@@ -52,38 +52,43 @@
       "additionalProperties": false
     },
     "tableOfAuthoritiesBlock": {
-      "type": "object",
-      "description": "Table of Authorities block for auto-generated citation index",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "legal:tableOfAuthorities" },
-        "id": {
-          "type": "string",
-          "description": "Block identifier"
-        },
-        "title": {
-          "type": "string",
-          "description": "Section title",
-          "default": "Table of Authorities"
-        },
-        "categories": {
-          "type": "array",
-          "description": "Category configuration for grouping",
-          "items": { "$ref": "#/$defs/toaCategoryConfig" }
-        },
-        "pageReferences": {
-          "type": "boolean",
-          "description": "Include page references",
-          "default": true
-        },
-        "passimThreshold": {
-          "type": "integer",
-          "description": "Number of references before showing 'passim'",
-          "minimum": 1,
-          "default": 5
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Table of Authorities block for auto-generated citation index",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "legal:tableOfAuthorities" },
+            "id": {
+              "type": "string",
+              "description": "Block identifier"
+            },
+            "title": {
+              "type": "string",
+              "description": "Section title",
+              "default": "Table of Authorities"
+            },
+            "categories": {
+              "type": "array",
+              "description": "Category configuration for grouping",
+              "items": { "$ref": "#/$defs/toaCategoryConfig" }
+            },
+            "pageReferences": {
+              "type": "boolean",
+              "description": "Include page references",
+              "default": true
+            },
+            "passimThreshold": {
+              "type": "integer",
+              "description": "Number of references before showing 'passim'",
+              "minimum": 1,
+              "default": 5
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "party": {
       "type": "object",
@@ -100,75 +105,80 @@
       }
     },
     "captionBlock": {
-      "type": "object",
-      "description": "Court caption block",
-      "required": ["type", "court"],
-      "properties": {
-        "type": { "const": "legal:caption" },
-        "id": {
-          "type": "string",
-          "description": "Block identifier"
-        },
-        "court": {
-          "type": "string",
-          "description": "Court name"
-        },
-        "caseNumber": {
-          "type": "string",
-          "description": "Case or docket number"
-        },
-        "parties": {
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
           "type": "object",
-          "description": "Parties to the case",
+          "description": "Court caption block",
+          "required": ["type", "court"],
           "properties": {
-            "plaintiff": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "#/$defs/party" }
-              ]
+            "type": { "const": "legal:caption" },
+            "id": {
+              "type": "string",
+              "description": "Block identifier"
             },
-            "defendant": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "#/$defs/party" }
-              ]
+            "court": {
+              "type": "string",
+              "description": "Court name"
             },
-            "appellant": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "#/$defs/party" }
-              ]
+            "caseNumber": {
+              "type": "string",
+              "description": "Case or docket number"
             },
-            "appellee": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "#/$defs/party" }
-              ]
+            "parties": {
+              "type": "object",
+              "description": "Parties to the case",
+              "properties": {
+                "plaintiff": {
+                  "oneOf": [
+                    { "type": "string" },
+                    { "$ref": "#/$defs/party" }
+                  ]
+                },
+                "defendant": {
+                  "oneOf": [
+                    { "type": "string" },
+                    { "$ref": "#/$defs/party" }
+                  ]
+                },
+                "appellant": {
+                  "oneOf": [
+                    { "type": "string" },
+                    { "$ref": "#/$defs/party" }
+                  ]
+                },
+                "appellee": {
+                  "oneOf": [
+                    { "type": "string" },
+                    { "$ref": "#/$defs/party" }
+                  ]
+                },
+                "petitioner": {
+                  "oneOf": [
+                    { "type": "string" },
+                    { "$ref": "#/$defs/party" }
+                  ]
+                },
+                "respondent": {
+                  "oneOf": [
+                    { "type": "string" },
+                    { "$ref": "#/$defs/party" }
+                  ]
+                }
+              }
             },
-            "petitioner": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "#/$defs/party" }
-              ]
+            "docket": {
+              "type": "string",
+              "description": "Docket or term information"
             },
-            "respondent": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "#/$defs/party" }
-              ]
+            "judge": {
+              "type": "string",
+              "description": "Assigned judge"
             }
           }
-        },
-        "docket": {
-          "type": "string",
-          "description": "Docket or term information"
-        },
-        "judge": {
-          "type": "string",
-          "description": "Assigned judge"
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "signatureBlockSigner": {
       "type": "object",
@@ -210,28 +220,33 @@
       }
     },
     "signatureBlockBlock": {
-      "type": "object",
-      "description": "Legal signature block with attorney information",
-      "required": ["type", "role", "signer"],
-      "properties": {
-        "type": { "const": "legal:signatureBlock" },
-        "id": {
-          "type": "string",
-          "description": "Block identifier"
-        },
-        "role": {
-          "type": "string",
-          "description": "Role of the signatory",
-          "enum": ["counsel", "attorney", "party", "witness", "notary"]
-        },
-        "signer": { "$ref": "#/$defs/signatureBlockSigner" },
-        "date": {
-          "type": "string",
-          "format": "date",
-          "description": "Date of signature"
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Legal signature block with attorney information",
+          "required": ["type", "role", "signer"],
+          "properties": {
+            "type": { "const": "legal:signatureBlock" },
+            "id": {
+              "type": "string",
+              "description": "Block identifier"
+            },
+            "role": {
+              "type": "string",
+              "description": "Role of the signatory",
+              "enum": ["counsel", "attorney", "party", "witness", "notary"]
+            },
+            "signer": { "$ref": "#/$defs/signatureBlockSigner" },
+            "date": {
+              "type": "string",
+              "format": "date",
+              "description": "Date of signature"
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     }
   },
   "type": "object",

--- a/schemas/phantoms.schema.json
+++ b/schemas/phantoms.schema.json
@@ -152,16 +152,7 @@
         "blocks": {
           "type": "array",
           "description": "Array of content blocks (uses core content block model)",
-          "items": {
-            "type": "object",
-            "required": ["type"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "description": "Block type identifier"
-              }
-            }
-          }
+          "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
         }
       },
       "additionalProperties": false

--- a/schemas/presentation.schema.json
+++ b/schemas/presentation.schema.json
@@ -833,21 +833,26 @@
       "additionalProperties": false
     },
     "presentationReference": {
-      "type": "object",
-      "description": "Cross-reference block for figure/table/section references",
-      "required": ["type", "target"],
-      "properties": {
-        "type": { "const": "presentation:reference" },
-        "target": {
-          "type": "string",
-          "description": "Content Anchor URI (internal references start with #)"
-        },
-        "format": {
-          "type": "string",
-          "description": "Display format template (e.g., 'Figure #')"
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Cross-reference block for figure/table/section references",
+          "required": ["type", "target"],
+          "properties": {
+            "type": { "const": "presentation:reference" },
+            "target": {
+              "type": "string",
+              "description": "Content Anchor URI (internal references start with #)"
+            },
+            "format": {
+              "type": "string",
+              "description": "Display format template (e.g., 'Figure #')"
+            }
+          }
         }
-      },
-      "additionalProperties": false
+      ],
+      "unevaluatedProperties": false
     },
     "indexMark": {
       "type": "object",

--- a/schemas/semantic.schema.json
+++ b/schemas/semantic.schema.json
@@ -46,7 +46,8 @@
           "description": "If true, omit the author name from the citation",
           "default": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "footnoteMark": {
       "type": "object",
@@ -69,6 +70,7 @@
           "description": "Unique footnote identifier for cross-referencing"
         }
       },
+      "additionalProperties": false,
       "oneOf": [
         { "required": ["number"] },
         { "required": ["symbol"] }
@@ -94,7 +96,8 @@
           "type": "string",
           "description": "Knowledge graph origin (e.g., 'wikidata', 'dbpedia')"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "glossaryMark": {
       "type": "object",
@@ -106,38 +109,43 @@
           "type": "string",
           "description": "Reference to the term definition ID"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "footnoteBlock": {
-      "type": "object",
-      "description": "Footnote content block",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "semantic:footnote" },
-        "number": {
-          "type": "integer",
-          "description": "Footnote number (must match corresponding mark)",
-          "minimum": 1
-        },
-        "symbol": {
-          "type": "string",
-          "description": "Symbol-based footnote marker (must match corresponding mark)",
-          "enum": ["asterisk", "dagger", "ddagger", "section", "parallel", "paragraph"]
-        },
-        "id": {
-          "type": "string",
-          "description": "Unique identifier (must match mark if present)"
-        },
-        "children": {
-          "type": "array",
-          "description": "Rich footnote content (paragraph blocks)"
-        },
-        "content": {
-          "type": "string",
-          "description": "Simple text content (alternative to children)"
-        }
-      },
       "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Footnote content block",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "semantic:footnote" },
+            "number": {
+              "type": "integer",
+              "description": "Footnote number (must match corresponding mark)",
+              "minimum": 1
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Symbol-based footnote marker (must match corresponding mark)",
+              "enum": ["asterisk", "dagger", "ddagger", "section", "parallel", "paragraph"]
+            },
+            "id": {
+              "type": "string",
+              "description": "Unique identifier (must match mark if present)"
+            },
+            "children": {
+              "type": "array",
+              "description": "Rich footnote content (paragraph blocks)",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+            },
+            "content": {
+              "type": "string",
+              "description": "Simple text content (alternative to children)"
+            }
+          }
+        },
         {
           "oneOf": [
             { "required": ["number"] },
@@ -150,7 +158,8 @@
             { "required": ["content"] }
           ]
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "bibliographyEntry": {
       "type": "object",
@@ -246,133 +255,164 @@
       "additionalProperties": true
     },
     "bibliographyBlock": {
-      "type": "object",
-      "description": "Bibliography block for rendering citations",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "semantic:bibliography" },
-        "style": {
-          "type": "string",
-          "description": "Citation style (e.g., 'apa', 'mla', 'chicago', 'ieee', 'harvard', 'vancouver')"
-        },
-        "title": {
-          "type": "string",
-          "description": "Bibliography section title"
-        },
-        "filter": {
-          "type": ["string", "null"],
-          "description": "Filter expression for selective bibliography"
-        },
-        "entries": {
-          "type": "array",
-          "description": "Inline CSL JSON entries (alternative to external bibliography.json)",
-          "items": { "$ref": "#/$defs/bibliographyEntry" }
-        }
-      }
-    },
-    "termBlock": {
-      "type": "object",
-      "description": "Glossary term definition block",
-      "required": ["type", "term", "definition"],
-      "properties": {
-        "type": { "const": "semantic:term" },
-        "id": {
-          "type": "string",
-          "description": "Unique term identifier"
-        },
-        "term": {
-          "type": "string",
-          "description": "The term being defined"
-        },
-        "definition": {
-          "type": "string",
-          "description": "Definition of the term"
-        },
-        "see": {
-          "type": "array",
-          "description": "Related term IDs",
-          "items": { "type": "string" }
-        }
-      }
-    },
-    "refBlock": {
-      "type": "object",
-      "description": "Cross-reference block for internal or external references",
-      "required": ["type", "target"],
-      "properties": {
-        "type": { "const": "semantic:ref" },
-        "target": {
-          "type": "string",
-          "description": "Target reference (Content Anchor URI for internal, URL for external)"
-        },
-        "format": {
-          "type": "string",
-          "description": "Display format template (e.g., 'Section {number}')"
-        },
-        "external": {
-          "type": "boolean",
-          "description": "If true, target is an external URL",
-          "default": false
-        },
-        "children": {
-          "type": "array",
-          "description": "Display content (text nodes)"
-        }
-      }
-    },
-    "glossaryBlock": {
-      "type": "object",
-      "description": "Glossary block for rendering collected term definitions",
-      "required": ["type"],
-      "properties": {
-        "type": { "const": "semantic:glossary" },
-        "title": {
-          "type": "string",
-          "description": "Glossary section title"
-        },
-        "sort": {
-          "type": "string",
-          "description": "Sort order for terms",
-          "enum": ["alphabetical", "appearance", "none"]
-        }
-      }
-    },
-    "measurementBlock": {
-      "type": "object",
-      "description": "Semantic measurement with linked data integration",
-      "required": ["type", "value", "unit"],
-      "properties": {
-        "type": { "const": "semantic:measurement" },
-        "value": {
-          "type": "number",
-          "description": "Numeric measurement value"
-        },
-        "unit": {
-          "type": "string",
-          "description": "Unit of measurement"
-        },
-        "schema": {
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
           "type": "object",
-          "description": "Schema.org QuantitativeValue representation",
+          "description": "Bibliography block for rendering citations",
+          "required": ["type"],
           "properties": {
-            "@type": {
+            "type": { "const": "semantic:bibliography" },
+            "style": {
               "type": "string",
-              "const": "QuantitativeValue"
+              "description": "Citation style (e.g., 'apa', 'mla', 'chicago', 'ieee', 'harvard', 'vancouver')"
             },
-            "value": {
-              "type": "number"
-            },
-            "unitCode": {
+            "title": {
               "type": "string",
-              "description": "UN/CEFACT unit code"
+              "description": "Bibliography section title"
             },
-            "unitText": {
-              "type": "string",
-              "description": "Human-readable unit name"
+            "filter": {
+              "type": ["string", "null"],
+              "description": "Filter expression for selective bibliography"
+            },
+            "entries": {
+              "type": "array",
+              "description": "Inline CSL JSON entries (alternative to external bibliography.json)",
+              "items": { "$ref": "#/$defs/bibliographyEntry" }
             }
           }
         }
-      }
+      ],
+      "unevaluatedProperties": false
+    },
+    "termBlock": {
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Glossary term definition block",
+          "required": ["type", "term", "definition"],
+          "properties": {
+            "type": { "const": "semantic:term" },
+            "id": {
+              "type": "string",
+              "description": "Unique term identifier"
+            },
+            "term": {
+              "type": "string",
+              "description": "The term being defined"
+            },
+            "definition": {
+              "type": "string",
+              "description": "Definition of the term"
+            },
+            "see": {
+              "type": "array",
+              "description": "Related term IDs",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "refBlock": {
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Cross-reference block for internal or external references",
+          "required": ["type", "target"],
+          "properties": {
+            "type": { "const": "semantic:ref" },
+            "target": {
+              "type": "string",
+              "description": "Target reference (Content Anchor URI for internal, URL for external)"
+            },
+            "format": {
+              "type": "string",
+              "description": "Display format template (e.g., 'Section {number}')"
+            },
+            "external": {
+              "type": "boolean",
+              "description": "If true, target is an external URL",
+              "default": false
+            },
+            "children": {
+              "type": "array",
+              "description": "Display content (text nodes)",
+              "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/textNode" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "glossaryBlock": {
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Glossary block for rendering collected term definitions",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "semantic:glossary" },
+            "title": {
+              "type": "string",
+              "description": "Glossary section title"
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort order for terms",
+              "enum": ["alphabetical", "appearance", "none"]
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "measurementBlock": {
+      "allOf": [
+        { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },
+        {
+          "type": "object",
+          "description": "Semantic measurement with linked data integration",
+          "required": ["type", "value", "unit"],
+          "properties": {
+            "type": { "const": "semantic:measurement" },
+            "value": {
+              "type": "number",
+              "description": "Numeric measurement value"
+            },
+            "unit": {
+              "type": "string",
+              "description": "Unit of measurement"
+            },
+            "schema": {
+              "type": "object",
+              "description": "Schema.org QuantitativeValue representation",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "const": "QuantitativeValue"
+                },
+                "value": {
+                  "type": "number"
+                },
+                "unitCode": {
+                  "type": "string",
+                  "description": "UN/CEFACT unit code"
+                },
+                "unitText": {
+                  "type": "string",
+                  "description": "Human-readable unit name"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
     },
     "jsonLdAnnotation": {
       "type": "object",

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -35,6 +35,10 @@ export const CLOSED_SCHEMAS: string[] = [
   'security.schema.json',
   'semantic.schema.json',
   'collaboration.schema.json',
+  'content.schema.json',
+  'academic.schema.json',
+  'legal.schema.json',
+  'forms.schema.json',
 ];
 
 // A syntactically valid algorithm-prefixed digest for hash-typed fields.
@@ -526,13 +530,6 @@ export const closureVectors: ClosureVector[] = [
   },
   {
     schema: 'presentation.schema.json',
-    ref: '#/$defs/presentationReference',
-    description: 'presentationReference',
-    validInstance: { type: 'presentation:reference', target: '#b1' },
-    invalidInstance: { type: 'presentation:reference', target: '#b1', bogus: 1 },
-  },
-  {
-    schema: 'presentation.schema.json',
     ref: '#/$defs/indexMark',
     description: 'indexMark',
     validInstance: { type: 'index', term: 'entropy' },
@@ -885,5 +882,332 @@ export const closureVectors: ClosureVector[] = [
     description: 'changePosition',
     validInstance: { after: 'b1' },
     invalidInstance: { after: 'b1', bogus: 1 },
+  },
+
+  // --- content: block dispatch, open-escape, leaf + mark closure (4.1e) -----
+  // The block dispatch is exercised through content#/$defs/block: a valid block
+  // is accepted (incl. the shared blockBase id/attributes) and the same block
+  // with one unknown key is rejected (the self-contained branch has teeth).
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'core block carries shared blockBase id/attributes',
+    validInstance: { type: 'paragraph', id: 'p1', attributes: { dir: 'ltr', lang: 'en' }, children: [] },
+    invalidInstance: { type: 'paragraph', id: 'p1', children: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'open escape: unknown namespaced block passes; bare unknown type rejected',
+    // A namespaced extension we do not recognise is open-world (fields unchecked);
+    // a bare (non-namespaced) unknown type is malformed per Content Blocks section 5.
+    validInstance: { type: 'myorg:widget', anything: 1, more: [true] },
+    invalidInstance: { type: 'bogus', anything: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'text node block (dual-context leaf) closed',
+    validInstance: { type: 'text', value: 'hi', marks: ['bold'] },
+    invalidInstance: { type: 'text', value: 'hi', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'image with bound presentation float',
+    validInstance: { type: 'image', src: 'assets/images/x.png', alt: 'x', float: { position: 'top', span: 'column' } },
+    invalidInstance: { type: 'image', src: 'assets/images/x.png', alt: 'x', float: { position: 'top' }, bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'figure children constrained to figure-content item types',
+    validInstance: { type: 'figure', children: [{ type: 'image', src: 'a.png', alt: 'a' }, { type: 'figcaption', children: [] }] },
+    invalidInstance: { type: 'figure', children: [{ type: 'paragraph', children: [] }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'signature.signer (inline ad-hoc person) closed',
+    validInstance: { type: 'signature', signatureType: 'digital', signer: { name: 'Ada', title: 'CEO' } },
+    invalidInstance: { type: 'signature', signatureType: 'digital', signer: { name: 'Ada', bogus: 1 } },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/blockAttributes',
+    description: 'blockAttributes closed (semantic JSON-LD stays open)',
+    validInstance: { dir: 'rtl', lang: 'ar', semantic: { '@type': 'Article', vocabExtra: true } },
+    invalidInstance: { dir: 'rtl', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/linkMark',
+    description: 'linkMark closed',
+    validInstance: { type: 'link', href: '#x', title: 't' },
+    invalidInstance: { type: 'link', href: '#x', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/anchorMark',
+    description: 'anchorMark closed',
+    validInstance: { type: 'anchor', id: 'a1' },
+    invalidInstance: { type: 'anchor', id: 'a1', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/mathMark',
+    description: 'mathMark closed',
+    validInstance: { type: 'math', format: 'latex', source: 'x^2' },
+    invalidInstance: { type: 'math', format: 'latex', source: 'x^2', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/highlightToken',
+    description: 'highlightToken closed',
+    validInstance: { type: 'keyword', value: 'const' },
+    invalidInstance: { type: 'keyword', value: 'const', bogus: 1 },
+  },
+
+  // --- extension block dispatch teeth (4.1e) -------------------------------
+  // Each authored extension block type is now wired into content#/$defs/block.
+  // A minimal valid instance is accepted and the same block with an unknown key
+  // is rejected (the wired branch closes via unevaluatedProperties:false).
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'academic:abstract wired + closed',
+    validInstance: { type: 'academic:abstract', children: [] },
+    invalidInstance: { type: 'academic:abstract', children: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'academic:theorem wired + closed',
+    validInstance: { type: 'academic:theorem', variant: 'theorem', id: 't1', children: [] },
+    invalidInstance: { type: 'academic:theorem', variant: 'theorem', children: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'academic:proof wired + closed',
+    validInstance: { type: 'academic:proof', children: [] },
+    invalidInstance: { type: 'academic:proof', children: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'academic:algorithm wired + closed',
+    validInstance: { type: 'academic:algorithm', lines: [] },
+    invalidInstance: { type: 'academic:algorithm', lines: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'academic:equation-group wired + closed',
+    validInstance: { type: 'academic:equation-group', lines: [] },
+    invalidInstance: { type: 'academic:equation-group', lines: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'academic:exercise-set wired + closed',
+    validInstance: { type: 'academic:exercise-set', exercises: [] },
+    invalidInstance: { type: 'academic:exercise-set', exercises: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'academic:exercise wired + closed (top-level + nested)',
+    validInstance: { type: 'academic:exercise', children: [] },
+    invalidInstance: { type: 'academic:exercise', children: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:footnote wired + closed',
+    validInstance: { type: 'semantic:footnote', number: 1, content: 'note' },
+    invalidInstance: { type: 'semantic:footnote', number: 1, content: 'note', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:bibliography wired + closed',
+    validInstance: { type: 'semantic:bibliography', style: 'apa' },
+    invalidInstance: { type: 'semantic:bibliography', style: 'apa', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:term wired + closed',
+    validInstance: { type: 'semantic:term', term: 'T', definition: 'D' },
+    invalidInstance: { type: 'semantic:term', term: 'T', definition: 'D', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:ref wired + closed',
+    validInstance: { type: 'semantic:ref', target: '#x' },
+    invalidInstance: { type: 'semantic:ref', target: '#x', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:glossary wired + closed',
+    validInstance: { type: 'semantic:glossary', sort: 'alphabetical' },
+    invalidInstance: { type: 'semantic:glossary', sort: 'alphabetical', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:measurement wired + closed',
+    validInstance: { type: 'semantic:measurement', value: 1, unit: 'm' },
+    invalidInstance: { type: 'semantic:measurement', value: 1, unit: 'm', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'legal:caption wired + closed',
+    validInstance: { type: 'legal:caption', court: 'Supreme Court' },
+    invalidInstance: { type: 'legal:caption', court: 'Supreme Court', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'legal:signatureBlock wired + closed',
+    validInstance: { type: 'legal:signatureBlock', role: 'counsel', signer: { name: 'Ada' } },
+    invalidInstance: { type: 'legal:signatureBlock', role: 'counsel', signer: { name: 'Ada' }, bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'legal:tableOfAuthorities wired + closed',
+    validInstance: { type: 'legal:tableOfAuthorities', title: 'Authorities' },
+    invalidInstance: { type: 'legal:tableOfAuthorities', title: 'Authorities', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:form wired + closed (children allow core + field blocks)',
+    validInstance: { type: 'forms:form', children: [{ type: 'heading', level: 2, children: [] }, { type: 'forms:submit' }] },
+    invalidInstance: { type: 'forms:form', children: [], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:textInput wired + closed; baseFormField props accepted (allOf fix)',
+    // The latent forms bug rejected baseFormField fields (name/label/placeholder)
+    // across the $ref; the unevaluatedProperties:false restructure accepts them.
+    validInstance: { type: 'forms:textInput', name: 'email', label: 'Email', placeholder: 'you@x.com', inputType: 'email' },
+    invalidInstance: { type: 'forms:textInput', name: 'email', notAField: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:textArea wired + closed',
+    validInstance: { type: 'forms:textArea', name: 'bio', label: 'Bio', rows: 6 },
+    invalidInstance: { type: 'forms:textArea', name: 'bio', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:checkbox wired + closed',
+    validInstance: { type: 'forms:checkbox', name: 'agree', label: 'Agree', defaultChecked: false },
+    invalidInstance: { type: 'forms:checkbox', name: 'agree', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:radioGroup wired + closed',
+    validInstance: { type: 'forms:radioGroup', name: 'plan', options: [{ value: 'a', label: 'A' }] },
+    invalidInstance: { type: 'forms:radioGroup', name: 'plan', options: [{ value: 'a', label: 'A' }], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:dropdown wired + closed',
+    validInstance: { type: 'forms:dropdown', name: 'country', options: [{ value: 'gb', label: 'UK' }] },
+    invalidInstance: { type: 'forms:dropdown', name: 'country', options: [{ value: 'gb', label: 'UK' }], bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:datePicker wired + closed',
+    validInstance: { type: 'forms:datePicker', name: 'dob', label: 'DOB' },
+    invalidInstance: { type: 'forms:datePicker', name: 'dob', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:signature wired + closed',
+    validInstance: { type: 'forms:signature', name: 'sig', label: 'Sign' },
+    invalidInstance: { type: 'forms:signature', name: 'sig', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:submit wired + closed',
+    validInstance: { type: 'forms:submit', label: 'Send' },
+    invalidInstance: { type: 'forms:submit', label: 'Send', bogus: 1 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'presentation:reference wired + closed',
+    validInstance: { type: 'presentation:reference', target: '#fig1', format: 'Figure #' },
+    invalidInstance: { type: 'presentation:reference', target: '#fig1', bogus: 1 },
+  },
+
+  // --- per-schema fragment coverage for CLOSED_SCHEMAS (4.1e) ---------------
+  // The extension block teeth above run through content#/$defs/block, so each
+  // extension schema also owns a self-contained closed-def vector so the
+  // CLOSED_SCHEMAS coverage check (every closed schema owns >=1 vector) holds.
+  {
+    schema: 'academic.schema.json',
+    ref: '#/$defs/equationLine',
+    description: 'academic equationLine closed',
+    validInstance: { value: 'e=mc^2', number: '1' },
+    invalidInstance: { value: 'e=mc^2', bogus: 1 },
+  },
+  {
+    schema: 'legal.schema.json',
+    ref: '#/$defs/legalCiteMark',
+    description: 'legal legalCiteMark closed',
+    validInstance: { type: 'legal:cite', citation: 'Roe v. Wade', category: 'cases' },
+    invalidInstance: { type: 'legal:cite', citation: 'Roe v. Wade', category: 'cases', bogus: 1 },
+  },
+  {
+    schema: 'forms.schema.json',
+    ref: '#/$defs/validation',
+    description: 'forms validation closed',
+    validInstance: { required: true, minLength: 1, message: 'required' },
+    invalidInstance: { required: true, bogus: 1 },
+  },
+  {
+    schema: 'semantic.schema.json',
+    ref: '#/$defs/citationMark',
+    description: 'semantic citationMark closed',
+    validInstance: { type: 'citation', refs: ['doe2020'], locator: '12' },
+    invalidInstance: { type: 'citation', refs: ['doe2020'], bogus: 1 },
+  },
+  {
+    schema: 'semantic.schema.json',
+    ref: '#/$defs/footnoteMark',
+    description: 'semantic footnoteMark closed',
+    validInstance: { type: 'footnote', number: 1 },
+    invalidInstance: { type: 'footnote', number: 1, bogus: 1 },
+  },
+  {
+    schema: 'semantic.schema.json',
+    ref: '#/$defs/entityMark',
+    description: 'semantic entityMark closed',
+    validInstance: { type: 'entity', uri: 'https://www.wikidata.org/wiki/Q1' },
+    invalidInstance: { type: 'entity', uri: 'https://www.wikidata.org/wiki/Q1', bogus: 1 },
+  },
+  {
+    schema: 'semantic.schema.json',
+    ref: '#/$defs/glossaryMark',
+    description: 'semantic glossaryMark closed',
+    validInstance: { type: 'glossary', ref: 'term-1' },
+    invalidInstance: { type: 'glossary', ref: 'term-1', bogus: 1 },
   },
 ];

--- a/scripts/lib/part-schema.ts
+++ b/scripts/lib/part-schema.ts
@@ -13,9 +13,11 @@ import { createAjv, loadSchema } from './ajv-utils.js';
 // Schema dependencies (schemas that need other schemas loaded first so their
 // cross-file $refs resolve at compile time).
 const schemaDependencies: Record<string, string[]> = {
-  'content.schema.json': ['semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json'],
+  'content.schema.json': ['semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'],
   'collaboration.schema.json': ['anchor.schema.json'],
-  'phantoms.schema.json': ['anchor.schema.json'],
+  // phantoms embeds the core content block model (phantomContent.blocks → content
+  // block dispatch), so it needs content plus content's whole cross-file cluster.
+  'phantoms.schema.json': ['anchor.schema.json', 'semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json', 'content.schema.json'],
   'security.schema.json': ['anchor.schema.json'],
   'annotations.schema.json': ['anchor.schema.json'],
   // dublin-core references anchor.schema.json#/$defs/mimeType (the shared

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -28,10 +28,12 @@ const dependentSchemas: DependentSchema[] = [
   { schema: 'annotations.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'asset-index.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'collaboration.schema.json', refs: ['anchor.schema.json'] },
-  { schema: 'content.schema.json', refs: ['semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json'] },
+  { schema: 'content.schema.json', refs: ['semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'] },
   { schema: 'dublin-core.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'manifest.schema.json', refs: ['anchor.schema.json'] },
-  { schema: 'phantoms.schema.json', refs: ['anchor.schema.json'] },
+  // phantoms embeds the content block model, which dispatches across the whole
+  // content + extension-schema cluster.
+  { schema: 'phantoms.schema.json', refs: ['anchor.schema.json', 'content.schema.json', 'semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'] },
   { schema: 'precise-layout.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'provenance.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'security.schema.json', refs: ['anchor.schema.json'] },

--- a/spec/extensions/presentation/README.md
+++ b/spec/extensions/presentation/README.md
@@ -433,6 +433,8 @@ The core `figure` block supports basic `numbering` ("auto", "none", or explicit 
 
 The `numberingConfig` field provides extended numbering configuration beyond the core `numbering` field. The core `numbering` field (string or integer) controls basic numbering mode, while `numberingConfig` provides presentation-specific formatting options.
 
+> **Note:** The closed `figure` block schema currently validates only the core `numbering` field. `numberingConfig` is described here as a planned capability; its full shape is not yet part of the schema, so the closed `figure` block does not accept it today. Schematizing `numberingConfig` is deferred to a future revision.
+
 ```json
 {
   "type": "figure",


### PR DESCRIPTION
## Summary

Completes Phase 4. Closes the content block model and wires every authored extension block type into the core dispatch.

- Wire all 26 extension block type-consts (academic, semantic, legal, forms, `presentation:reference`) plus core `tableRow`/`tableCell` into the content block dispatch.
- Close the block model via the self-contained-branch pattern: a shared `blockBase` (`{type,id,attributes}`) composed by every block def via `allOf` + `unevaluatedProperties:false`, so a block keeps its shared identity in both the dispatch context and when referenced directly as a child.
- Open escape: an unrecognised type must be namespaced (per Content Blocks §5); unknown namespaced blocks pass (open-world), while a bare unknown type is rejected as malformed.
- Fix the forms field-block latent closure bug (inner `additionalProperties:false` sat over `allOf {$ref baseFormField}` and rejected the base fields; closure moves to `unevaluatedProperties:false` at the parent).
- Deep recursive closure: extension blocks' children/content arrays are constrained to the content block (or text-node) model.
- Close the open content and semantic marks, `blockAttributes` (keeping the JSON-LD annotation open), and the inline `signature.signer`.
- Bind the presentation `float` onto content image/figure blocks; remove the orphaned forms `formBlock` union; re-point phantom content at the real block model.
- Reconcile the semantic-document bibliography example (`title` is a non-null string per spec; drop the stray null) and re-freeze that draft document id.
- Grow `check:schema-closure` to 161 vectors across 13 schemas; note in the presentation spec that `figure.numberingConfig` is not yet schematized.

## Test plan

- [x] Clean `npm ci` + full gate suite green: `npm test`, `test:canonicalize`, `check:document-id`, `check:manifest-projection`, `check:jws-envelope`, `check:trust-state`, `check:webauthn`, `check:signature-set`, `check:lineage`, `check:provenance-timestamp`, `check:schema-closure`, `check:sync`, `check:refs`, `check:coverage`, `check:hash-centralization`, `tsc --noEmit`, `npm audit --audit-level=high`.
- [x] `check:document-id` verifies all 11 corpus ids — only `semantic-document` re-frozen, no other id moved.
- [x] `check:schema-closure` at 161 vectors / 13 schemas: per-extension-block teeth, open-escape accept + bare-unknown reject, forms allOf-fix regression.