### PR TITLE
Phase 5.2: reconcile presentation-precision rule + intro/profile staleness

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This divide creates workflow friction, format conversion overhead, and lost fide
 
 - Efficient compression using modern algorithms (Zstandard, AVIF)
 - Clear document state machine (draft → review → frozen/signed)
-- State-aware presentation (reactive for drafts, precise for frozen/published)
+- State-aware presentation (reactive for drafts, precise when page-precise fidelity is required)
 - Block-level proofs (prove a section exists without revealing the whole document)
 - Timestamp anchoring (RFC 3161, blockchain)
 - Accessibility built-in (WCAG-aligned)
@@ -109,20 +109,20 @@ CDX uses **progressive enhancement** for presentation — the level of layout pr
 |----------------|-------------------------|---------------|
 | DRAFT | Reactive only (hints/styles) | Nothing — content flows freely |
 | REVIEW | Reactive (precise optional) | Nothing — still editing |
-| FROZEN | Reactive + **precise required** | Content immutable; appearance locked |
+| FROZEN | Reactive (precise when fidelity required) | Content immutable; included layout locked |
 | PUBLISHED | Same as FROZEN | Authoritative, immutable record |
 
 ### Why This Matters
 
-When a document reaches FROZEN or PUBLISHED state, its **precise layout** (exact coordinates for every element) becomes part of the immutable record:
+When a frozen or published document includes a **precise layout** (exact coordinates for every element), that layout becomes part of the immutable record:
 
 - **Semantic content is the hash**: The document ID covers semantic content only — what it says, not how it looks
 - **Appearance is locked alongside content**: Precise layouts are immutable when frozen, but separate from the content hash. Use scoped signatures (Security Extension) for appearance attestation
 - **Citations are reliable**: "Page 7, line 23" means the same thing in every viewer
-- **Legal/archival integrity**: Frozen documents render pixel-perfectly, forever
+- **Legal/archival integrity**: documents that assert page-precise fidelity render pixel-perfectly, forever
 - **No viewer inconsistency**: Unlike PDF, whose appearance varies by renderer
 
-This is the key insight: **the state machine isn't just about workflow** — it enforces the relationship between content stability and presentation precision. You can't freeze a document without committing to exactly how it looks.
+This is the key insight: **the state machine isn't just about workflow** — it ties presentation precision to content stability. Freezing always locks the semantic content; documents that assert page-precise fidelity also commit the precise layout that shows exactly how they look.
 
 ```
 DRAFT                    FROZEN/PUBLISHED
@@ -131,7 +131,7 @@ DRAFT                    FROZEN/PUBLISHED
 │ (JSON blocks)   │      │ (JSON blocks)   │    (content hash)
 ├─────────────────┤      ├─────────────────┤
 │ Reactive hints  │  →   │ Reactive hints  │
-│ (optional)      │      │ + Precise layout│ ← Required, immutable
+│ (optional)      │      │ + Precise layout│ ← When fidelity required
 └─────────────────┘      │ (exact coords)  │    (scoped signatures
                          └─────────────────┘     for attestation)
 ```
@@ -145,6 +145,7 @@ The specification is modular:
 - [Container Format](spec/core/01-container-format.md) - ZIP-based packaging
 - [Manifest](spec/core/02-manifest.md) - Document metadata and structure
 - [Content Blocks](spec/core/03-content-blocks.md) - Semantic content model
+- [Anchors and References](spec/core/03a-anchors-and-references.md) - Unified sub-block addressing
 - [Presentation Layers](spec/core/04-presentation-layers.md) - Rendering instructions
 - [Asset Embedding](spec/core/05-asset-embedding.md) - Images, fonts, files
 - [Document Hashing](spec/core/06-document-hashing.md) - Content-addressable identity
@@ -159,6 +160,9 @@ The specification is modular:
 - [Presentation Extension](spec/extensions/presentation/) - Advanced layout, print styling
 - [Forms Extension](spec/extensions/forms/) - Input fields, validation
 - [Semantic Extension](spec/extensions/semantic/) - JSON-LD, knowledge graphs, citations
+- [Academic Extension](spec/extensions/academic/) - Theorems, proofs, exercises, algorithms, equations
+- [Phantoms Extension](spec/extensions/phantoms/) - Off-page annotation clusters
+- [Legal Extension](spec/extensions/legal/) - Legal citations, clause references, jurisdiction metadata
 
 ## Quick Start
 
@@ -176,7 +180,7 @@ document.cdx
 │   ├── defaults.json      # Base styles
 │   ├── paginated.json     # Print hints (reactive)
 │   ├── continuous.json    # Screen hints (reactive)
-│   └── layouts/           # Precise layouts (required for FROZEN/PUBLISHED)
+│   └── layouts/           # Precise layouts (when fidelity required)
 │       ├── letter.json    # US Letter format coordinates
 │       └── a4.json        # A4 format coordinates
 ├── assets/

--- a/schemas/precise-layout.schema.json
+++ b/schemas/precise-layout.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdx.dev/schemas/precise-layout.schema.json",
   "title": "CDX Precise Layout",
-  "description": "Schema for precise layout files (presentation/layouts/*.json) in a CDX document. Required for FROZEN and PUBLISHED states.",
+  "description": "Schema for precise layout files (presentation/layouts/*.json) in a CDX document. Required for FROZEN and PUBLISHED documents that assert page-precise fidelity; recommended otherwise.",
   "type": "object",
   "required": ["version", "presentationType", "targetFormat", "pageSize", "contentHash", "generatedAt", "pages"],
   "properties": {

--- a/spec/core/00-introduction.md
+++ b/spec/core/00-introduction.md
@@ -108,7 +108,7 @@ document.cdx
 ├── presentation/
 │   ├── paginated.json      # Fixed layout presentation (optional)
 │   ├── continuous.json     # Reflow presentation (optional)
-│   └── layouts/            # Precise layouts (required for FROZEN/PUBLISHED)
+│   └── layouts/            # Precise layouts (when page-precise fidelity is required)
 │       ├── letter.json     # US Letter format coordinates
 │       └── a4.json         # A4 format coordinates
 ├── assets/
@@ -173,6 +173,7 @@ Extension specifications (optional modules) are defined separately:
 - Phantom Extension
 - Forms Extension
 - Semantic Extension
+- Academic Extension
 - Legal Extension
 
 ### 1.8 Versioning

--- a/spec/core/04-presentation-layers.md
+++ b/spec/core/04-presentation-layers.md
@@ -39,12 +39,12 @@ Presentation precision evolves with document maturity. The presentation layer fo
 |----------------|-------------------------|-----------|
 | **DRAFT** | Reactive only | Content is fluid, layout doesn't matter yet |
 | **REVIEW** | Reactive (precise optional) | Reviewers see approximate pagination |
-| **FROZEN** | Reactive + **precise required** | Layout becomes part of immutable record |
-| **PUBLISHED** | Same as FROZEN | Authoritative appearance, pixel-perfect |
+| **FROZEN** | Reactive (precise when page-precise fidelity is required) | Content immutable; an included layout is locked too |
+| **PUBLISHED** | Same as FROZEN | Authoritative, immutable record |
 
 ### 3.2 Why State-Awareness Matters
 
-1. **Provenance integrity** — When frozen, the precise layout is immutable alongside the content. The document ID covers semantic content; use scoped signatures (Security Extension) for appearance attestation
+1. **Provenance integrity** — When a frozen document includes a precise layout, that layout is immutable alongside the content. The document ID covers semantic content; use scoped signatures (Security Extension) for appearance attestation
 2. **Legal/academic needs** — Citations reference "page 7, line 23" with confidence
 3. **Lifecycle alignment** — Precision emerges naturally as documents mature
 4. **No capability loss** — Semantic content always present for accessibility/search
@@ -60,11 +60,11 @@ Presentation precision evolves with document maturity. The presentation layer fo
 
 When transitioning to FROZEN or PUBLISHED state:
 
-1. At least one precise layout MUST exist
-2. The layout's `contentHash` MUST match current content hash
-3. If layout is stale, transition MUST fail
+1. If the document asserts page-precise fidelity (e.g. citable pagination or print/legal use), at least one precise layout MUST exist; otherwise a precise layout is RECOMMENDED but not required
+2. Any precise layout present MUST have a `contentHash` matching the current content hash
+3. If a present layout is stale, the transition MUST fail
 
-This ensures that when a document is "frozen," its appearance is frozen too.
+Freezing always locks the semantic content (the document ID). When a precise layout is included, its appearance is locked alongside the content and attested via scoped signatures (Security Extension).
 
 ## 4. Presentation File Structure
 
@@ -78,7 +78,7 @@ presentation/
 ├── continuous.json       # Reactive: scroll layout hints
 ├── responsive.json       # Reactive: viewport adaptation
 └── layouts/              # Precise: exact coordinates
-    ├── letter.json       # Required for FROZEN/PUBLISHED
+    ├── letter.json       # Used when page-precise fidelity is required
     └── a4.json           # Additional formats (optional)
 ```
 
@@ -182,7 +182,7 @@ Supported units:
 
 | Unit | Description | Use |
 |------|-------------|-----|
-| `px` | Pixels (72 per inch for print) | Absolute sizing |
+| `px` | Pixels (96 per inch, CSS reference pixel) | Absolute sizing |
 | `pt` | Points (1/72 inch) | Typography |
 | `em` | Relative to font size | Responsive sizing |
 | `rem` | Relative to root font size | Consistent sizing |
@@ -635,7 +635,7 @@ If `contentHash` doesn't match current content hash, the presentation should be 
 
 ## 12. Precise Layouts
 
-Precise layouts provide exact coordinates for every element, enabling pixel-perfect reproduction regardless of rendering implementation. They are **required** for FROZEN and PUBLISHED documents.
+Precise layouts provide exact coordinates for every element, enabling pixel-perfect reproduction regardless of rendering implementation. They are **required** for FROZEN and PUBLISHED documents that assert page-precise fidelity (e.g. citable pagination or print/legal use), and **RECOMMENDED** otherwise.
 
 ### 12.1 Location
 
@@ -810,8 +810,8 @@ Layout Hash:  sha256:abc123...  ✗ Stale - content has changed
 |-------|------------------------|-----------------|
 | DRAFT | No | No |
 | REVIEW | No | Optional |
-| FROZEN | **Yes** | **Yes** (must match) |
-| PUBLISHED | **Yes** | **Yes** (must match) |
+| FROZEN | When page-precise fidelity is asserted (else recommended) | **Yes**, if a layout is present |
+| PUBLISHED | When page-precise fidelity is asserted (else recommended) | **Yes**, if a layout is present |
 
 ## 13. Fallback Behavior
 

--- a/spec/extensions/README.md
+++ b/spec/extensions/README.md
@@ -71,7 +71,6 @@ Most extensions store data in dedicated directories:
 | collaboration | `collaboration/` | `comments.json`, `changes.json` |
 | security | `security/` | `signatures.json`, `encryption.json` |
 | phantoms | `phantoms/` | `clusters.json` |
-| legal | `legal/` | `citations.json` |
 
 ### Shared Definitions
 

--- a/spec/profiles/simple-documents.md
+++ b/spec/profiles/simple-documents.md
@@ -80,6 +80,8 @@ Simple Documents do not need:
   "cdx": "0.1",
   "id": "pending",
   "state": "draft",
+  "created": "2025-01-15T10:30:00Z",
+  "modified": "2025-01-15T10:30:00Z",
   "content": {
     "path": "content/document.json"
   },
@@ -96,6 +98,8 @@ Simple Documents do not need:
 | `cdx` | Yes | Specification version |
 | `id` | Yes | Use `"pending"` for drafts |
 | `state` | Yes | Typically `"draft"` for simple documents |
+| `created` | Yes | ISO 8601 creation timestamp |
+| `modified` | Yes | ISO 8601 last modification timestamp |
 | `content` | Yes | Path to content file |
 | `metadata.dublinCore` | Yes | Path to Dublin Core metadata |
 | `extensions` | No | Simple Documents use no extensions |
@@ -109,6 +113,8 @@ Simple Documents do not need:
   "cdx": "0.1",
   "id": "pending",
   "state": "draft",
+  "created": "2025-01-15T10:30:00Z",
+  "modified": "2025-01-15T10:30:00Z",
   "content": {
     "path": "content/document.json"
   },
@@ -116,14 +122,11 @@ Simple Documents do not need:
     "dublinCore": "metadata/dublin-core.json"
   },
   "assets": {
-    "index": [
-      {
-        "id": "cover",
-        "type": "image",
-        "path": "assets/images/cover.jpg",
-        "mimeType": "image/jpeg"
-      }
-    ]
+    "images": {
+      "count": 1,
+      "totalSize": 102400,
+      "index": "assets/images/index.json"
+    }
   }
 }
 ```
@@ -397,6 +400,8 @@ A minimal novel in three files:
   "cdx": "0.1",
   "id": "pending",
   "state": "draft",
+  "created": "2025-01-15T10:30:00Z",
+  "modified": "2025-01-15T10:30:00Z",
   "content": {
     "path": "content/document.json"
   },


### PR DESCRIPTION
## Summary
- Make the precise-layout requirement conditional: required for frozen/published documents only when they assert page-precise fidelity (citable pagination, print, legal use), and recommended otherwise. Aligns the presentation chapter, README, introduction, schema description, and the Simple Documents profile. The document ID covers semantic content only; appearance is attested by scoped signatures.
- Define the `px` unit as 96 per inch (CSS reference pixel) so it no longer collapses into `pt` and matches the format's CSS lineage.
- Index the Anchors-and-References (`03a`) chapter and the Academic, Phantoms, and Legal extensions in the top-level README; add the Academic extension to the introduction's listing.
- Remove the phantom `legal/citations.json` reference (the legal extension has no dedicated part file).
- Add the required `created`/`modified` fields to the profile manifest examples and field table, and correct the cover-image example's `assets` declaration to the per-category index form.

## Test plan
- [x] All 17 CI gates green from a clean `npm ci`
- [x] Re-freeze tripwires unchanged (`check:document-id`, `check:manifest-projection`) — doc/prose plus one schema description; no document id or manifest projection moved