### PR TITLE
Phase 5.1: document manifest fields + ratify asset-index per-category

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -4,13 +4,15 @@ This directory contains JSON Schema definitions for validating CDX document comp
 
 ## Schema Files
 
+The tables below are the canonical registry of CDX part paths: each schema is paired with the archive path(s) it governs.
+
 | Schema | Purpose | Validates |
 |--------|---------|-----------|
 | `manifest.schema.json` | Document manifest | `manifest.json` |
 | `content.schema.json` | Semantic content blocks | `content/document.json` |
 | `presentation.schema.json` | Presentation layer | `presentation/*.json` |
 | `precise-layout.schema.json` | Precise layouts | `presentation/layouts/*.json` |
-| `asset-index.schema.json` | Asset index | `assets/index.json` |
+| `asset-index.schema.json` | Asset index | `assets/<category>/index.json` |
 | `dublin-core.schema.json` | Dublin Core metadata | `metadata/dublin-core.json` |
 | `provenance.schema.json` | Provenance records | `provenance/record.json` |
 | `anchor.schema.json` | Content anchor definitions | (shared definitions) |
@@ -23,6 +25,7 @@ This directory contains JSON Schema definitions for validating CDX document comp
 |--------|---------|-----------|
 | `semantic.schema.json` | Semantic extension | `semantic:*` blocks and marks |
 | `academic.schema.json` | Academic extension | `academic:*` blocks and marks |
+| `legal.schema.json` | Legal extension | `legal:*` blocks and marks |
 | `collaboration.schema.json` | Collaboration extension | `collaboration/comments.json`, `collaboration/changes.json` |
 | `forms.schema.json` | Forms extension | `forms/data.json`, `forms:*` blocks |
 | `security.schema.json` | Security extension | `security/signatures.json`, `security/encryption.json` |

--- a/spec/core/02-manifest.md
+++ b/spec/core/02-manifest.md
@@ -62,6 +62,13 @@ The manifest MUST be:
 | `extensions` | array | Active extension declarations |
 | `lineage` | object | Version history and parent reference |
 | `phantoms` | object | Phantom layer reference (Phantom Extension) |
+| `hashAlgorithm` | string | Hash algorithm for the document ID (default `sha256`) |
+| `provenance` | string | Path to the provenance record file |
+| `signaturePolicy` | object | Required-signer policy (Security Extension) |
+| `academic` | object | Academic Extension configuration |
+| `semantic` | object | Semantic Extension configuration |
+| `legal` | object | Legal Extension configuration |
+| `collaboration` | object | Collaboration Extension configuration |
 
 ## 4. Field Definitions
 
@@ -327,6 +334,59 @@ Version history and document relationships. The manifest lineage provides a summ
 | `version` | integer | No | Sequential version number |
 | `branch` | string | No | Branch identifier for parallel versions |
 | `note` | string | No | Description of changes from parent |
+
+### 4.14 `hashAlgorithm` (Optional)
+
+The hash algorithm used to compute the document `id`. Defaults to `sha256` when omitted.
+
+```json
+{
+  "hashAlgorithm": "sha256"
+}
+```
+
+When present, this value MUST match the algorithm prefix of the `id`. See the Document Hashing specification for the supported algorithms and computation rules.
+
+### 4.15 `provenance` (Optional)
+
+Path to the provenance record file, which carries the document's extended lineage chain, derivation history, and timestamps beyond the summary in `lineage`.
+
+```json
+{
+  "provenance": "provenance/record.json"
+}
+```
+
+The canonical location is `provenance/record.json`. See the Provenance and Lineage specification.
+
+### 4.16 `signaturePolicy` (Optional)
+
+The document's signature policy. Its `requiredSigners` set binds the signature set against stripping and downgrade: the policy rides in the signed manifest projection, so every manifest-covering signature attests it. While any such signature survives, the set is tamper-evident — a stripped required signer is detected (survivors still declare it required), and editing the set breaks each survivor's manifest coverage.
+
+```json
+{
+  "signaturePolicy": {
+    "requiredSigners": [ ... ]
+  }
+}
+```
+
+See the Security Extension specification.
+
+### 4.17 Extension Configuration (`academic`, `semantic`, `legal`, `collaboration`) (Optional)
+
+Top-level configuration objects for the correspondingly named extensions. Each is an open object whose shape is defined by the extension that owns it — for example, file-path pointers or rendering options — and appears at the manifest root only when that extension is active.
+
+```json
+{
+  "academic": { ... },
+  "semantic": { ... },
+  "legal": { ... },
+  "collaboration": { ... }
+}
+```
+
+See the relevant extension specification for each object's shape.
 
 ## 5. Validation
 

--- a/spec/core/05-asset-embedding.md
+++ b/spec/core/05-asset-embedding.md
@@ -39,7 +39,7 @@ assets/
 
 ### 3.1 Index File
 
-Each asset category has an index file (`index.json`) that catalogs all assets:
+Each asset category declared in the manifest MUST have its own index file located at `assets/<category>/index.json`, where `<category>` is the corresponding key in the manifest's `assets` object. Asset `path` values within an index are resolved relative to that category directory. The index catalogs all assets in the category:
 
 ```json
 {

--- a/spec/core/08-metadata.md
+++ b/spec/core/08-metadata.md
@@ -37,7 +37,7 @@ Location: `metadata/extended.json` (or custom paths)
 
 ### 3.1 File Format
 
-The `version` field in Dublin Core metadata refers to the Dublin Core Metadata Element Set standard version (currently 1.1), not the CDX specification version. The CDX specification version is declared in the manifest's `specVersion` field.
+The `version` field in Dublin Core metadata refers to the Dublin Core Metadata Element Set standard version (currently 1.1), not the CDX specification version. The CDX specification version is declared in the manifest's `cdx` field.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Document the seven manifest fields used by example documents but absent from the manifest reference: `provenance`, `signaturePolicy`, `hashAlgorithm` (cross-referenced to Document Hashing), and the `academic`/`semantic`/`legal`/`collaboration` extension-config slots (`02-manifest.md` §3.3 + §4.14–4.17).
- State the per-category asset index model normatively: each declared category has its own index at `assets/<category>/index.json`, with asset paths resolved relative to the category directory (`05-asset-embedding.md`). Matches the schema and the document-ID computation; no example or schema is restructured.
- Correct the metadata chapter to name the manifest's `cdx` field (`specVersion` was a phantom — no schema declares it).
- Curate the schema README as the canonical part-path registry: fix the stale single-index path and add the missing `legal.schema.json` row.

## Test plan
- [x] All 17 CI gates green from a clean `npm ci`
- [x] Re-freeze tripwires unchanged (`check:document-id`, `check:manifest-projection`) — a doc-only change moves no document id or manifest projection