### PR TITLE
Reconcile legal example and collaboration documentation

### DIFF
--- a/examples/legal-document/content/document.json
+++ b/examples/legal-document/content/document.json
@@ -10,7 +10,8 @@
         "plaintiff": "Jane Doe",
         "defendant": "Acme Corporation"
       },
-      "docket": "Hon. Sarah Johnson"
+      "judge": "Hon. Sarah Johnson",
+      "docket": "Civil Action, Complex Litigation Division"
     },
     {
       "type": "heading",

--- a/examples/legal-document/manifest.json
+++ b/examples/legal-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:9321c311cff917acbeffa65b93fcd36f8ae6a77a6b6f9af86385a7686dca46a2",
+  "id": "sha256:2d5054cba6b27fbe79df330224fadca77eefe97115fd50f5e6e1ba36d44d8b52",
   "state": "draft",
   "created": "2025-01-30T10:00:00Z",
   "modified": "2025-01-30T10:00:00Z",
@@ -13,7 +13,7 @@
   ],
   "content": {
     "path": "content/document.json",
-    "hash": "sha256:453c8fb835ada526a6b13ecd73ad5c2d93984d35f4aa4b4b73acf98c318d8796"
+    "hash": "sha256:187b8e1e8338762d7b129c64418870784d0522006e3d5b820e26b206833527b0"
   },
   "metadata": {
     "dublinCore": "metadata/dublin-core.json"

--- a/spec/extensions/collaboration/README.md
+++ b/spec/extensions/collaboration/README.md
@@ -126,19 +126,15 @@ Implementations MAY define additional `crdtFormat` values for other CRDT librari
 
 ### 3.7 Synchronization Metadata
 
-Documents can include sync metadata for tracking collaboration state:
+Implementations can track live collaboration state with sync metadata. This is runtime state exchanged between peers, not an archived object (see the note below); `crdtFormat`/`crdtVersion` are declared separately, in the collaboration files (section 3.6):
 
 ```json
 {
-  "collaboration": {
-    "crdtFormat": "yjs",
-    "crdtVersion": "13.6",
-    "syncVersion": 1234,
-    "lastSync": "2025-01-15T10:00:00Z",
-    "peers": [
-      { "id": "peer1", "lastSeen": "2025-01-15T09:55:00Z" }
-    ]
-  }
+  "syncVersion": 1234,
+  "lastSync": "2025-01-15T10:00:00Z",
+  "peers": [
+    { "id": "peer1", "lastSeen": "2025-01-15T09:55:00Z" }
+  ]
 }
 ```
 
@@ -147,6 +143,8 @@ Documents can include sync metadata for tracking collaboration state:
 | `syncVersion` | integer | No | Logical clock or sequence number for sync state |
 | `lastSync` | string | No | ISO 8601 timestamp of last synchronization |
 | `peers` | array | No | Known collaboration peers |
+
+> **Informative — not archived.** The synchronization metadata here (`syncVersion`, `lastSync`, `peers`) is live, transport-layer session state. This specification defines no schema, no part file, and no archive location for it: implementations exchange it out-of-band over their collaboration transport, and a conformant CDX archive is not expected to contain it. The *archived* CRDT state is the per-node `crdt` field on content blocks (Content Blocks specification); the `crdtFormat`/`crdtVersion` declaration (section 3.6) is carried in the collaboration file(s) — `collaboration/comments.json` or `collaboration/changes.json`.
 
 ### 3.8 Document Materialization
 
@@ -431,7 +429,7 @@ For real-time collaboration, track user presence:
 
 ### 6.2 Presence Data
 
-This is typically ephemeral (not stored in document), but can be synchronized:
+This is live, transport-layer session state, exchanged out-of-band over the collaboration transport. This specification defines no schema, part file, or archive location for it, and a conformant CDX archive does not carry presence data; the shape below is informative, describing what implementations typically synchronize at runtime:
 
 ```json
 {
@@ -451,6 +449,8 @@ This is typically ephemeral (not stored in document), but can be synchronized:
 ## 7. Revision History
 
 ### 7.1 Overview
+
+> **Informative — the authoritative version chain is core lineage.** This revision list is a convenience view, not an integrity record: it is unschematized, may be carried out-of-band, and (like all collaboration data) is forgeable. The authenticated source of version history is the document's lineage chain — `manifest.lineage` and the provenance record (Provenance and Lineage specification). A consumer MUST treat a revision `documentId` as authoritative only when it resolves against that chain, and SHOULD reconcile any persisted revision list against it rather than trusting it directly.
 
 Track document evolution over time:
 

--- a/spec/extensions/legal/README.md
+++ b/spec/extensions/legal/README.md
@@ -28,6 +28,8 @@ The Legal Extension provides specialized blocks and marks for legal documents, i
 
 A document-level default citation style MAY be set in the manifest's `legal` configuration object as `citationStyle` (e.g. `bluebook`); individual citations MAY override it. Where the `legal` configuration carries operative values — a `jurisdiction` or governing-law selection — the document SHOULD declare the extension `required: true`, so that configuration is bound by the manifest projection (see section 9).
 
+The legal structure blocks (`legal:caption`, `legal:signatureBlock`, `legal:tableOfAuthorities`) carry no fallback rendering, so a reader that does not support the extension IGNOREs them as unknown namespaced blocks (Content Blocks specification, section 5; State Machine specification, section 5.4) — silently dropping the court caption, signatories, or table of authorities. A document whose legal meaning depends on these blocks (a filing, a brief, an executed agreement) MUST therefore declare `cdx.legal` `required: true`, so a non-supporting reader fails closed rather than presenting a document with its operative legal structure removed. The `required: false` form above is for documents that merely *cite* legal authorities and degrade acceptably without the extension.
+
 ## 3. Legal Citation Mark
 
 The `legal:cite` mark annotates text with legal citation information for automatic Table of Authorities generation.


### PR DESCRIPTION
## Summary
Second Phase-4 increment (example/prose reconciliation):

- **Legal example field mapping:** the sole legal example put the judge's name in the caption `docket` field; moved it to the dedicated `judge` field and put term/division text in `docket`. The example is an unsigned draft, so its document ID and `content.hash` are recomputed.
- **Legal fallback guidance:** the legal structure blocks carry no fallback rendering, so a reader without the extension IGNOREs them (Content Blocks §5; State Machine §5.4) — silently dropping the caption/signatories/ToA. A document whose legal meaning depends on these blocks MUST declare `cdx.legal` `required: true`.
- **Collaboration informative shapes:** presence (§6) and synchronization metadata (§3.7) are live transport-layer state with no schema, part file, or archive location; revision history (§7) is informative and points at the authoritative version chain (core lineage + provenance). The CRDT format declaration is carried in the collaboration files; the §3.7 example no longer co-locates it with the out-of-band sync state.

## Test plan
- [x] All 18 gates green from a clean `npm ci`.
- [x] **Re-freeze:** only `legal-document`'s id moved (intentional — content fix on an unsigned draft); the other 10 ids + 2 signed manifest projections are byte-unchanged. `content.hash` independently recomputed and verified by `check:document-id` + `validate:examples`.
- [x] Every cited section verified to exist (Content Blocks §5, State Machine §5.4, Provenance and Lineage, `manifest.lineage`); `check:refs` 173 valid.
- [x] Independent adversarial review (verdict SHIP, 0 ≥80); its one sub-threshold observation applied (split the §3.7 sync example so it no longer co-locates archived `crdtFormat` with out-of-band sync state).