### PR TITLE
check:refs: validate cross-document section references

### DIFF
--- a/scripts/validate-cross-refs.ts
+++ b/scripts/validate-cross-refs.ts
@@ -153,9 +153,118 @@ function findMarkdownFiles(dir: string): string[] {
   return files;
 }
 
+// Build a canonical document-title -> relative-path index for the cross-document
+// "<Document title> section X.Y" reference idiom. Titles come from each file's H1,
+// minus the generic top-level "CDX ..." headings (which are never used as a
+// reference anchor), plus the documented short-form aliases.
+function buildTitleIndex(files: string[]): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const file of files) {
+    const rel = path.relative(rootDir, file);
+    const h1 = fs.readFileSync(file, 'utf8').split('\n').find((l) => /^#\s+/.test(l));
+    if (!h1) continue;
+    const title = h1.replace(/^#\s+/, '').trim();
+    if (/^CDX\b/.test(title)) continue; // not used as a cross-reference anchor
+    index.set(title.toLowerCase(), rel);
+  }
+  // Documented short forms: the Introduction's H1 is "CDX Specification", and the
+  // Provenance and Lineage chapter is sometimes cited as "Provenance".
+  index.set('introduction', 'spec/core/00-introduction.md');
+  index.set('provenance', 'spec/core/09-provenance-and-lineage.md');
+  return index;
+}
+
+// Build a per-file index of section numbers (e.g. "5", "5.4", "5.4.1") parsed from
+// the leading number token of each heading. Fenced code blocks (``` or ~~~) are
+// skipped so that "#"-prefixed lines inside diagrams/JSON snippets are not mistaken
+// for headings; a fence is closed only by a fence of the same marker character, so
+// a nested fence of the other kind cannot prematurely end the block.
+function buildSectionNumberIndex(files: string[]): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  for (const file of files) {
+    const rel = path.relative(rootDir, file);
+    const set = new Set<string>();
+    let fence: string | null = null; // the opening fence char ('`' or '~') when inside a fence
+    for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+      const fenceMatch = line.match(/^\s*(```+|~~~+)/);
+      if (fenceMatch) {
+        const marker = fenceMatch[1][0];
+        if (fence === null) fence = marker; // opening fence
+        else if (marker === fence) fence = null; // matching closing fence
+        continue;
+      }
+      if (fence !== null) continue;
+      const m = line.match(/^#{1,6}\s+(\d+(?:\.\d+)*)\b/);
+      if (m) set.add(m[1]);
+    }
+    index.set(rel, set);
+  }
+  return index;
+}
+
+// Extract cross-document "<Document title> [spec] section(s) X.Y[, X.Z][ and X.W]"
+// references. Anchored on the known-title set (longest title first) so generic
+// prose like "the design goals in section 1.2" is not mistaken for a titled
+// reference. Each captured section number becomes its own resolvable reference
+// with target shape `titled:<relPath>#<number>`. A range form ("sections X to Y")
+// splits on the range operator, so only its endpoints are validated, not interior
+// numbers — acceptable while no titled range references exist in the corpus.
+function extractTitledRefs(filePath: string, titleIndex: Map<string, string>): Reference[] {
+  const references: Reference[] = [];
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+  const filename = path.relative(rootDir, filePath);
+
+  const titleAlt = [...titleIndex.keys()]
+    .sort((a, b) => b.length - a.length)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+  const numList = '\\d+(?:\\.\\d+)*(?:\\s*(?:,|and|–|-|to|&)\\s*\\d+(?:\\.\\d+)*)*';
+  const pattern = new RegExp(
+    `\\b(${titleAlt})\\b(?:\\s+(?:spec|specification))?\\s+sections?\\s+(${numList})`,
+    'gi'
+  );
+
+  lines.forEach((line, index) => {
+    let match;
+    while ((match = pattern.exec(line)) !== null) {
+      const targetFile = titleIndex.get(match[1].toLowerCase());
+      if (!targetFile) continue;
+      const numbers = match[2].split(/\s*(?:,|and|–|-|to|&)\s*/).map((s) => s.trim()).filter(Boolean);
+      for (const num of numbers) {
+        references.push({
+          target: `titled:${targetFile}#${num}`,
+          file: filename,
+          line: index + 1,
+          context: match[0],
+        });
+      }
+    }
+  });
+
+  return references;
+}
+
 // Validate a reference against known sections
-function validateReference(ref: Reference, sections: Section[], files: string[]): boolean {
+function validateReference(
+  ref: Reference,
+  sections: Section[],
+  files: string[],
+  sectionNumbers: Map<string, Set<string>>
+): boolean {
   const target = ref.target;
+
+  // Handle cross-document titled section references: titled:<relPath>#<number>.
+  // Resolves the named document's section-number index (the dominant cross-doc
+  // idiom, previously unchecked).
+  if (target.startsWith('titled:')) {
+    const rest = target.slice('titled:'.length);
+    const hashIdx = rest.lastIndexOf('#');
+    const targetFile = rest.slice(0, hashIdx);
+    const num = rest.slice(hashIdx + 1);
+    const set = sectionNumbers.get(targetFile);
+    return set !== undefined && set.has(num);
+  }
 
   // Handle anchor references: #anchor
   if (target.startsWith('#')) {
@@ -216,20 +325,28 @@ function validateCrossRefs(): ValidationReport {
   }
   console.log(`Indexed ${allSections.length} sections/anchors`);
 
+  // Build the document-title and section-number indexes for cross-document
+  // "<Document title> section X.Y" reference resolution.
+  const titleIndex = buildTitleIndex(markdownFiles);
+  const sectionNumbers = buildSectionNumberIndex(markdownFiles);
+
   // Extract all references
   const allReferences: Reference[] = [];
+  let titledCount = 0;
   for (const file of markdownFiles) {
-    const refs = extractReferences(file);
-    allReferences.push(...refs);
+    allReferences.push(...extractReferences(file));
+    const titled = extractTitledRefs(file, titleIndex);
+    titledCount += titled.length;
+    allReferences.push(...titled);
   }
-  console.log(`Found ${allReferences.length} cross-references\n`);
+  console.log(`Found ${allReferences.length} cross-references (${titledCount} cross-document section refs)\n`);
 
   // Validate references
   const broken: Reference[] = [];
   const valid: Reference[] = [];
 
   for (const ref of allReferences) {
-    if (validateReference(ref, allSections, markdownFiles)) {
+    if (validateReference(ref, allSections, markdownFiles, sectionNumbers)) {
       valid.push(ref);
     } else {
       broken.push(ref);


### PR DESCRIPTION
## Summary

The `check:refs` gate previously treated the dominant cross-document reference idiom — `<Document title> section X.Y` — as informational and always valid, so a reference to a section that does not exist in the named document went undetected.

This change resolves those references:

- A **document-title index** maps a title to its file (from each file's H1 + two documented short forms: `Introduction`, `Provenance`).
- A **per-file section-number index** is parsed from heading numbers, skipping fenced code blocks (``` and ~~~) so `#`-prefixed lines inside diagrams/JSON snippets are not mistaken for headings.
- Each `<title> section(s) X.Y[, X.Z][ and X.W]` reference is resolved against the named document's actual sections (longest title wins). A stale cross-document section number now fails the build.

All existing cross-document references resolve, so this lands as a **regression guard with no specification changes**. The same-document bare `section X.Y` form is left as-is (ambiguous without a title). Single-file tooling change — no schema, example, or spec-prose changes.

## Test plan

- [x] Full 17-gate CI-parity suite green from a clean `npm ci` (incl. `check:refs`, `check:document-id`, `check:manifest-projection`, `tsc`, `npm audit`).
- [x] Seed-and-revert: a stale `<Document> section X.Y` reference → exit 1; clean tree → exit 0.
- [x] Verified a deeper subsection (e.g. `5.4.1`) does not satisfy a reference to its parent (`section 5.4`), and a child section is unaffected when the parent heading is absent.