### PR TITLE
Phase 5: clear schema-spec drift warnings + schema riders

### DIFF
--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -1042,6 +1042,10 @@
             "float": {
               "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/float",
               "description": "Float positioning for this figure (presentation extension)"
+            },
+            "numberingConfig": {
+              "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/numberingConfig",
+              "description": "Extended figure numbering configuration (presentation extension)"
             }
           },
           "oneOf": [

--- a/schemas/presentation.schema.json
+++ b/schemas/presentation.schema.json
@@ -1048,6 +1048,21 @@
         }
       },
       "additionalProperties": false
+    },
+    "numberingConfig": {
+      "type": "object",
+      "description": "Extended figure numbering configuration (chapter-based numbering, format template). Defined here for reference by the content figure block.",
+      "properties": {
+        "style": {
+          "type": "string",
+          "description": "Numbering format template (e.g. \"Figure #\")"
+        },
+        "chapter": {
+          "type": "boolean",
+          "description": "Whether figure numbering is chapter-based"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/scripts/check-spec-schema-sync.ts
+++ b/scripts/check-spec-schema-sync.ts
@@ -22,7 +22,9 @@
  *
  * Matching is exact-token (see specTokens), so `config` does not spuriously match
  * `configuration`. The token class includes ':' so namespaced discriminators like
- * `academic:theorem` are matched whole.
+ * `academic:theorem` are matched whole. Warned values the tokenizer cannot
+ * represent (containing '/', '+', '*', e.g. `PDF/A-1`, `ECDH-ES+A256KW`) fall back
+ * to a literal substring check (see undocumentedWarned); gated names stay exact.
  *
  * Future: generate the spec's field tables from the schemas so drift is
  * impossible by construction rather than detected after the fact.
@@ -138,6 +140,19 @@ function undocumented(names: Map<string, string>, tokens: Set<string>): Array<[s
     .sort((a, b) => a[0].localeCompare(b[0]));
 }
 
+// Like `undocumented`, but for the WARNED categories (optional fields, enum
+// values). A value counts as documented if its exact token is present OR — for
+// values the tokenizer cannot represent (containing '/', '+', '*', etc., such as
+// `PDF/A-1` or `ECDH-ES+A256KW`) — its literal form appears as a substring of the
+// spec text. Gated categories stay strictly token-exact so a non-tokenizable
+// required prop can never be cleared by a coincidental substring.
+const TOKENIZABLE = /^[A-Za-z0-9_@.:-]+$/;
+function undocumentedWarned(names: Map<string, string>, tokens: Set<string>, specText: string): Array<[string, string]> {
+  return [...names.entries()]
+    .filter(([name]) => (TOKENIZABLE.test(name) ? !tokens.has(name) : !specText.includes(name)))
+    .sort((a, b) => a[0].localeCompare(b[0]));
+}
+
 function printList(items: Array<[string, string]>): void {
   for (const [name, source] of items) {
     console.log(`    ${name}`);
@@ -193,8 +208,9 @@ const declaredWithoutSchema = [...declaredTypes]
   .map(t => [t, 'spec via `Always "<type>"` idiom'] as [string, string]);
 
 // Warnings (schema -> spec): optional fields / enum values with no mention.
-const undocumentedOptional = undocumented(optional, tokens);
-const undocumentedEnums = undocumented(facts.enums, tokens);
+// Uses the substring fallback so non-tokenizable values (e.g. `PDF/A-1`) are matchable.
+const undocumentedOptional = undocumentedWarned(optional, tokens, specText);
+const undocumentedEnums = undocumentedWarned(facts.enums, tokens, specText);
 
 const gatedCount =
   undocumentedTypes.length + undocumentedRequired.length + declaredWithoutSchema.length;
@@ -219,7 +235,7 @@ if (undocumentedOptional.length > 0) {
   printList(undocumentedOptional);
 }
 if (undocumentedEnums.length > 0) {
-  console.log(`\n⚠ ${undocumentedEnums.length} enum value(s) not found in the spec (informational; values containing '/' or '+' may be tokenization artifacts):`);
+  console.log(`\n⚠ ${undocumentedEnums.length} enum value(s) not found in the spec (review: document or remove):`);
   printList(undocumentedEnums);
 }
 

--- a/scripts/generate-template.ts
+++ b/scripts/generate-template.ts
@@ -327,7 +327,7 @@ function selfValidate(outputDir: string, relPaths: string[]): void {
     const data = JSON.parse(fs.readFileSync(path.join(outputDir, relPath), 'utf8'));
     const validate = getValidator(rule.schema, rule.ref);
     if (validate(data)) {
-      console.log(`  ${rule.note ? '⚠' : '✓'} ${relPath}${rule.note ? ` — ${rule.note}` : ''}`);
+      console.log(`  ✓ ${relPath}`);
     } else {
       ok = false;
       console.error(`  ✗ ${relPath}`);

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -928,6 +928,13 @@ export const closureVectors: ClosureVector[] = [
   {
     schema: 'content.schema.json',
     ref: '#/$defs/block',
+    description: 'figure numberingConfig bound + closed (presentation extension)',
+    validInstance: { type: 'figure', children: [{ type: 'image', src: 'a.png', alt: 'a' }], numberingConfig: { style: 'Figure #', chapter: true } },
+    invalidInstance: { type: 'figure', children: [{ type: 'image', src: 'a.png', alt: 'a' }], numberingConfig: { style: 'Figure #', bogus: 1 } },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
     description: 'signature.signer (inline ad-hoc person) closed',
     validInstance: { type: 'signature', signatureType: 'digital', signer: { name: 'Ada', title: 'CEO' } },
     invalidInstance: { type: 'signature', signatureType: 'digital', signer: { name: 'Ada', bogus: 1 } },

--- a/scripts/lib/part-schema.ts
+++ b/scripts/lib/part-schema.ts
@@ -53,10 +53,6 @@ export interface Rule {
   test: RegExp;
   schema: string;
   ref?: string;
-  // Set when validation is known to be against a root schema that does NOT
-  // describe the part-file contents (i.e. currently vacuous). Reported as a
-  // warning rather than a clean ✓ so the gap is not mistaken for real coverage.
-  note?: string;
 }
 
 // Ordered rule table — FIRST match wins, so more-specific paths come first

--- a/scripts/validate-examples.ts
+++ b/scripts/validate-examples.ts
@@ -83,7 +83,7 @@ for (const exampleName of exampleDirs) {
     }
 
     if (validate(data)) {
-      console.log(`  ${rule.note ? '⚠' : '✓'} ${relPath}${rule.note ? ` — ${rule.note}` : ''}`);
+      console.log(`  ✓ ${relPath}`);
       validated++;
     } else {
       console.log(`  ✗ ${relPath}`);

--- a/spec/core/04-presentation-layers.md
+++ b/spec/core/04-presentation-layers.md
@@ -113,7 +113,7 @@ Presentation styling uses a subset of CSS properties. This provides familiarity 
 **Typography:**
 - `fontFamily` - Font family stack
 - `fontSize` - Font size (with units)
-- `fontWeight` - Font weight (100-900 or keywords)
+- `fontWeight` - Font weight (100-900, or keywords `normal`/`bold`/`bolder`/`lighter`)
 - `fontStyle` - normal, italic
 - `lineHeight` - Line height (unitless ratio or with units)
 - `letterSpacing` - Letter spacing
@@ -159,6 +159,8 @@ The `writingMode` property controls the direction of text flow and block progres
 **Borders:**
 - `borderWidth`, `borderStyle`, `borderColor`
 - Individual sides: `borderTopWidth`, etc.
+- Per-side shorthands: `borderTop`, `borderBottom`, `borderLeft`, `borderRight`
+- `borderCollapse` - table border model (`collapse` or `separate`)
 
 **Background:**
 - `backgroundColor`

--- a/spec/core/05-asset-embedding.md
+++ b/spec/core/05-asset-embedding.md
@@ -200,7 +200,7 @@ Content blocks reference images by path:
 |-------|------|-------------|
 | `family` | string | Font family name |
 | `weight` | integer | Font weight (100-900) |
-| `style` | string | Font style (normal, italic) |
+| `style` | string | Font style (normal, italic, oblique) |
 | `unicodeRange` | string | Supported Unicode ranges |
 
 ### 5.3 Font Families

--- a/spec/core/08-metadata.md
+++ b/spec/core/08-metadata.md
@@ -380,7 +380,7 @@ The document hash includes a projection of exactly these Dublin Core terms, extr
 - `description` (string)
 - `language` (array)
 
-A term that is absent or wholly empty (`""`/`[]`) is omitted from the projection. The structured `creators` array is not included.
+A term that is absent or wholly empty (`""`/`[]`) is omitted from the projection. The structured `creators` array (each entry an object with `name`, `orcid`, `affiliation`, and `email`) is not included.
 
 ### 6.2 Excluded from Hash
 

--- a/spec/core/09-provenance-and-lineage.md
+++ b/spec/core/09-provenance-and-lineage.md
@@ -548,6 +548,8 @@ Location: `provenance/record.json`
 }
 ```
 
+The `relationship` field describes how the derived document relates to its source: one of `excerpt`, `quotation`, `translation`, `revision`, or `derivation`.
+
 ### 8.2 Provenance Queries
 
 The provenance record enables queries like:

--- a/spec/extensions/forms/README.md
+++ b/spec/extensions/forms/README.md
@@ -433,7 +433,7 @@ When a document containing forms is frozen or published:
 
 When a form is submitted (`"submitted": true` in `forms/data.json`):
 
-- The submission state is recorded in the form data file
+- The submission state is recorded in the form data file, with the submission time in `submittedAt`
 - For archival purposes, implementations MAY create a new document version with form data folded into the content layer, producing a new document ID that captures the filled state
 
 ### 6.4 Hashing Exclusion

--- a/spec/extensions/legal/README.md
+++ b/spec/extensions/legal/README.md
@@ -26,6 +26,8 @@ The Legal Extension provides specialized blocks and marks for legal documents, i
 }
 ```
 
+A document-level default citation style MAY be set in the manifest's `legal` configuration object as `citationStyle` (e.g. `bluebook`); individual citations MAY override it.
+
 ## 3. Legal Citation Mark
 
 The `legal:cite` mark annotates text with legal citation information for automatic Table of Authorities generation.
@@ -215,6 +217,8 @@ Oxford University Standard for Citation of Legal Authorities (UK)
 }
 ```
 
+The `parties` object supports the role keys `plaintiff`, `defendant`, `appellant`, `appellee`, `petitioner`, and `respondent`; the caption MAY also name the assigned `judge`.
+
 ### 6.2 Signature Block
 
 Legal documents often require specific signature block formats:
@@ -233,6 +237,8 @@ Legal documents often require specific signature block formats:
   }
 }
 ```
+
+The signature block `role` is one of `counsel`, `attorney`, `party`, `witness`, or `notary`; the signer object MAY also include a `fax` number.
 
 ## 7. Examples
 

--- a/spec/extensions/presentation/README.md
+++ b/spec/extensions/presentation/README.md
@@ -175,6 +175,8 @@ A color definition is discriminated by `type`. An `rgb` or `cmyk` color carries 
 }
 ```
 
+The `standard` field selects the print/archival output intent. Supported values: `PDF/X-1a`, `PDF/X-3`, `PDF/X-4`, `PDF/A-1`, `PDF/A-2`, and `PDF/A-3`.
+
 ## 5. Master Pages
 
 ### 5.1 Definition
@@ -431,9 +433,7 @@ Span options: `column`, `page`, `spread`
 
 The core `figure` block supports basic `numbering` ("auto", "none", or explicit number). This extension adds chapter-based numbering via the `numberingConfig` field:
 
-The `numberingConfig` field provides extended numbering configuration beyond the core `numbering` field. The core `numbering` field (string or integer) controls basic numbering mode, while `numberingConfig` provides presentation-specific formatting options.
-
-> **Note:** The closed `figure` block schema currently validates only the core `numbering` field. `numberingConfig` is described here as a planned capability; its full shape is not yet part of the schema, so the closed `figure` block does not accept it today. Schematizing `numberingConfig` is deferred to a future revision.
+The `numberingConfig` field provides extended numbering configuration beyond the core `numbering` field. The core `numbering` field (string or integer) controls basic numbering mode, while `numberingConfig` provides presentation-specific formatting options (`style`, a format template such as `"Figure #"`, and `chapter`, a boolean enabling chapter-based numbering).
 
 ```json
 {
@@ -488,6 +488,8 @@ The `presentation:reference` block's `target` field uses Content Anchor URI synt
   }
 }
 ```
+
+The `leaders` style is one of `none`, `dots`, `dashes`, or `underline`.
 
 ### 8.2 List of Figures/Tables
 
@@ -560,6 +562,8 @@ In content:
 ```
 
 ### 10.2 Footnote Styling
+
+The footnote `position` is one of `page-bottom`, `column-bottom`, or `section-end`. The `numbering` style is one of `1`, `a`, `A`, `i`, `I`, or `*` (symbolic/asterisk).
 
 ```json
 {

--- a/spec/extensions/semantic/README.md
+++ b/spec/extensions/semantic/README.md
@@ -130,6 +130,8 @@ Location: `semantic/bibliography.json`
 }
 ```
 
+Entries follow CSL JSON, so any CSL field is permitted — including `ISSN`, `publisher-place`, an `issued` object with `day` (alongside `month`/`year`), and author objects that use `literal` for organizational names.
+
 ### 4.3 Citation Styles
 
 Supported styles:
@@ -386,6 +388,8 @@ The semantic extension provides `semantic:measurement` for measurements with lin
 | `value` | number | Yes | Numeric measurement value |
 | `unit` | string | Yes | Unit of measurement |
 | `schema` | object | No | Schema.org QuantitativeValue for linked data |
+
+The `schema` object follows Schema.org QuantitativeValue, using `unitCode` (UN/CEFACT code) and an optional `unitText` for the human-readable unit.
 
 #### 6.2.1 Core vs Semantic Measurements
 


### PR DESCRIPTION
## Summary
- Drive the spec-schema sync check to **zero** warnings: document every schema field and enum value the prose did not mention (legal party roles / signature roles + fax / citation style; CSL bibliography fields + measurement unit text; per-side border shorthands, border-collapse, font-weight keywords; PDF/X and PDF/A output intents; TOC leaders; footnote position + numbering; structured-creator ORCID; oblique font style; provenance derivation relationship; form submission timestamp).
- Teach the sync check to match values its tokenizer cannot represent (`/`, `+`, `*`) via a literal substring fallback, applied **only** to the non-gating warned categories; the gated required-property and type-discriminator checks stay strictly token-exact.
- Schematize the figure `numberingConfig` (presentation `$def` + figure binding, mirroring `float`); remove the disclosure note; add a schema-closure vector.
- Remove the unused `Rule.note` field and its dead reporting branches.

## Test plan
- [x] All 17 CI gates green from a clean `npm ci`; `check:sync` reports 0 warnings; `check:schema-closure` 162 vectors
- [x] Gate fix negative-tested (seed-and-revert): an undocumented non-tokenizable enum still warns; a non-tokenizable required prop still gates (exit 1)
- [x] Re-freeze tripwires unchanged (`check:document-id`, `check:manifest-projection`) — schema changes are additive/optional; no example uses `numberingConfig`