### PR TITLE
Phase 6.4: profile normativity — advisory profiles + conformance classes

### DIFF
--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -171,6 +171,10 @@
       "description": "Document signature policy: the required-signer set that binds the signature set against stripping and downgrade (Security Extension §3.12). Bound by the signed manifest projection (§9.7).",
       "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/signaturePolicy"
     },
+    "profile": {
+      "type": "string",
+      "description": "Advisory profile declaration (e.g. \"simple\"). A non-normative hint identifying the profile the document targets; it never affects document validity, and consumers process the document as standard CDX regardless of the declared value (Manifest §4.18, Profiles). Not a conformance class — see Introduction §1.3."
+    },
     "academic": {
       "type": "object",
       "description": "Academic Extension manifest configuration (e.g. the numbering config path). The extension owns this object's shape, so it is left open here."

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -596,6 +596,14 @@ export const closureVectors: ClosureVector[] = [
   },
   {
     schema: 'manifest.schema.json',
+    description: 'advisory profile declaration accepted as a string',
+    // the optional `profile` hint is accepted (a bare string); a non-string is rejected.
+    // Removing the schema slot makes the valid instance fail (closed root rejects the key) — the field's teeth.
+    validInstance: { cdx: '0.1', id: HASH, state: 'draft', created: '2020-01-01T00:00:00Z', modified: '2020-01-01T00:00:00Z', content: { path: 'content/document.json', hash: HASH }, metadata: { dublinCore: 'metadata/dublin-core.json' }, profile: 'simple' },
+    invalidInstance: { cdx: '0.1', id: HASH, state: 'draft', created: '2020-01-01T00:00:00Z', modified: '2020-01-01T00:00:00Z', content: { path: 'content/document.json', hash: HASH }, metadata: { dublinCore: 'metadata/dublin-core.json' }, profile: 123 },
+  },
+  {
+    schema: 'manifest.schema.json',
     ref: '#/$defs/fileReference',
     description: 'fileReference',
     validInstance: { path: 'content/document.json', hash: HASH },

--- a/spec/core/00-introduction.md
+++ b/spec/core/00-introduction.md
@@ -52,6 +52,16 @@ The CDX format addresses these issues through the following design goals:
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this specification are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
+This specification defines three conformance classes. Each class's requirements are stated in full by the normative sections cross-referenced below; this section names the classes and gathers those references. The design goals in section 1.2 are rationale, not conformance criteria — they are not RFC 2119 requirements and impose no obligation on any class.
+
+- **Conformant document** — a CDX archive that satisfies the structural and integrity requirements of the core specification: the Container Format, the required-field and validation rules of the Manifest (section 5), the Content Blocks model, Document Hashing, and the State Machine. A document that declares an extension with `required: true` (Manifest section 4.10) is conformant only if it also satisfies that extension's requirements. Declared profiles (section 4.18 of the Manifest) place no additional requirements on a conformant document.
+
+- **Conformant producer** — an implementation that writes CDX (an authoring tool, exporter, or converter). A producer MUST emit conformant documents and MUST honor the writer-side state rules (State Machine section 5.2): it MUST NOT modify the content of a frozen or published document in place.
+
+- **Conformant consumer** — an implementation that reads CDX (a reader, renderer, or validator). A consumer MUST honor the reader-side state rules (State Machine section 5.1), perform the load-time validation for the document's state (State Machine section 5.3), and apply the failure dispositions of State Machine section 5.4 — in particular it MUST reject what that section requires rejecting and MUST NOT present an integrity-failed document as authentic.
+
+Producing-conformance and consuming-conformance are independent: a read-only viewer is a conformant consumer without being a producer, and a one-way exporter is a conformant producer without being a consumer. Conformance is defined against CDX core (plus any declared `required` extensions) and never against a profile — profiles are non-normative guidance (see the Profiles specification).
+
 ### 1.4 Terminology
 
 This section defines key terms used throughout the specification.

--- a/spec/core/02-manifest.md
+++ b/spec/core/02-manifest.md
@@ -65,6 +65,7 @@ The manifest MUST be:
 | `hashAlgorithm` | string | Hash algorithm for the document ID (default `sha256`) |
 | `provenance` | string | Path to the provenance record file |
 | `signaturePolicy` | object | Required-signer policy (Security Extension) |
+| `profile` | string | Advisory profile declaration (Profiles) |
 | `academic` | object | Academic Extension configuration |
 | `semantic` | object | Semantic Extension configuration |
 | `legal` | object | Legal Extension configuration |
@@ -389,6 +390,24 @@ Top-level configuration objects for the correspondingly named extensions. Each i
 ```
 
 See the relevant extension specification for each object's shape.
+
+### 4.18 `profile` (Optional)
+
+An advisory declaration of the profile a document targets, as a bare identifier.
+
+```json
+{
+  "profile": "simple"
+}
+```
+
+A profile is non-normative guidance on which features suit a use case (see the Profiles specification); it defines no conformance class (Introduction section 1.3). The `profile` field is therefore advisory only:
+
+- It never affects document validity. A document that declares a profile but uses features outside that profile's guidance is still a fully valid CDX document.
+- A consumer MUST process a document that declares a profile as a standard CDX document — honoring every feature it actually contains regardless of the declared value — and SHOULD ignore an unrecognized profile value.
+- A producer MAY declare a profile to signal intent; doing so imposes no obligation to restrict the document to that profile's recommended features.
+
+The declaration carries no version component and is not bound by the document ID or the signed manifest projection.
 
 ## 5. Validation
 

--- a/spec/profiles/README.md
+++ b/spec/profiles/README.md
@@ -1,6 +1,6 @@
 # CDX Profiles
 
-Profiles define subsets of the CDX format optimized for specific use cases. They provide guidance on which features to use (and avoid) for particular document types.
+Profiles describe recommended subsets of CDX features for specific use cases. They provide guidance on which features to use (and avoid) for particular document types. Profiles are non-normative: they define no conformance class and place no requirements on documents or implementations (see Introduction section 1.3).
 
 ## Available Profiles
 
@@ -13,7 +13,7 @@ Profiles define subsets of the CDX format optimized for specific use cases. They
 A profile is **non-normative guidance** that:
 
 - Identifies which features are appropriate for a use case
-- Defines minimal requirements for that use case
+- Recommends a minimal feature set for that use case
 - Provides examples tailored to that use case
 - Offers migration guidance from other formats
 
@@ -23,12 +23,13 @@ Profiles do NOT:
 - Override the core specification
 - Require special handling by implementations
 - Restrict what a valid CDX document can contain
+- Constrain the set of extensions a document may declare
 
-## Profile Conformance
+Because a profile restricts nothing, there is no such thing as "conforming to a profile" and no profile-specific conformance test. A document that uses only a profile's recommended features is simply a valid CDX document; one that goes beyond them is equally valid. Conformance is defined against CDX core, not against any profile (Introduction section 1.3).
 
-Documents are not required to declare profile conformance. A document conforming to a profile is simply a valid CDX document that happens to use only the features recommended by that profile.
+## Declaring a Profile
 
-However, documents MAY declare their intended profile in the manifest for tooling purposes:
+Declaring a profile is optional and purely advisory — a hint about the document's intended use, useful to tooling. Documents MAY declare a profile in the manifest:
 
 ```json
 {
@@ -38,7 +39,9 @@ However, documents MAY declare their intended profile in the manifest for toolin
 }
 ```
 
-Implementations SHOULD ignore unrecognized profile values and treat the document as a standard CDX document.
+A profile declaration never affects how a document is processed: a consumer treats a document that declares a profile as a standard CDX document, honoring every feature it actually contains regardless of whether that feature falls within the declared profile's guidance, and disregards an unrecognized profile value. These are normative requirements on consumers, stated in Manifest section 4.18. A document that declares `profile: "simple"` but contains, say, a table block is therefore still fully valid and is processed normally.
+
+The declaration is a bare identifier with no version component: profiles are not independently versioned, and a profile carries no conformance level to target.
 
 ## Future Profiles
 

--- a/spec/profiles/simple-documents.md
+++ b/spec/profiles/simple-documents.md
@@ -1,7 +1,6 @@
 # Simple Documents Profile
 
 **Profile ID**: `simple`
-**Version**: 0.1
 **Status**: Draft
 
 ## 1. Overview
@@ -13,7 +12,7 @@ The Simple Documents profile defines a minimal subset of CDX for recreational re
 - **Universally renderable** — any CDX reader can display these documents
 - **EPUB-comparable** — similar complexity for similar use cases
 
-This profile is non-normative guidance. Documents conforming to this profile are fully valid CDX documents that happen to use only a subset of available features.
+This profile is non-normative guidance: it recommends a subset of CDX features and places no requirements on documents or implementations. A document that follows this guidance is an ordinary valid CDX document, and so is one that does not — there is no "simple-conformant" test (see the Profiles overview and Introduction section 1.3).
 
 ## 2. Use Cases
 
@@ -102,7 +101,7 @@ Simple Documents do not need:
 | `modified` | Yes | ISO 8601 last modification timestamp |
 | `content` | Yes | Path to content file |
 | `metadata.dublinCore` | Yes | Path to Dublin Core metadata |
-| `extensions` | No | Simple Documents use no extensions |
+| `extensions` | No | Simple Documents typically use no extensions |
 | `assets` | No | Only if images/fonts are embedded |
 | `presentation` | No | Renderers apply defaults |
 
@@ -263,7 +262,7 @@ For simplicity, these block types are discouraged in Simple Documents:
 
 ### 7.1 No Presentation Required
 
-Simple Documents do not require any presentation files. Renderers MUST apply sensible defaults when no presentation is specified:
+Simple Documents do not require any presentation files. Renderers apply sensible defaults when no presentation is specified, for example:
 
 - Continuous vertical scroll layout
 - System fonts or reader-preferred fonts


### PR DESCRIPTION
## Summary

Profiles previously claimed to be non-normative guidance that restricts nothing while simultaneously defining "conformance to a profile", a Profile ID, a Version, and MUST language — a self-contradiction that left "profile-conformant" undefined and open to incompatible reader behavior. Separately, the profiles guide told producers to write a `profile` field in the manifest, but the manifest chapter never defined it and the closed manifest schema rejected it.

This change keeps profiles advisory and gives the format real conformance targets:

- **Introduction (§1.3)** — define three conformance classes (conformant document, producer, consumer) by naming and cross-referencing the read-time and save-time requirements that already exist in the Manifest and State Machine chapters. The design goals stay rationale, not requirements.
- **Manifest (§3.3, new §4.18 + schema)** — add an optional, advisory `profile` string field with an allow-and-ignore rule: a consumer processes a document that declares a profile as standard CDX regardless of the declared value, and ignores an unrecognized value. A producer may declare a profile to signal intent with no obligation to restrict the document.
- **Profiles (overview + Simple Documents)** — de-normativize: profiles define no conformance class, never constrain the extension set, and carry no version component.
- Add a schema-closure vector exercising the new field, with seed-and-revert teeth.

## Compatibility

The `profile` field is optional and bound by neither the document ID nor the signed manifest projection, so existing document ids and signatures are unaffected (11 corpus document ids and 2 signed projections unchanged; trust-core libraries untouched).

## Test plan

- [x] Full CI-parity suite green from a clean `npm ci`: schema + example validation, canonicalizer KAT, spec↔schema sync, cross-references, coverage, hash-centralization, document-id, manifest-projection, JWS envelope, trust-state, WebAuthn, signature-set, lineage, provenance-timestamp, schema-closure (169 vectors), `tsc --noEmit`, `npm audit --audit-level=high` (0 vulnerabilities).
- [x] Seed-and-revert: removing the `profile` schema slot makes the new closure vector fail (closed-root rejection), proving the field's teeth.