### PR TITLE
Add a gate validating manifest extension-config slots

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -98,3 +98,6 @@ jobs:
 
       - name: Check README examples
         run: npm run check:readme-examples
+
+      - name: Check manifest extension config
+        run: npm run check:manifest-extension-config

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check:provenance-timestamp": "npx tsx scripts/check-provenance-timestamp.ts",
     "check:schema-closure": "npx tsx scripts/check-schema-closure.ts",
     "check:readme-examples": "npx tsx scripts/check-readme-examples.ts",
+    "check:manifest-extension-config": "npx tsx scripts/check-manifest-extension-config.ts",
     "generate:template": "npx tsx scripts/generate-template.ts"
   },
   "devDependencies": {

--- a/schemas/collaboration.schema.json
+++ b/schemas/collaboration.schema.json
@@ -4,6 +4,21 @@
   "title": "CDX Collaboration Extension",
   "description": "Schema for collaboration extension files in a CDX document",
   "$defs": {
+    "manifestConfig": {
+      "type": "object",
+      "description": "Shape of the manifest's `collaboration` configuration slot: paths to the collaboration part files. (Presence and synchronization metadata are transport-layer and not carried here — see the extension README, section 3.7.)",
+      "properties": {
+        "comments": {
+          "type": "string",
+          "description": "Path to the comments file (e.g. 'collaboration/comments.json')"
+        },
+        "changes": {
+          "type": "string",
+          "description": "Path to the change-tracking file (e.g. 'collaboration/changes.json')"
+        }
+      },
+      "additionalProperties": false
+    },
     "crdtFormat": {
       "type": "string",
       "description": "CRDT library format for interoperability",

--- a/scripts/check-manifest-extension-config.ts
+++ b/scripts/check-manifest-extension-config.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Enforcing gate for manifest extension-config slots.
+ *
+ * The manifest leaves each extension's config slot (`legal`, `academic`,
+ * `semantic`, …) an open `{type: object}` BY DESIGN, so the core manifest schema
+ * carries no dependency on extension schemas. The cost of that decoupling is that
+ * a malformed config — an out-of-enum citation style, a misspelled key — passes
+ * the manifest schema unchecked. This gate closes that gap WITHOUT coupling the
+ * core schema to the extensions: it validates every example manifest's MAPPED
+ * extension config slot against that extension's config schema, and pins a set of
+ * vectors so a malformed config is provably rejected (the teeth) and a well-formed
+ * one provably accepted.
+ *
+ * legal/academic/semantic use their SCHEMA ROOT as the manifest-config shape
+ * (e.g. legal's root is `{citationStyle, jurisdiction}`, additionalProperties:false);
+ * collaboration uses a dedicated `manifestConfig` $def (its root describes a
+ * comments/changes FILE, not the manifest slot). A manifest config slot with no
+ * entry below is intentionally unchecked — the manifest is additionalProperties:false,
+ * so only the named slots can appear, and each gains validation as its config shape
+ * is pinned. The gate grows by adding a slot→schema entry and its vectors.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createAjv, loadSchema } from './lib/ajv-utils.js';
+
+// Manifest config slot -> the schema (and optional $ref) describing that slot's
+// shape. legal/academic/semantic use their schema ROOT; collaboration's root is a
+// comments/changes FILE, so it uses a dedicated manifestConfig $def.
+const CONFIG_SCHEMAS: Record<string, { schema: string; ref?: string }> = {
+  legal: { schema: 'legal.schema.json' },
+  academic: { schema: 'academic.schema.json' },
+  semantic: { schema: 'semantic.schema.json' },
+  collaboration: { schema: 'collaboration.schema.json', ref: '#/$defs/manifestConfig' },
+};
+
+// One AJV with every schema loaded so any cross-file $ref in a config root resolves.
+const schemasDir = path.join(__dirname, '..', 'schemas');
+const ajv = createAjv();
+for (const f of fs.readdirSync(schemasDir).filter((f) => f.endsWith('.schema.json'))) {
+  ajv.addSchema(loadSchema(f));
+}
+
+import type { ValidateFunction } from 'ajv/dist/2020';
+const validators: Record<string, ValidateFunction> = {};
+for (const [slot, entry] of Object.entries(CONFIG_SCHEMAS)) {
+  const id = (loadSchema(entry.schema) as { $id: string }).$id;
+  validators[slot] = ajv.compile({ $ref: id + (entry.ref ?? '') });
+}
+
+interface ConfigVector {
+  slot: string;
+  description: string;
+  config: unknown;
+  valid: boolean;
+}
+
+// Teeth: a well-formed config MUST validate; a malformed one (out-of-enum value
+// or an unknown key, against the additionalProperties:false config roots) MUST be
+// rejected. These are the negative half the corpus cannot give.
+const configVectors: ConfigVector[] = [
+  { slot: 'legal', description: 'valid citationStyle + jurisdiction', config: { citationStyle: 'bluebook', jurisdiction: 'US' }, valid: true },
+  { slot: 'legal', description: 'out-of-enum citationStyle rejected', config: { citationStyle: 'not-a-style' }, valid: false },
+  { slot: 'legal', description: 'unknown key rejected', config: { citationStyle: 'bluebook', bogus: 1 }, valid: false },
+  { slot: 'legal', description: 'wrong-type jurisdiction rejected', config: { jurisdiction: 123 }, valid: false },
+  { slot: 'academic', description: 'valid numbering path', config: { numbering: 'academic/numbering.json' }, valid: true },
+  { slot: 'academic', description: 'unknown key rejected', config: { numbering: 'academic/numbering.json', bogus: 1 }, valid: false },
+  { slot: 'semantic', description: 'valid bibliography + glossary', config: { bibliography: 'semantic/bibliography.json', glossary: 'semantic/glossary.json' }, valid: true },
+  { slot: 'semantic', description: 'unknown key rejected', config: { bogus: 1 }, valid: false },
+  { slot: 'collaboration', description: 'valid comments + changes paths', config: { comments: 'collaboration/comments.json', changes: 'collaboration/changes.json' }, valid: true },
+  { slot: 'collaboration', description: 'unknown key rejected', config: { comments: 'collaboration/comments.json', sync: {} }, valid: false },
+];
+
+let failures = 0;
+const fail = (msg: string): void => {
+  console.log(`  ✗ ${msg}`);
+  failures++;
+};
+
+// --- Part 1: example corpus -----------------------------------------------
+console.log('Manifest extension configs (example corpus):');
+const examplesDir = path.join(__dirname, '..', 'examples');
+let checked = 0;
+for (const name of fs.readdirSync(examplesDir, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name).sort()) {
+  const manifestPath = path.join(examplesDir, name, 'manifest.json');
+  if (!fs.existsSync(manifestPath)) continue;
+  let manifest: Record<string, unknown>;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (err) {
+    fail(`${name} — manifest parse error: ${(err as Error).message}`);
+    continue;
+  }
+  for (const slot of Object.keys(CONFIG_SCHEMAS)) {
+    if (manifest[slot] === undefined) continue;
+    checked++;
+    const validate = validators[slot];
+    if (!validate(manifest[slot])) {
+      fail(`${name}: manifest.${slot} invalid — ${JSON.stringify(validate.errors)}`);
+    } else {
+      console.log(`  ✓ ${name}: manifest.${slot}`);
+    }
+  }
+}
+
+// --- Part 2: vectors (teeth) -----------------------------------------------
+console.log('\nConfig vectors (teeth):');
+for (const v of configVectors) {
+  const validate = validators[v.slot];
+  const ok = validate(v.config);
+  if (v.valid && !ok) {
+    fail(`${v.slot} "${v.description}" — valid config REJECTED: ${JSON.stringify(validate.errors)}`);
+  } else if (!v.valid && ok) {
+    fail(`${v.slot} "${v.description}" — invalid config ACCEPTED (no teeth)`);
+  } else {
+    console.log(`  ✓ ${v.slot} "${v.description}"`);
+  }
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} manifest-extension-config check(s) failed`);
+  process.exit(1);
+}
+console.log(`\n✓ manifest-extension-config: ${checked} example config(s) + ${configVectors.length} vectors across ${Object.keys(CONFIG_SCHEMAS).length} extensions, all validated`);

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -836,6 +836,13 @@ export const closureVectors: ClosureVector[] = [
   },
   {
     schema: 'collaboration.schema.json',
+    ref: '#/$defs/manifestConfig',
+    description: 'manifestConfig (comments/changes paths) closed',
+    validInstance: { comments: 'collaboration/comments.json', changes: 'collaboration/changes.json' },
+    invalidInstance: { comments: 'collaboration/comments.json', bogus: 1 },
+  },
+  {
+    schema: 'collaboration.schema.json',
     ref: '#/$defs/changesFile',
     description: 'changesFile',
     validInstance: { version: '0.2', changes: [] },


### PR DESCRIPTION
## Summary
Final Phase-4 increment (S5 — dead/vacuous config roots). The manifest leaves each extension's config slot (`legal`, `academic`, `semantic`, `collaboration`) an open object *by design*, so the core schema carries no dependency on extension schemas — but a malformed config (out-of-enum citation style, misspelled key) passed unchecked.

- Adds **`check:manifest-extension-config`** (19th gate): validates every example manifest's mapped config slot against the extension's own config schema, without coupling the core schema to the extensions. legal/academic/semantic use their schema **root** (which is the manifest-config shape); collaboration uses a dedicated **`manifestConfig`** definition (its root describes a comments/changes *file*, not the manifest slot).
- Pins positive + negative vectors so an out-of-enum value, an unknown key, or a wrong-type value is provably rejected (teeth).
- Adds the collaboration `manifestConfig` definition (comments/changes path object) + a schema-closure vector for it.
- Wired into **both** package.json and the CI workflow.

Tooling + one additive out-of-hash definition only — no schema/example data change, so document IDs and signed manifest projections are unaffected.

## Test plan
- [x] All 19 gates green from a clean `npm ci`.
- [x] New gate validates 4 corpus configs (academic/collaboration/legal/semantic) + 10 vectors; seed-and-revert: an out-of-enum `citationStyle` injected into the real legal-document manifest fails the gate (exit 1), then reverts clean.
- [x] **Re-freeze:** `check:document-id` 11 ids unmoved, `check:manifest-projection` 2 unmoved (the `manifestConfig` def is additive and out-of-hash).
- [x] Independent adversarial review of the gate (verdict SHIP, 0 ≥80); validators proven non-vacuous via 20 external probes + a simulated closure-removal. Its two findings applied: mapped `collaboration` (was an unchecked open slot) and added a wrong-type vector + documented the unmapped-slot limitation.