### PR TITLE
Add renderer-safety primitive: safe URIs and content sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The specification is modular:
 - [State Machine](spec/core/07-state-machine.md) - Draft/frozen lifecycle
 - [Metadata](spec/core/08-metadata.md) - Dublin Core and extensions
 - [Provenance and Lineage](spec/core/09-provenance-and-lineage.md) - Hash chains, Merkle trees, timestamping
+- [Renderer Safety](spec/core/10-renderer-safety.md) - Safe URIs and untrusted-content sanitization
 
 ### Extension Specifications (Optional)
 

--- a/schemas/anchor.schema.json
+++ b/schemas/anchor.schema.json
@@ -25,6 +25,18 @@
       "description": "Media type in lowercase 'type/subtype' form (canonical, no parameters). Shared definition; do not inline a MIME pattern elsewhere.",
       "pattern": "^[a-z]+/[a-zA-Z0-9.+-]+$"
     },
+    "safeUri": {
+      "type": "string",
+      "description": "Allowlisted navigational/link/action URI. Permits https/http (any case), mailto:, fragment (#…) and relative references (including protocol-relative //host and the empty string); every other scheme — javascript:, data:, file:, tel:, ftp:, blob:, vbscript:, ws: — is rejected. This is an authoring guardrail only; the normative boundary is the renderer sanitization rule in the Renderer Safety core specification. Shared definition; do not inline a URI-safety pattern elsewhere.",
+      "$comment": "Default-deny allowlist. The relative branch [^:/?#]* requires any ':' to be preceded by '/', '?' or '#', which is what rejects whitespace/control-character scheme smuggling (e.g. 'ja\\tvascript:') — do not 'simplify' it to .* . No trailing $ anchor is needed: a match can only begin at an allowlisted prefix, so a dangerous scheme can never appear at the start.",
+      "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?://|[Mm][Aa][Ii][Ll][Tt][Oo]:|#|[^:/?#]*(?:[/?#]|$))"
+    },
+    "safeImageUri": {
+      "type": "string",
+      "description": "Allowlisted image-source URI. As safeUri, but ALSO permits data:image/<subtype>[;params],<payload> for legitimate inline raster images, while still rejecting data:text/html, data:application/*, and every script scheme. Any data:image subtype naming SVG (e.g. data:image/svg+xml) is excluded because inline SVG is active content. Shared definition; do not inline an image-URI-safety pattern elsewhere.",
+      "$comment": "Any image/* subtype whose name contains 'svg' is deliberately excluded from the data: branch — SVG is the one image type that can execute script. The negative lookahead spans the whole subtype (up to the first ';' or ',') so spellings like 'svg', 'x-svg+xml' or 'svg+xmlx' cannot slip through. If a future change re-admits SVG, the Renderer Safety core specification still requires it be rasterized or sandboxed first.",
+      "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?://|[Dd][Aa][Tt][Aa]:image/(?![^,;]*[Ss][Vv][Gg])[A-Za-z0-9.+-]+(?:;[A-Za-z0-9.+=-]+)*,|[^:/?#]*(?:[/?#]|$))"
+    },
     "person": {
       "type": "object",
       "description": "Base person/agent identity. Extensions may add additional properties via allOf composition.",

--- a/schemas/collaboration.schema.json
+++ b/schemas/collaboration.schema.json
@@ -21,9 +21,8 @@
               "description": "User identifier in an external system"
             },
             "avatar": {
-              "type": "string",
-              "format": "uri",
-              "description": "URL to avatar image"
+              "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeImageUri",
+              "description": "URL to avatar image. Constrained to safe image sources (see the Renderer Safety core specification): https/relative or a data:image payload, excluding data:image/svg+xml (active content)."
             },
             "color": {
               "type": "string",

--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -400,8 +400,8 @@
       "properties": {
         "type": { "const": "link" },
         "href": {
-          "type": "string",
-          "description": "Link URL or Content Anchor URI (values beginning with '#' are internal references)"
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeUri",
+          "description": "Link URL or Content Anchor URI (values beginning with '#' are internal references). Constrained to safe schemes (see the Renderer Safety core specification); javascript:/data:/file: and other dangerous schemes are rejected."
         },
         "title": {
           "type": "string",

--- a/schemas/forms.schema.json
+++ b/schemas/forms.schema.json
@@ -217,9 +217,8 @@
               "description": "Unique form identifier"
             },
             "action": {
-              "type": "string",
-              "format": "uri",
-              "description": "Form submission URL"
+              "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeUri",
+              "description": "Form submission URL. Constrained to safe schemes (see the Renderer Safety core specification): a javascript:/data: action would otherwise be a signed code-execution primitive when carried in signed content."
             },
             "method": {
               "type": "string",

--- a/schemas/presentation.schema.json
+++ b/schemas/presentation.schema.json
@@ -842,8 +842,8 @@
           "properties": {
             "type": { "const": "presentation:reference" },
             "target": {
-              "type": "string",
-              "description": "Content Anchor URI (internal references start with #)"
+              "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeUri",
+              "description": "Content Anchor URI (internal references start with #). Constrained to safe schemes (see the Renderer Safety core specification); fragment and relative references remain permitted."
             },
             "format": {
               "type": "string",

--- a/schemas/semantic.schema.json
+++ b/schemas/semantic.schema.json
@@ -83,9 +83,8 @@
       "properties": {
         "type": { "const": "entity" },
         "uri": {
-          "type": "string",
-          "format": "uri",
-          "description": "URI identifying the entity in a knowledge graph"
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeUri",
+          "description": "URI identifying the entity in a knowledge graph. Constrained to safe schemes (see the Renderer Safety core specification)."
         },
         "entityType": {
           "type": "string",
@@ -326,8 +325,8 @@
           "properties": {
             "type": { "const": "semantic:ref" },
             "target": {
-              "type": "string",
-              "description": "Target reference (Content Anchor URI for internal, URL for external)"
+              "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeUri",
+              "description": "Target reference (Content Anchor URI for internal, URL for external). Constrained to safe schemes (see the Renderer Safety core specification); fragment and relative references remain permitted."
             },
             "format": {
               "type": "string",

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -1273,4 +1273,72 @@ export const closureVectors: ClosureVector[] = [
     validInstance: { type: 'glossary', ref: 'term-1' },
     invalidInstance: { type: 'glossary', ref: 'term-1', bogus: 1 },
   },
+
+  // --- safe-URI allowlist (anchor safeUri/safeImageUri + the fields applying them) -
+  // These $defs are string allowlists, so the vector pins them the string way:
+  // validInstance is an allowlisted URI that MUST pass, invalidInstance is a
+  // dangerous-scheme URI that MUST be rejected (the allowlist has teeth).
+  {
+    schema: 'anchor.schema.json',
+    ref: '#/$defs/safeUri',
+    description: 'safeUri admits https; rejects javascript:',
+    validInstance: 'https://example.com/page',
+    invalidInstance: 'javascript:alert(1)',
+  },
+  {
+    schema: 'anchor.schema.json',
+    ref: '#/$defs/safeUri',
+    description: 'safeUri admits relative/fragment refs; rejects data: documents',
+    validInstance: 'assets/embeds/quarterly-data.xlsx',
+    invalidInstance: 'data:text/html,<script>alert(1)</script>',
+  },
+  {
+    schema: 'anchor.schema.json',
+    ref: '#/$defs/safeImageUri',
+    description: 'safeImageUri admits data:image raster; rejects data:image/svg+xml (active content)',
+    validInstance: 'data:image/png;base64,iVBORw0KGgo=',
+    invalidInstance: 'data:image/svg+xml,<svg onload=alert(1)>',
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/linkMark',
+    description: 'linkMark.href safe-scheme teeth (javascript: rejected)',
+    validInstance: { type: 'link', href: 'https://example.com' },
+    invalidInstance: { type: 'link', href: 'javascript:alert(1)' },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'forms:form action safe-scheme teeth (javascript: rejected)',
+    validInstance: { type: 'forms:form', action: 'https://api.example.com/submit', children: [{ type: 'forms:submit' }] },
+    invalidInstance: { type: 'forms:form', action: 'javascript:alert(1)', children: [{ type: 'forms:submit' }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:ref target safe-scheme teeth (javascript: rejected)',
+    validInstance: { type: 'semantic:ref', target: '#section-3' },
+    invalidInstance: { type: 'semantic:ref', target: 'javascript:alert(1)' },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'presentation:reference target safe-scheme teeth (javascript: rejected)',
+    validInstance: { type: 'presentation:reference', target: '#fig1', format: 'Figure #' },
+    invalidInstance: { type: 'presentation:reference', target: 'javascript:alert(1)', format: 'Figure #' },
+  },
+  {
+    schema: 'semantic.schema.json',
+    ref: '#/$defs/entityMark',
+    description: 'entity.uri safe-scheme teeth (javascript: rejected)',
+    validInstance: { type: 'entity', uri: 'https://www.wikidata.org/wiki/Q1' },
+    invalidInstance: { type: 'entity', uri: 'javascript:alert(1)' },
+  },
+  {
+    schema: 'collaboration.schema.json',
+    ref: '#/$defs/author',
+    description: 'author.avatar safe-image teeth (javascript: rejected)',
+    validInstance: { name: 'Ada', avatar: 'https://example.com/avatars/jane.png' },
+    invalidInstance: { name: 'Ada', avatar: 'javascript:alert(1)' },
+  },
 ];

--- a/scripts/lib/part-schema.ts
+++ b/scripts/lib/part-schema.ts
@@ -13,8 +13,13 @@ import { createAjv, loadSchema } from './ajv-utils.js';
 // Schema dependencies (schemas that need other schemas loaded first so their
 // cross-file $refs resolve at compile time).
 const schemaDependencies: Record<string, string[]> = {
-  'content.schema.json': ['semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'],
+  'content.schema.json': ['anchor.schema.json', 'semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'],
   'collaboration.schema.json': ['anchor.schema.json'],
+  // forms/semantic/presentation reference anchor.schema.json#/$defs/safeUri (the
+  // shared safe-URI definition) for their author-controlled URI fields.
+  'forms.schema.json': ['anchor.schema.json'],
+  'semantic.schema.json': ['anchor.schema.json'],
+  'presentation.schema.json': ['anchor.schema.json'],
   // phantoms embeds the core content block model (phantomContent.blocks → content
   // block dispatch), so it needs content plus content's whole cross-file cluster.
   'phantoms.schema.json': ['anchor.schema.json', 'semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json', 'content.schema.json'],

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -15,10 +15,7 @@ interface DependentSchema {
 const standaloneSchemas: string[] = [
   'academic.schema.json',
   'anchor.schema.json',
-  'forms.schema.json',
   'legal.schema.json',
-  'presentation.schema.json',
-  'semantic.schema.json',
 ];
 
 // Schemas that reference other schemas. manifest/asset-index/provenance/
@@ -28,9 +25,14 @@ const dependentSchemas: DependentSchema[] = [
   { schema: 'annotations.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'asset-index.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'collaboration.schema.json', refs: ['anchor.schema.json'] },
-  { schema: 'content.schema.json', refs: ['semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'] },
+  { schema: 'content.schema.json', refs: ['anchor.schema.json', 'semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'] },
   { schema: 'dublin-core.schema.json', refs: ['anchor.schema.json'] },
+  // forms/semantic/presentation reference anchor.schema.json#/$defs/safeUri for
+  // their author-controlled URI fields (form action, entity uri, cross-reference target).
+  { schema: 'forms.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'manifest.schema.json', refs: ['anchor.schema.json'] },
+  { schema: 'presentation.schema.json', refs: ['anchor.schema.json'] },
+  { schema: 'semantic.schema.json', refs: ['anchor.schema.json'] },
   // phantoms embeds the content block model, which dispatches across the whole
   // content + extension-schema cluster.
   { schema: 'phantoms.schema.json', refs: ['anchor.schema.json', 'content.schema.json', 'semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'] },

--- a/spec/core/10-renderer-safety.md
+++ b/spec/core/10-renderer-safety.md
@@ -1,0 +1,210 @@
+# Renderer Safety
+
+**Section**: Core Specification
+**Version**: 0.1
+
+## 1. Overview
+
+A CDX document is authored data that is ultimately handed to a renderer — a
+browser, a PDF engine, a math typesetter, a native viewer. Much of that data is
+author-controlled: link targets, form actions, entity URIs, avatar images,
+mathematical source, style values, and embedded markup. A renderer that treats
+this data as trusted exposes its host to cross-site scripting, content
+injection, server-side request forgery, and denial of service.
+
+Two properties of the format make renderer safety a normative concern rather
+than an implementation detail:
+
+- **Signing does not make content safe.** A signature attests *who authored*
+  the content and that it has *not been altered* — never that it is *safe to
+  render*. A `javascript:` URI carried in signed content is a *signed*
+  code-execution primitive: the signature makes it more trustworthy to a naive
+  renderer, not less dangerous. Integrity and safety are orthogonal.
+
+- **Schema validation is an authoring guardrail, not a security boundary.** The
+  schema-level constraints in this specification (the `safeUri` and
+  `safeImageUri` definitions) reject the most common dangerous inputs at
+  authoring time, but a renderer MUST NOT rely on a document having been
+  validated. A renderer MUST enforce the rules below on every document it
+  renders, validated or not (Section 2.3).
+
+This section defines the renderer's obligations. It uses MUST/SHOULD/MAY per
+RFC 2119. The obligations apply to *any* component that materializes
+author-controlled data into an executable or rendered context; "renderer" below
+means any such component.
+
+## 2. Safe URIs
+
+A *safe URI* is an author-controlled URI that a renderer may resolve as a link,
+navigation, or action. The format constrains the relevant fields with a
+shared, default-deny allowlist; renderers impose the same allowlist
+independently.
+
+### 2.1 Navigational and action URIs
+
+Fields whose value is rendered as a hyperlink, a navigation target, or a
+submitted action — core `link` mark `href`, the forms extension's form
+`action`, the semantic extension's entity `uri` and cross-reference `target`,
+and the presentation extension's cross-reference `target` — are constrained by
+the shared `safeUri` definition (`anchor.schema.json#/$defs/safeUri`).
+
+`safeUri` is an **allowlist**. It permits:
+
+- `https:` and `http:` URLs (scheme matched case-insensitively),
+- `mailto:` URLs,
+- fragment references (`#blockId`, `#blockId/offset`),
+- relative references (no scheme), including protocol-relative `//host` forms.
+
+Every other scheme is rejected, including `javascript:`, `data:`, `file:`,
+`blob:`, `vbscript:`, `tel:`, `ftp:`, and `ws:`. A renderer MUST reject (decline
+to navigate to or execute) any value outside this allowlist, and MUST apply the
+allowlist *after* performing whatever normalization it would apply before
+navigation (trimming leading and embedded control characters and whitespace,
+case-folding the scheme). A naive substring check is insufficient: an attacker
+can split a dangerous scheme with a tab or newline (`java&#9;script:`) that the
+renderer's URL parser will later strip. The renderer MUST normalize first, then
+test the scheme against the allowlist.
+
+The allowlist deliberately rejects schemes that are legitimate in some contexts
+(`tel:`, `ftp:`, custom application schemes). A profile or application that
+requires such a scheme MUST opt in explicitly and accept responsibility for the
+resulting navigation; the default-deny posture is the conformant baseline.
+
+### 2.2 Image sources
+
+Fields whose value is rendered as an image source — the collaboration
+extension's author `avatar`, and any extension image reference that mirrors the
+core image block — are constrained by the shared `safeImageUri` definition
+(`anchor.schema.json#/$defs/safeImageUri`).
+
+`safeImageUri` permits the `https:`/`http:` URLs and relative references (no
+scheme) that `safeUri` permits, and additionally permits `data:image/<subtype>`
+payloads so that legitimate inline raster images (`data:image/png`,
+`data:image/jpeg`, `data:image/webp`, `data:image/gif`) are not rejected. It
+does not add the `mailto:` scheme. It does **not** permit any `data:image` SVG
+subtype (such as `data:image/svg+xml`): an inline SVG is active content that can
+carry script, so SVG delivered as a `data:` payload is excluded at the schema
+level. A renderer MUST treat any SVG it renders —
+external, `data:`, or inline — as untrusted markup and sanitize or sandbox it
+per Section 3.1, regardless of how it arrived.
+
+### 2.3 Validation is not a security boundary
+
+A renderer MUST NOT treat schema validation as having sanitized a document. The
+`safeUri`/`safeImageUri` constraints exist to catch dangerous values at
+authoring time and to document intent; they are a regular expression over a
+string and cannot anticipate every renderer-specific normalization. The
+renderer is the security boundary: it MUST enforce the safe-scheme allowlist and
+the sanitization rules of Section 3 on every document, including documents that
+arrive without ever having been validated.
+
+## 3. Sanitizing rendered untrusted strings
+
+Several fields carry strings that are materialized into a rendering context that
+can execute or reinterpret them. A renderer MUST sanitize or sandbox each of the
+following before rendering.
+
+### 3.1 Inline SVG and vector markup
+
+SVG is active content: it can contain `<script>`, event-handler attributes
+(`onload`, `onclick`, …), `<foreignObject>`, and external references. A renderer
+that renders author-supplied SVG MUST either sanitize it (removing script
+elements, event-handler attributes, `<foreignObject>`, and external fetches) or
+render it in a sandbox that cannot execute script or reach the network. This
+applies to SVG from any source — an external file, a `data:` payload, or markup
+embedded in the document.
+
+### 3.2 Mathematical notation
+
+The academic extension carries mathematical and algorithmic source as LaTeX
+(equation lines, algorithm lines) rendered by a typesetting engine such as
+KaTeX, MathJax, or a full TeX system. Untrusted LaTeX is a code-execution and
+denial-of-service surface. A renderer MUST:
+
+- disable file-access and shell-escape constructs (`\input`, `\include`,
+  `\write18`, `\openin`, and equivalents) — a full-TeX engine MUST NOT be
+  invoked on untrusted source with these enabled,
+- disable or sanitize link- and HTML-emitting macros (`\href`, `\url`,
+  `\htmlClass`, and equivalents) so math source cannot inject navigation or
+  markup that bypasses Section 2,
+- bound macro expansion (expansion depth and output size) so a small input
+  cannot expand into an unbounded document.
+
+A renderer SHOULD prefer a restricted, non-Turing-complete math renderer
+(KaTeX-class) over a full TeX system for untrusted input.
+
+### 3.3 Style and color values
+
+The collaboration extension carries a CSS `color` value for cursor and
+highlight display; other extensions may carry style strings. A renderer MUST NOT
+inject an author-supplied style or color string into a stylesheet or a `style`
+attribute without validating it against the expected grammar (for `color`, a CSS
+color value) or escaping it. An unvalidated value can break out of the intended
+property and inject additional declarations, including `url()`, `expression()`,
+or `@import` constructs that fetch remote resources or alter layout.
+
+### 3.4 Contact and identity strings
+
+Identity and contact strings — the legal extension's signer name, address,
+telephone, and fax fields; party and notary names; and equivalent
+advisory-identity fields across extensions — are author-asserted text. A
+renderer MUST render them as inert text, escaping any markup, and MUST NOT
+auto-linkify or otherwise promote them to a navigation target except through the
+safe-URI allowlist of Section 2. (Their *authority* status is governed
+separately by the Security Extension section 3.10.)
+
+## 4. Client-side validation patterns
+
+The forms extension lets a field declare a validation `pattern` (a regular
+expression) and other client-side validation hints. These are an authoring and
+user-experience convenience; they are **not** a trust boundary. Two obligations
+follow:
+
+- **The receiving endpoint MUST re-validate.** Client-side validation can be
+  bypassed trivially (the data files that carry submitted form values sit
+  outside the content hash and any signature). A server or processor that acts
+  on submitted values MUST re-validate them independently and MUST NOT treat the
+  presence of a client-side `pattern` as having constrained the input.
+
+- **Pattern evaluation is a denial-of-service surface.** An author-supplied
+  regular expression can exhibit catastrophic backtracking (ReDoS). A renderer
+  that evaluates a `pattern` SHOULD use a linear-time matching engine
+  (RE2-class) or otherwise bound evaluation time and input length, and MUST NOT
+  let a single pattern evaluation stall the rendering context.
+
+## 5. External reference resolution
+
+Some fields name resources a processor might fetch — most notably the semantic
+extension's JSON-LD `@context`, which a JSON-LD processor may dereference. A
+processor MUST NOT fetch remote resources named by an untrusted document by
+default: doing so is a server-side request forgery surface (the document can
+point the processor at internal hosts) and a privacy and availability surface. A
+processor MUST default to offline resolution — a bundled or allowlisted context
+set — and MAY fetch a remote reference only when an operator has explicitly
+allowed that specific origin. The same rule applies to any other author-named
+external reference a processor would resolve at render time.
+
+## 6. Active and embedded content
+
+An extension MAY embed a block model inside its own data — most notably the
+phantom extension, whose clusters carry an embedded content model and whose
+assets are an unverified channel (Phantom Extension section 5.1). A renderer
+MUST render embedded and phantom content with the *same* safe-URI allowlist and
+sanitization rules it applies to primary content: embedded link targets, image
+sources, SVG, math, and style values are no more trustworthy than their
+top-level counterparts, and an embedded or out-of-hash channel is frequently
+*less* trustworthy. A renderer MUST treat such content as untrusted regardless
+of the integrity status of the surrounding document, and MUST NOT grant it any
+capability (script execution, navigation, network access) it would deny to
+primary content.
+
+## 7. Relationship to identity authority
+
+Renderer safety is concerned with what a renderer may *execute or fetch* from
+author-controlled data. It is complementary to, and distinct from, the question
+of what a renderer may *present as authoritative*, which is governed by the
+Security Extension section 3.10 (Identity Authority) and the integrity-status
+discipline of the extension overview. A value can be integrity-protected and
+still unsafe to render (a signed `javascript:` link); a value can be safe to
+render and still carry no authority (an unauthenticated signer name). A
+conformant renderer MUST satisfy both disciplines independently.

--- a/spec/extensions/academic/README.md
+++ b/spec/extensions/academic/README.md
@@ -379,6 +379,8 @@ Each line in the `lines` array:
 
 **Note:** Use either `number` or `tag`, not both. If `tag` is present, it takes precedence.
 
+> **Renderer safety.** Equation `value` and algorithm-line `content` are LaTeX rendered by a math engine, and untrusted LaTeX is a code-execution and denial-of-service surface. A renderer MUST disable file-access and shell-escape constructs and link/HTML-emitting macros, and MUST bound macro expansion, on untrusted source — preferring a restricted (KaTeX-class) renderer over a full TeX system (Renderer Safety section 3.2).
+
 ## 7.3 Chemical Formulas (mhchem)
 
 For chemical formulas and reaction equations, use the core `math` block with the mhchem LaTeX package notation. The mhchem package provides intuitive syntax for molecular formulas and chemical reactions.

--- a/spec/extensions/collaboration/README.md
+++ b/spec/extensions/collaboration/README.md
@@ -277,6 +277,8 @@ The `author` field uses a consistent structure throughout the collaboration exte
 
 The `color` field enables consistent visual identification across real-time collaboration sessions. When a user's cursor or selection is shown, implementations SHOULD use this color. If not specified, implementations SHOULD assign a consistent color based on `userId` or `email`.
 
+> **Renderer safety.** `avatar` is constrained to safe image sources (Renderer Safety section 2.2): an `https`/relative URL or a `data:image` raster payload, excluding `data:image/svg+xml` and every script scheme. A renderer MUST validate `color` against the CSS color grammar, or escape it, before injecting it into a stylesheet or `style` attribute (Renderer Safety section 3.3).
+
 ### 4.4 Content Anchors
 
 The `anchor` field uses a ContentAnchor object from the core Anchors and References specification. Block-level, point, and range anchors are supported:

--- a/spec/extensions/forms/README.md
+++ b/spec/extensions/forms/README.md
@@ -54,6 +54,8 @@ The `forms:form` block is a container that groups form fields together. It wraps
 | `encoding` | string | No | Form encoding type. Defaults to `"application/json"`. |
 | `children` | array | Yes | Array of form field blocks and submit buttons |
 
+> **Renderer safety.** The form `action` is constrained to safe schemes (Renderer Safety section 2.1): a `javascript:` or `data:` action carried in signed content would otherwise be a signed code-execution primitive, so it is rejected. A field's `validation.pattern` is a client-side convenience, not a trust boundary — the receiving endpoint MUST re-validate every submitted value, and a renderer MUST bound pattern evaluation against catastrophic backtracking (Renderer Safety section 4).
+
 ### 3.0b Submit Button
 
 The `forms:submit` block renders a submission button within a form.

--- a/spec/extensions/legal/README.md
+++ b/spec/extensions/legal/README.md
@@ -240,6 +240,8 @@ Legal documents often require specific signature block formats:
 
 The signature block `role` is one of `counsel`, `attorney`, `party`, `witness`, or `notary`; the signer object MAY also include a `fax` number. A `legal:signatureBlock` records a signatory for display; it is content, not a cryptographic signature, and attests nothing about execution or notarization (see section 9).
 
+> **Renderer safety.** Signer contact strings (name, address, telephone, fax) and party, judge, and notary names are author-asserted text. A renderer MUST render them as inert, escaped text and MUST NOT auto-linkify or otherwise promote them to a navigation target except through the safe-URI allowlist (Renderer Safety section 3.4).
+
 ## 7. Examples
 
 ### 7.1 Legal Brief with Table of Authorities

--- a/spec/extensions/phantoms/README.md
+++ b/spec/extensions/phantoms/README.md
@@ -222,6 +222,8 @@ All phantom data is in neither the document hash nor the manifest projection (se
 - **Anchors can be re-targeted silently.** A cluster `anchor` is a Content Anchor whose optional `contentHash` (Anchors and References specification) detects when its target has changed. Because phantoms are mutable on a `frozen` or `published` document, a note can be re-anchored to a different passage — or left anchored to since-edited content — without breaking a signature. Producers SHOULD populate `contentHash`, and consumers SHOULD warn when it is absent or no longer matches.
 - **Forking MUST NOT rely on the `author` field.** The `author` field is forgeable, so the private-cluster carry-over rule (section 8) MUST determine "the forking user is the phantom author" from local or session identity, never from the in-archive `author`; a private cluster whose author cannot be authenticated MUST be stripped from the fork (fail closed).
 
+Beyond integrity, the embedded content block tree is also a *rendering* surface. A renderer MUST apply the same safe-URI allowlist and untrusted-string sanitization to phantom content — link targets, image sources, SVG, math, and style values — that it applies to primary content, and MUST NOT grant phantom or other embedded content any capability (script execution, navigation, network access) it would deny to primary content (Renderer Safety section 6).
+
 ## 6. Scope
 
 Each cluster has a scope controlling its visibility:

--- a/spec/extensions/presentation/README.md
+++ b/spec/extensions/presentation/README.md
@@ -457,6 +457,8 @@ The `numberingConfig` field provides extended numbering configuration beyond the
 
 The `presentation:reference` block's `target` field uses Content Anchor URI syntax (see core Anchors and References specification). The `#` prefix identifies internal document references. The block uses the `presentation:` namespace prefix as required by the core content blocks spec (section 5) for extension block types:
 
+> **Renderer safety.** The `target` field is constrained to safe schemes (Renderer Safety section 2.1); fragment and relative references remain permitted, but dangerous schemes such as `javascript:` are rejected.
+
 ```json
 {
   "type": "text",

--- a/spec/extensions/semantic/README.md
+++ b/spec/extensions/semantic/README.md
@@ -439,6 +439,8 @@ Internal references use Content Anchor URI syntax (see core Anchors and Referenc
 }
 ```
 
+> **Renderer safety.** An entity `uri` and a cross-reference `target` are constrained to safe schemes (Renderer Safety section 2.1); fragment and relative references remain permitted, but dangerous schemes such as `javascript:` are rejected. A JSON-LD `@context` (section 3) MUST NOT be dereferenced from an untrusted document by default — a processor MUST resolve it offline or from an operator allowlist (Renderer Safety section 5).
+
 ## 8. Glossary
 
 ### 8.1 Term Definition


### PR DESCRIPTION
## Summary
- New **Renderer Safety** core specification (`spec/core/10-renderer-safety.md`): a default-deny safe-scheme allowlist for author-controlled URIs, plus normative renderer-MUST sanitization rules for inline SVG, math/LaTeX, CSS color, contact strings, client-side validation patterns (ReDoS), external reference resolution (JSON-LD `@context` / SSRF), and embedded/active content.
- Two shared schema definitions in `anchor.schema.json`: `safeUri` (navigational/link/action URIs) and `safeImageUri` (image sources — permits `data:image` raster payloads but excludes any SVG subtype, which is active content).
- Applied to every author-controlled URI field that reaches a renderer: core `link` `href`, form `action`, entity `uri`, the semantic and presentation cross-reference `target`, and collaboration `avatar`. `javascript:`, `data:` documents, `file:`, and other dangerous schemes are rejected — a signed `javascript:` URI would otherwise be a signed code-execution primitive.
- A `check:schema-closure` vector per constrained field (proving the constraint has teeth); schema dependency declarations updated so content/forms/semantic/presentation resolve their anchor reference; the new specification cross-referenced from the affected extensions.

Validation-layer tightening only — no canonical-byte or required-field change, so document identifiers and signed manifest projections are unaffected (the `check:document-id` and `check:manifest-projection` gates verify both unmoved).

## Test plan
- [x] All 18 gates green from a clean `npm ci` (schemas, examples, canonicalize, refs, coverage, hash-centralization, document-id, manifest-projection, jws-envelope, trust-state, webauthn, signature-set, lineage, provenance-timestamp, schema-closure, readme-examples, `tsc --noEmit`, `npm audit`).
- [x] Zero blast radius: every existing example URI uses a safe scheme; no example is rejected by the new constraints.
- [x] Seed-and-revert: a `javascript:` href injected into a real example fails `validate:examples`, then reverts clean.
- [x] `safeUri` / `safeImageUri` patterns AJV-tested against a real-value corpus plus an attack corpus (scheme smuggling via whitespace/control chars, case variants, `data:image/svg` spellings).