### PR TITLE
Represent documented content/collaboration fields in the schemas

### DIFF
--- a/examples/collaboration-document/collaboration/comments.json
+++ b/examples/collaboration-document/collaboration/comments.json
@@ -51,6 +51,7 @@
         "color": "#95e1d3"
       },
       "created": "2025-01-28T11:00:00Z",
+      "color": "#ffeb3b",
       "content": "This is a key differentiator from our current system.",
       "resolved": false
     },

--- a/examples/phantoms-document/phantoms/assets/index.json
+++ b/examples/phantoms-document/phantoms/assets/index.json
@@ -1,0 +1,10 @@
+{
+  "assets": [
+    {
+      "id": "sketch",
+      "path": "phantoms/assets/sketch.png",
+      "type": "image/png",
+      "size": 15360
+    }
+  ]
+}

--- a/examples/semantic-document/manifest.json
+++ b/examples/semantic-document/manifest.json
@@ -16,7 +16,8 @@
     "hash": "sha256:92500a7583caa81dbf668930afc74c01550a6903458360c6ef030518c5e65adb"
   },
   "metadata": {
-    "dublinCore": "metadata/dublin-core.json"
+    "dublinCore": "metadata/dublin-core.json",
+    "jsonld": "metadata/jsonld.json"
   },
   "semantic": {
     "bibliography": "semantic/bibliography.json",

--- a/examples/semantic-document/metadata/jsonld.json
+++ b/examples/semantic-document/metadata/jsonld.json
@@ -1,0 +1,11 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "@id": "https://example.org/semantic-document",
+  "name": "Semantic Document Example",
+  "author": {
+    "@type": "Person",
+    "name": "Ada Lovelace"
+  },
+  "keywords": ["semantics", "knowledge graph", "JSON-LD"]
+}

--- a/schemas/collaboration.schema.json
+++ b/schemas/collaboration.schema.json
@@ -134,6 +134,10 @@
           "type": "object",
           "properties": {
             "type": { "const": "highlight" },
+            "color": {
+              "type": "string",
+              "description": "Highlight color (a CSS color value; a renderer MUST validate or escape it before use — see the Renderer Safety core specification, section 3.3)"
+            },
             "content": {
               "type": "string",
               "description": "Optional note for the highlight"

--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -289,6 +289,11 @@
         },
         "attributes": {
           "$ref": "#/$defs/blockAttributes"
+        },
+        "crdt": {
+          "type": "object",
+          "description": "Transient CRDT synchronization state for the collaboration extension (e.g. a Yjs/Automerge per-node identifier). Library-specific and intentionally open. This field is stripped before the document hash is computed (Document Hashing section 4.3.1), so it never affects the document ID or any signature.",
+          "additionalProperties": true
         }
       }
     },

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -99,6 +99,10 @@
           "description": "Path to Dublin Core metadata",
           "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/relativePath"
         },
+        "jsonld": {
+          "description": "Path to a document-level JSON-LD metadata file (semantic extension). Out-of-hash advisory data — referenced by path only, with no manifest hash.",
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/relativePath"
+        },
         "custom": {
           "type": "object",
           "description": "Custom metadata references",

--- a/schemas/phantoms.schema.json
+++ b/schemas/phantoms.schema.json
@@ -183,6 +183,45 @@
         { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/person" }
       ],
       "unevaluatedProperties": false
+    },
+    "assetIndex": {
+      "type": "object",
+      "description": "Index for phantoms/assets/index.json. Mirrors the core asset index but, because phantom assets are out-of-hash and unverified (section 5.1), the per-asset content hash is OPTIONAL and the root version is optional: a phantom asset index makes no integrity claim. A consumer MUST treat phantom assets as untrusted regardless of any hash present.",
+      "required": ["assets"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Asset index version",
+          "pattern": "^\\d+\\.\\d+$"
+        },
+        "assets": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/phantomAsset" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "phantomAsset": {
+      "type": "object",
+      "description": "One phantom asset. Unlike a core asset, the content `hash` is optional because phantom assets carry no integrity binding.",
+      "required": ["id", "path", "type", "size"],
+      "properties": {
+        "id": { "type": "string", "description": "Asset identifier" },
+        "path": {
+          "description": "Archive-relative path to the asset",
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/relativePath"
+        },
+        "type": {
+          "description": "Media type",
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/mimeType"
+        },
+        "size": { "type": "integer", "minimum": 0, "description": "Asset size in bytes" },
+        "hash": {
+          "description": "Optional content hash (advisory only; phantom assets are out-of-hash)",
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentHash"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/schemas/semantic.schema.json
+++ b/schemas/semantic.schema.json
@@ -435,6 +435,21 @@
       },
       "additionalProperties": true
     },
+    "jsonLdDocument": {
+      "type": "object",
+      "description": "Schema for metadata/jsonld.json (document-level JSON-LD). An open JSON-LD graph: arbitrary vocabulary properties are permitted. Referenced by path only (no manifest hash), so it is out-of-hash advisory metadata; a processor MUST NOT dereference its @context from an untrusted document by default (Renderer Safety core specification, section 5).",
+      "properties": {
+        "@context": {
+          "oneOf": [
+            { "type": "string", "format": "uri" },
+            { "type": "object" },
+            { "type": "array" }
+          ],
+          "description": "JSON-LD context"
+        }
+      },
+      "additionalProperties": true
+    },
     "bibliographyFile": {
       "type": "object",
       "description": "Schema for semantic/bibliography.json (external CSL bibliography file)",

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -851,8 +851,8 @@ export const closureVectors: ClosureVector[] = [
   {
     schema: 'collaboration.schema.json',
     ref: '#/$defs/highlight',
-    description: 'highlight',
-    validInstance: { id: 'h1', type: 'highlight', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z' },
+    description: 'highlight carries color + content note; stays closed',
+    validInstance: { id: 'h1', type: 'highlight', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', color: '#ffeb3b', content: 'note' },
     invalidInstance: { id: 'h1', type: 'highlight', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', bogus: 1 },
   },
   {
@@ -1340,5 +1340,32 @@ export const closureVectors: ClosureVector[] = [
     description: 'author.avatar safe-image teeth (javascript: rejected)',
     validInstance: { name: 'Ada', avatar: 'https://example.com/avatars/jane.png' },
     invalidInstance: { name: 'Ada', avatar: 'javascript:alert(1)' },
+  },
+
+  // --- documented-field representability (S8) -------------------------------
+  // The optional crdt sync field is accepted on a block (and stripped before
+  // hashing); the block stays closed otherwise.
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'block carries optional crdt sync object; def stays closed',
+    validInstance: { type: 'paragraph', crdt: { clientId: 7, clock: 3 }, children: [] },
+    invalidInstance: { type: 'paragraph', crdt: { clientId: 7 }, children: [], bogus: 1 },
+  },
+  // Relaxed phantom asset index: per-asset hash is OPTIONAL (out-of-hash), but
+  // the index and each asset stay closed.
+  {
+    schema: 'phantoms.schema.json',
+    ref: '#/$defs/assetIndex',
+    description: 'phantom assetIndex (no required hash/version) closed',
+    validInstance: { assets: [{ id: 'a', path: 'phantoms/assets/x.png', type: 'image/png', size: 1 }] },
+    invalidInstance: { assets: [{ id: 'a', path: 'phantoms/assets/x.png', type: 'image/png', size: 1 }], bogus: 1 },
+  },
+  {
+    schema: 'phantoms.schema.json',
+    ref: '#/$defs/phantomAsset',
+    description: 'phantomAsset requires id/path/type/size; hash optional; closed',
+    validInstance: { id: 'a', path: 'phantoms/assets/x.png', type: 'image/png', size: 1 },
+    invalidInstance: { id: 'a', path: 'phantoms/assets/x.png', type: 'image/png', size: 1, bogus: 1 },
   },
 ];

--- a/scripts/lib/part-schema.ts
+++ b/scripts/lib/part-schema.ts
@@ -67,6 +67,7 @@ export const rules: Rule[] = [
   { test: /^manifest\.json$/, schema: 'manifest.schema.json' },
   { test: /^content\/document\.json$/, schema: 'content.schema.json' },
   { test: /^metadata\/dublin-core\.json$/, schema: 'dublin-core.schema.json' },
+  { test: /^metadata\/jsonld\.json$/, schema: 'semantic.schema.json', ref: '#/$defs/jsonLdDocument' },
   // academic.schema's root is the manifest-level academic config ({numbering: path});
   // the numbering data file is described by the numberingConfig $def.
   { test: /^academic\/numbering\.json$/, schema: 'academic.schema.json', ref: '#/$defs/numberingConfig' },
@@ -78,6 +79,9 @@ export const rules: Rule[] = [
   { test: /^provenance\/record\.json$/, schema: 'provenance.schema.json' },
   { test: /^forms\/data\.json$/, schema: 'forms.schema.json' },
   { test: /^phantoms\/clusters\.json$/, schema: 'phantoms.schema.json' },
+  // Phantom assets use a relaxed index (no required per-asset hash); the core
+  // asset rule is start-anchored on `assets/` and does not match `phantoms/assets/`.
+  { test: /^phantoms\/assets\/index\.json$/, schema: 'phantoms.schema.json', ref: '#/$defs/assetIndex' },
   { test: /^security\/signatures\.json$/, schema: 'security.schema.json' },
   { test: /^security\/annotations\.json$/, schema: 'annotations.schema.json' },
   // semantic file parts validate against their file-shape $defs (the schema root

--- a/spec/extensions/collaboration/README.md
+++ b/spec/extensions/collaboration/README.md
@@ -337,14 +337,14 @@ Standard emoji identifiers using Unicode CLDR short names (without colons). Exam
   "author": { "name": "Reviewer" },
   "created": "2025-01-15T14:00:00Z",
   "color": "#ffeb3b",
-  "note": "Important passage to revisit"
+  "content": "Important passage to revisit"
 }
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `color` | string | No | Highlight color (CSS color value, defaults to yellow) |
-| `note` | string | No | Optional note attached to the highlight |
+| `color` | string | No | Highlight color (a CSS color value; a renderer MUST validate or escape it — see the Renderer Safety core specification, section 3.3) |
+| `content` | string | No | Optional note attached to the highlight |
 
 ## 5. Change Tracking
 

--- a/spec/extensions/phantoms/README.md
+++ b/spec/extensions/phantoms/README.md
@@ -276,7 +276,7 @@ phantoms/
     └── sketch.png
 ```
 
-The asset index follows the same structure as the core asset index:
+The asset index mirrors the core asset index, but because phantom assets are out-of-hash and unverified (section 5.1), the per-asset content `hash` and the root `version` are OPTIONAL — a phantom asset index makes no integrity claim, and a consumer MUST treat phantom assets as untrusted regardless of any hash present:
 
 ```json
 {

--- a/spec/extensions/semantic/README.md
+++ b/spec/extensions/semantic/README.md
@@ -60,10 +60,12 @@ Location: `metadata/jsonld.json`
 {
   "type": "paragraph",
   "id": "definition-1",
-  "semantic": {
-    "@type": "DefinedTerm",
-    "name": "Semantic Document",
-    "description": "A document with machine-readable meaning"
+  "attributes": {
+    "semantic": {
+      "@type": "DefinedTerm",
+      "name": "Semantic Document",
+      "description": "A document with machine-readable meaning"
+    }
   },
   "children": [...]
 }
@@ -356,10 +358,12 @@ Based on Schema.org types:
 ```json
 {
   "type": "table",
-  "semantic": {
-    "@type": "Dataset",
-    "name": "Quarterly Revenue",
-    "description": "Revenue data for Q1-Q4 2024"
+  "attributes": {
+    "semantic": {
+      "@type": "Dataset",
+      "name": "Quarterly Revenue",
+      "description": "Revenue data for Q1-Q4 2024"
+    }
   },
   "children": [...]
 }
@@ -502,14 +506,16 @@ The `semantic:glossary` block renders a collected glossary by aggregating all `s
 ```json
 {
   "type": "blockquote",
-  "semantic": {
-    "source": {
-      "@type": "Book",
-      "name": "The Art of Computer Programming",
-      "author": "Donald Knuth",
-      "datePublished": "1968"
-    },
-    "page": "42"
+  "attributes": {
+    "semantic": {
+      "source": {
+        "@type": "Book",
+        "name": "The Art of Computer Programming",
+        "author": "Donald Knuth",
+        "datePublished": "1968"
+      },
+      "page": "42"
+    }
   },
   "children": [...]
 }
@@ -519,13 +525,17 @@ The `semantic:glossary` block renders a collected glossary by aggregating all `s
 
 ```json
 {
-  "semantic": {
-    "provenance": {
-      "source": "https://data.example.org/dataset/123",
-      "retrieved": "2025-01-10",
-      "license": "CC BY 4.0"
+  "type": "table",
+  "attributes": {
+    "semantic": {
+      "provenance": {
+        "source": "https://data.example.org/dataset/123",
+        "retrieved": "2025-01-10",
+        "license": "CC BY 4.0"
+      }
     }
-  }
+  },
+  "children": [...]
 }
 ```
 


### PR DESCRIPTION
## Summary
First of two Phase-4 increments (S8 "the spec's own examples/shapes fail their schemas", plus the clean wiring). Makes the schema express constructs the docs already teach but the schema rejected:

- **`crdt`** optional object on the core block base, for the collaboration extension's real-time sync state. It is stripped before the document hash (Document Hashing §4.3.1), so it is **hash-invisible** — no document ID or signature changes.
- **highlight `color`** added; the note reuses the existing `content` field, and the README example + field table are aligned.
- **`metadata.jsonld`** slot + a `jsonLdDocument` definition + a route for `metadata/jsonld.json`, backing the already-documented document-level JSON-LD file. Path-only / out-of-hash advisory metadata → not in the document ID.
- **Relaxed phantom asset index** (per-asset `hash` and root `version` optional) + a route for `phantoms/assets/index.json`. Phantom assets are out-of-hash and unverified, so the index makes no integrity claim; the README prose (wrongly "follows the core asset index") is corrected.
- **Semantic block-level JSON-LD examples** rewritten to place the annotation under `attributes.semantic` — the home the schema actually defines.

Each schema addition has a `check:schema-closure` vector; the two new routes are exercised by corpus examples (`metadata/jsonld.json`, `phantoms/assets/index.json`).

## Test plan
- [x] All 18 gates green from a clean `npm ci`.
- [x] **Re-freeze:** `check:document-id` 11 ids unmoved, `check:manifest-projection` 2 unmoved — confirmed the `crdt` field is hash-stripped (AJV-verified it survives nowhere a schema-valid document can place it) and `metadata.jsonld` is out-of-hash.
- [x] `check:schema-closure` 181 vectors (4 new + updated highlight); seed-and-revert: a wrong-type phantom-asset `size` fails `validate:examples`, then reverts clean.
- [x] Independent adversarial review (verdict SHIP, 0 ≥80); its two sub-threshold findings applied (stale `note` field-table row → `content`; dropped the undocumented `@graph` slot).