### PR TITLE
Phase 6 (PR1): conformant-reader contract — error-handling table + must-ignore-vs-reject

### DIFF
--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -353,7 +353,31 @@
                   { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/equationRefMark" },
                   { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/algorithmRefMark" },
                   { "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/indexMark" },
-                  { "$ref": "https://cdx.dev/schemas/legal.schema.json#/$defs/legalCiteMark" }
+                  { "$ref": "https://cdx.dev/schemas/legal.schema.json#/$defs/legalCiteMark" },
+                  {
+                    "$comment": "Open escape (mirrors the dispatch in #/$defs/block): known marks are validated strictly by the branches above; an unrecognized mark MUST be namespaced (Content Blocks section 5.1). An unknown namespaced mark passes unchecked — as either a bare string or a typed object — while a bare, non-namespaced unknown mark is rejected as malformed, so a misspelled core mark is still caught.",
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "allOf": [
+                          { "pattern": "^[A-Za-z0-9_-]+:[A-Za-z0-9._:-]+$" },
+                          { "not": { "$ref": "#/$defs/knownMarkTypes" } }
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                          "type": {
+                            "allOf": [
+                              { "pattern": "^[A-Za-z0-9_-]+:[A-Za-z0-9._:-]+$" },
+                              { "not": { "$ref": "#/$defs/knownMarkTypes" } }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
                 ]
               }
             }
@@ -361,6 +385,14 @@
         }
       ],
       "unevaluatedProperties": false
+    },
+    "knownMarkTypes": {
+      "$comment": "Every mark identifier validated by a branch of textNode.marks.items.oneOf — the seven core string marks and the twelve structured marks. The open escape excludes these so an unknown namespaced mark cannot collide with (or masquerade as) a known one in either string or object form.",
+      "enum": [
+        "bold", "italic", "underline", "strikethrough", "code", "superscript", "subscript",
+        "link", "anchor", "math", "citation", "footnote", "entity", "glossary",
+        "theorem-ref", "equation-ref", "algorithm-ref", "index", "legal:cite"
+      ]
     },
     "linkMark": {
       "type": "object",

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -911,6 +911,31 @@ export const closureVectors: ClosureVector[] = [
     validInstance: { type: 'text', value: 'hi', marks: ['bold'] },
     invalidInstance: { type: 'text', value: 'hi', bogus: 1 },
   },
+  // Mark open escape (6.2): unknown marks MUST be namespaced — the mark analogue
+  // of the block dispatch escape above. A namespaced unknown mark passes as a bare
+  // string or a typed object; a bare unknown mark (incl. a misspelled core mark)
+  // is rejected; a known mark name in the wrong form is rejected (no smuggling).
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'mark escape: unknown namespaced mark (bare string) passes; bare unknown mark rejected',
+    validInstance: { type: 'text', value: 'x', marks: ['myorg:flag'] },
+    invalidInstance: { type: 'text', value: 'x', marks: ['highlight'] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'mark escape: unknown namespaced mark (typed object) passes; misspelled core mark rejected',
+    validInstance: { type: 'text', value: 'x', marks: [{ type: 'myorg:flag', data: 1 }] },
+    invalidInstance: { type: 'text', value: 'x', marks: ['itlaic'] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'mark escape excludes known marks: core mark accepted; known namespaced mark in bare-string form rejected',
+    validInstance: { type: 'text', value: 'x', marks: ['bold'] },
+    invalidInstance: { type: 'text', value: 'x', marks: ['legal:cite'] },
+  },
   {
     schema: 'content.schema.json',
     ref: '#/$defs/block',

--- a/spec/core/01-container-format.md
+++ b/spec/core/01-container-format.md
@@ -175,6 +175,20 @@ Implementations MUST ignore unrecognized files and directories. This enables:
 - Application-specific metadata
 - Gradual migration between versions
 
+### 7.3 Closed by Default Within Files
+
+While unrecognized *files and directories* are ignored (section 7.2), the JSON inside a part file is validated **closed by default**: every object rejects properties the schema does not define, and every enumerated value set rejects values it does not list. An unknown property or enum value is a validation failure, dispositioned by document state (State Machine section 5.4) — never silently accepted.
+
+Forward compatibility *within* a file is provided only at these enumerated extension points, each deliberately open:
+
+- **Extension block types** — an unrecognized block whose `type` is namespaced (`namespace:type`) passes unchecked; a bare unrecognized type is rejected (Content Blocks section 5).
+- **Extension mark types** — the same rule for marks within a text node (Content Blocks section 5.1).
+- **Extension configuration** — the manifest's per-extension configuration objects and each extension's `config` are open (Manifest sections 4.10, 4.17).
+- **Asset metadata** — an asset entry's `metadata` object is open, its shape being asset-type-specific (Asset Embedding).
+- **Renderer defaults** — a presentation file's free-form style bags — the root `defaults`, each named style's `base` overrides, and a section's `attributes` — are open, carrying renderer- and theme-specific keys (Presentation Layers).
+
+Everything else — manifest fields, Dublin Core terms, presentation modes, asset-index fields, signature structures — is closed: an unknown name there is a defect, not a forward-compatibility signal. An extension adds new structured data under one of the points above, or in a namespaced file or directory (section 7.1) — never by introducing unknown keys into a closed object.
+
 ## 8. Implementation Notes
 
 ### 8.1 Creating Archives

--- a/spec/core/02-manifest.md
+++ b/spec/core/02-manifest.md
@@ -84,7 +84,7 @@ The specification version this document conforms to.
 
 Format: `MAJOR.MINOR` (PATCH omitted for documents)
 
-Implementations MUST reject documents with a major version they do not support.
+Implementations MUST reject documents with a major version they do not support. A higher **minor** version within a supported major version MUST NOT be rejected: an implementation SHOULD process the fields it recognizes and ignore unrecognized additions (a warning disposition — State Machine section 5.4).
 
 ### 4.2 `id` (Required)
 
@@ -275,7 +275,7 @@ Array of active extensions beyond the core specification.
 | `version` | string | Yes | Extension version |
 | `required` | boolean | Yes | Whether extension is required for correct rendering |
 
-If `required` is `true`, implementations that do not support the extension MUST refuse to process the document.
+If `required` is `true`, implementations that do not support the extension MUST refuse to process the document. If `required` is `false`, an implementation that does not support the extension MUST still process the document, ignoring that extension's data and degrading gracefully (State Machine section 5.4).
 
 ### 4.11 `metadata` (Required)
 
@@ -400,9 +400,11 @@ Implementations MUST verify:
 4. Referenced files exist in archive
 5. File hashes match when present
 
+The disposition when any of these checks fails is defined by State Machine section 5.4.
+
 ### 5.2 Hash Verification
 
-For frozen documents, implementations SHOULD verify that referenced file hashes match actual contents. Hash mismatches in frozen documents MUST be reported as errors.
+For frozen and published documents, implementations MUST verify that referenced file hashes match actual contents; a mismatch is an INTEGRITY-ERROR (State Machine section 5.4).
 
 ### 5.3 State Consistency
 

--- a/spec/core/03-content-blocks.md
+++ b/spec/core/03-content-blocks.md
@@ -1005,9 +1005,12 @@ Example:
 
 ### 5.1 Extension Mark Types
 
-Extensions MAY define additional mark types for use within text nodes. Unlike block types, extension marks are NOT required to use a namespace prefix — marks operate within the text node's `marks` array where the collision risk is lower. However, extensions MAY use a namespace prefix (e.g., `legal:cite`) when the unqualified name could cause confusion with marks from other extensions.
+Extensions MAY define additional mark types for use within text nodes. An extension mark that is not registered in the core schema MUST use a namespace prefix (e.g., `myorg:flag`), exactly as extension block types do (section 5). The schema validates marks with an open escape: a recognized mark is checked strictly against its definition; an unrecognized **namespaced** mark passes unchecked (open-world forward compatibility); and an unrecognized **bare**, non-namespaced mark is rejected as malformed — which keeps a misspelled core mark (such as `itlaic`) from being silently accepted as an unknown mark. A reader's disposition for each case is given in the State Machine (section 5.4).
+
+A few registered marks carry a namespaced identifier of their own (for example `legal:cite`); these belong to the known set and are validated strictly, not treated as unknown.
 
 Extension marks:
+- MUST use a namespace prefix unless registered in the core schema
 - SHOULD be documented in the extension specification
 - MUST define their field table (type, required fields, optional fields)
 - SHOULD avoid names that collide with core marks or marks from commonly-paired extensions

--- a/spec/core/03a-anchors-and-references.md
+++ b/spec/core/03a-anchors-and-references.md
@@ -238,6 +238,8 @@ Implementations SHOULD validate that anchor targets (block IDs, named anchor IDs
 - **FROZEN/PUBLISHED**: Broken anchors produce an **error** because content is immutable, so a broken anchor indicates corruption or invalid construction.
 - Named anchor IDs that collide with block IDs MUST produce an error in all states, since the shared namespace requires uniqueness.
 
+These severities are the WARNING and INTEGRITY-ERROR dispositions of State Machine section 5.4.
+
 ### 7.3 Range Validation
 
 - `start` MUST be less than `end`

--- a/spec/core/04-presentation-layers.md
+++ b/spec/core/04-presentation-layers.md
@@ -833,6 +833,12 @@ For content blocks without styling rules:
 2. Log warning for implementers
 3. Render content in fallback style
 
+### 13.3 Unsupported Presentation Type
+
+A presentation's `type` (`paginated`, `continuous`, `responsive`) is a **closed** set: it selects the file's entire structure, so unlike a content block it has no defined fallback shape, and the set is intentionally not extensible. A `type` outside this set is a validation failure (State Machine section 5.4), not a forward-compatibility escape, and the `type` MUST agree between the manifest's `presentation` reference and the presentation file.
+
+An implementation that recognizes the `type` but does not implement that presentation mode falls back to default rendering (section 13.1); the document's content is unaffected.
+
 ## 14. Print Considerations
 
 ### 14.1 Page Breaks

--- a/spec/core/05-asset-embedding.md
+++ b/spec/core/05-asset-embedding.md
@@ -340,7 +340,7 @@ Each asset's hash MUST be verified when loading:
 1. Read asset file from archive
 2. Compute hash of file contents
 3. Compare with hash in index
-4. Reject on mismatch
+4. On mismatch, apply the state-keyed disposition of State Machine section 5.4 — a WARNING in draft/review, an INTEGRITY-ERROR in frozen/published
 
 ### 8.2 Hash Algorithm
 

--- a/spec/core/06-document-hashing.md
+++ b/spec/core/06-document-hashing.md
@@ -275,13 +275,13 @@ These hashes are computed from the raw asset bytes. When a content block referen
 1. Decompress file from archive
 2. Compute hash of decompressed bytes
 3. Compare with hash in manifest
-4. Reject on mismatch
+4. On mismatch, apply the state-keyed disposition (section 6.3; State Machine section 5.4)
 
 **Document-level verification:**
 1. Verify all file hashes
 2. Recompute document ID from canonical content
 3. Compare with ID in manifest
-4. Reject on mismatch
+4. On mismatch, apply the state-keyed disposition (section 6.3; State Machine section 5.4)
 
 ### 6.3 Hash Mismatch Handling
 
@@ -292,7 +292,7 @@ These hashes are computed from the raw asset bytes. When a content block referen
 | frozen | Error (document integrity compromised) |
 | published | Error (document integrity compromised) |
 
-For frozen/published documents, hash mismatches indicate tampering or corruption.
+For frozen/published documents, hash mismatches indicate tampering or corruption. The frozen/published *Error* disposition is the INTEGRITY-ERROR of State Machine section 5.4: the document MUST NOT be presented as valid and MUST NOT be edited in place, but MAY be shown read-only behind a prominent integrity warning.
 
 ## 7. Draft Documents
 

--- a/spec/core/07-state-machine.md
+++ b/spec/core/07-state-machine.md
@@ -284,12 +284,12 @@ The disposition depends on document state because state is a contract (section 2
 | Unsupported **required** extension (`required: true`) | REJECT | REJECT |
 | Unsupported **optional** extension (Manifest section 4.10) | IGNORE — degrade; SHOULD surface | IGNORE |
 | Unrecognized file or directory in the archive (Container Format) | IGNORE | IGNORE |
-| Unknown **namespaced** block type (Content Blocks section 5) | IGNORE — render a fallback when provided | IGNORE |
-| Unknown **bare**, non-namespaced block type | REJECT | REJECT |
+| Unknown **namespaced** block or mark type (Content Blocks sections 5, 5.1) | IGNORE — render a fallback (block) or the unmarked text (mark) | IGNORE |
+| Unknown **bare**, non-namespaced block or mark type | REJECT | REJECT |
 | Missing the required `content` part | REJECT | REJECT |
 | Missing required metadata — the Dublin Core part or a required term | WARNING | INTEGRITY-ERROR |
 | Missing another referenced part (presentation, provenance, …) | WARNING | INTEGRITY-ERROR |
-| Structurally malformed block of a **known** type | WARNING | INTEGRITY-ERROR |
+| Structurally malformed block or mark of a **known** type | WARNING | INTEGRITY-ERROR |
 | Dangling anchor reference (Anchors and References section 7.2) | WARNING | INTEGRITY-ERROR |
 | Dangling asset reference — a canonicalization error once the ID is computed (Document Hashing section 4.3.1) | WARNING | INTEGRITY-ERROR |
 | File `hash` or document-ID mismatch (Document Hashing section 6.3) | WARNING | INTEGRITY-ERROR |

--- a/spec/core/07-state-machine.md
+++ b/spec/core/07-state-machine.md
@@ -253,7 +253,62 @@ When loading a frozen/published document:
 2. Verify at least one signature exists
 3. Verify at least one signature is valid
 4. Recompute the document ID from the canonical content and verify it matches `manifest.id` (this is distinct from the raw file hash in `content.hash`)
-5. If any verification fails, warn user
+5. If any verification fails, apply the disposition of section 5.4
+
+### 5.4 Failure Dispositions
+
+Validation can fail in many ways. This section defines, normatively and in one place, what a conformant reader does for each failure class, keyed by document state. It is the canonical reconciliation of the per-class rules stated throughout the specification (Document Hashing sections 4.3.2 and 6.3, Anchors and References section 7.2, Asset Embedding section 8, Provenance and Lineage sections 3.3 and 6.7, and the Security Extension sections 3.7 and 3.12); where a referenced section describes the *mechanism* of a check it remains authoritative for that mechanism, while the *disposition* — what the reader does when the check fails — is defined here.
+
+#### 5.4.1 Disposition Vocabulary
+
+A reader's response to a failure is exactly one of the following, in increasing severity:
+
+- **IGNORE** — silently skip the unrecognized element and continue. Reserved for forward compatibility: material that a future version or an unsupported extension may legitimately add. The document remains valid; its editability is governed by document state (sections 5.1–5.2).
+- **WARNING** — surface the issue to the user and/or log it, but otherwise process the document normally. The document remains valid and a warning never blocks loading; editability is governed by document state (sections 5.1–5.2).
+- **INTEGRITY-ERROR** — the document parses, but an integrity claim cannot be confirmed. The reader MUST surface the failure, MUST NOT present the document as valid or authentic, and MUST NOT permit it to be edited in place (continuing work requires `fork()` to a new draft, section 4.4). The reader MAY render the content read-only behind a prominent, persistent integrity warning, and MAY instead refuse to render it (for example under a strict security policy). INTEGRITY-ERROR is the **minimum** obligation for an integrity failure: a reader MAY escalate any INTEGRITY-ERROR to a refusal, but MUST NOT downgrade one to a mere WARNING on a frozen or published document.
+- **REJECT** — the document cannot be coherently or safely loaded at all; the reader MUST refuse to process it. Reserved for failures that leave the document unparseable, ambiguous, or unsupportable.
+
+The line between INTEGRITY-ERROR and REJECT is whether the document can be meaningfully interpreted: a parseable document whose integrity is in doubt is an INTEGRITY-ERROR (the reader MAY show it, never as valid); a document that cannot be parsed, or whose identity cannot be established, is a REJECT.
+
+#### 5.4.2 Disposition by Failure Class
+
+The disposition depends on document state because state is a contract (section 2.2): `draft` and `review` documents are works in progress whose content is expected to change, so most defects are warnings; `frozen` and `published` documents assert fixed, integrity-checked content, so the same defect is an integrity failure.
+
+| Failure class | DRAFT / REVIEW | FROZEN / PUBLISHED |
+|---------------|----------------|--------------------|
+| Archive unreadable, or an unsafe path — `..` or an escaping symlink (Container Format) | REJECT | REJECT |
+| Duplicate JSON keys in any part (Document Hashing section 4.3.2) | REJECT | REJECT |
+| Manifest absent, unparseable, or missing or mistyping a required field | REJECT | REJECT |
+| Unsupported **major** version (Manifest) | REJECT | REJECT |
+| Unsupported **minor** version (Manifest section 4.1) | WARNING — process known fields, IGNORE unknown additions | WARNING |
+| Unsupported **required** extension (`required: true`) | REJECT | REJECT |
+| Unsupported **optional** extension (Manifest section 4.10) | IGNORE — degrade; SHOULD surface | IGNORE |
+| Unrecognized file or directory in the archive (Container Format) | IGNORE | IGNORE |
+| Unknown **namespaced** block type (Content Blocks section 5) | IGNORE — render a fallback when provided | IGNORE |
+| Unknown **bare**, non-namespaced block type | REJECT | REJECT |
+| Missing the required `content` part | REJECT | REJECT |
+| Missing required metadata — the Dublin Core part or a required term | WARNING | INTEGRITY-ERROR |
+| Missing another referenced part (presentation, provenance, …) | WARNING | INTEGRITY-ERROR |
+| Structurally malformed block of a **known** type | WARNING | INTEGRITY-ERROR |
+| Dangling anchor reference (Anchors and References section 7.2) | WARNING | INTEGRITY-ERROR |
+| Dangling asset reference — a canonicalization error once the ID is computed (Document Hashing section 4.3.1) | WARNING | INTEGRITY-ERROR |
+| File `hash` or document-ID mismatch (Document Hashing section 6.3) | WARNING | INTEGRITY-ERROR |
+| Asset hash mismatch (Asset Embedding section 8) | WARNING | INTEGRITY-ERROR |
+| Invalid or missing required signature on a frozen or published document (Security Extension section 3.7) | see note 1 | INTEGRITY-ERROR |
+| Stripped or downgraded signature set, or a signature that does not cover the manifest projection (Security Extension sections 3.7, 3.12) | — | REJECT (see note 2) |
+| Unverifiable **timestamp** (Provenance and Lineage section 6.7; Security Extension section 3.6) | the timestamp is reported *unverified*; the document is unaffected | same |
+| INCOMPLETE or REJECTED **lineage**, or a divergent claimed `depth` or `version` (Provenance and Lineage section 3.3) | WARNING — ancestry is not authenticated, but the document is never blocked | WARNING |
+
+*Note 1*: a `draft` requires no signature and a `review` document's signature is optional (section 6.2), so a missing signature is not a failure below `frozen`. A signature that is *present* in any state still receives a per-signature state (Security Extension section 3.8).
+
+*Note 2*: a stripped or downgraded signature set is an actively detected attack on an author-declared policy, which the Security Extension requires rejecting (sections 3.7, 3.12) — stricter than the INTEGRITY-ERROR baseline because the author named exactly who must sign. The required-signer policy is carried only in a frozen or published document's signed manifest projection, so it does not apply below `frozen` (—). An individual invalid or missing signature, by contrast, leaves the document viewable-but-untrusted (INTEGRITY-ERROR).
+
+#### 5.4.3 State-Invariant Rules
+
+Two rules do **not** vary by state and override the table above:
+
+- **Duplicate keys always REJECT.** Any part containing an object with duplicate keys MUST be rejected before hashing or verification, in *every* state (Document Hashing section 4.3.2); an unrejected duplicate permits a split-view substitution.
+- **An unverifiable proof never rejects the document.** A verifier that cannot complete a timestamp or lineage proof MUST report *that proof* as unverified and MUST NOT, on those grounds, reject or downgrade the document itself (Provenance and Lineage sections 3.3 and 6.7). The disposition attaches to the proof, not to the document.
 
 ## 6. Signatures and State
 
@@ -404,6 +459,8 @@ Optionally, state transitions can be logged:
 ```
 
 ## 9. Edge Cases
+
+The cases below are worked instances of the failure dispositions in section 5.4: an invalid or missing signature on a frozen or published document is an INTEGRITY-ERROR — surfaced, never presented as valid, and never editable in place.
 
 ### 9.1 Invalid Signature on Frozen Document
 


### PR DESCRIPTION
## Summary

Phase 6 begins the contract-completeness work. This PR lands the two coupled reader-contract pieces.

**Error-handling table (State Machine §5.4).** Consolidates the spec's scattered reader-side failure rules into one normative table keyed by document state, with a single disposition vocabulary — REJECT, INTEGRITY-ERROR, WARNING, IGNORE. Resolves a standing contradiction over how a reader treats a frozen/published document that fails its integrity check: document hashing said "reject", the state machine said "warn and view-anyway". The table adopts INTEGRITY-ERROR as the baseline (read-only behind a warning, never presented as valid, never editable in place), with refuse-to-render permitted as a stricter escalation; an actively detected stripped or downgraded signature set remains a hard REJECT. Duplicate keys always reject; an unverifiable timestamp or lineage proof never rejects the document. Satellite sites (document hashing, asset embedding, anchors, manifest validation) are aligned, and two manifest gaps are filled (unsupported minor version; unsupported optional extension).

**Must-ignore-vs-reject (marks escape + closed-by-default).** Marks had a closed validation set while the prose allowed un-namespaced extension marks, so any new extension mark failed validation. Mirrors the existing block model: an open escape lets an unrecognized namespaced mark pass while a bare unrecognized mark is rejected (so a misspelled core mark is still caught), with a shared known-mark definition preventing double-match or wrong-form smuggling; the content-blocks prose is reversed to require namespacing. A new "closed by default within files" policy states the forward-compatibility model explicitly and enumerates the open extension points. The presentation type set stays closed.

## Test plan

- [x] Full 17-gate suite green from a clean \`npm ci\` (schema + example validation, canonicalization, document IDs, manifest projection, schema closure, cross-refs, sync, trust gates, tsc, audit)
- [x] Three new schema-closure vectors cover the mark escape (namespaced unknown accepted; bare unknown + misspelled core rejected; known mark in wrong form rejected); gate teeth proven by seed-and-revert
- [x] No document IDs move — prose plus an additive schema escape; the canonicalizer is schema-free (11 corpus IDs + manifest projection unchanged)
- [x] Both pieces independently reviewed (no findings >= 80); the marks escape is empirically proven to have no oneOf double-match across all known marks