### PR TITLE
Open closed enums on inherently open extension vocabularies

### DIFF
--- a/schemas/collaboration.schema.json
+++ b/schemas/collaboration.schema.json
@@ -21,8 +21,7 @@
     },
     "crdtFormat": {
       "type": "string",
-      "description": "CRDT library format for interoperability",
-      "enum": ["yjs", "automerge", "diamond-types", "custom"]
+      "description": "CRDT library format for interoperability (open vocabulary; the Collaboration Extension README lists recognized formats). An unrecognized value is treated as opaque, not rejected."
     },
     "author": {
       "description": "Comment/change author information extending base person",

--- a/schemas/legal.schema.json
+++ b/schemas/legal.schema.json
@@ -6,13 +6,11 @@
   "$defs": {
     "citationCategory": {
       "type": "string",
-      "description": "Category for Table of Authorities grouping",
-      "enum": ["cases", "statutes", "regulations", "constitutions", "treatises", "law-reviews", "other"]
+      "description": "Category for Table of Authorities grouping (open vocabulary; the Legal Extension README lists recommended categories). An unrecognized category is preserved, not rejected."
     },
     "citationFormat": {
       "type": "string",
-      "description": "Legal citation style",
-      "enum": ["bluebook", "alwd", "mcgill", "oscola"]
+      "description": "Legal citation style (open vocabulary; the Legal Extension README lists recommended styles). An unrecognized style is treated as advisory and degrades gracefully, not rejected."
     },
     "legalCiteMark": {
       "type": "object",

--- a/schemas/semantic.schema.json
+++ b/schemas/semantic.schema.json
@@ -88,8 +88,7 @@
         },
         "entityType": {
           "type": "string",
-          "description": "Schema.org type of the entity",
-          "enum": ["Person", "Organization", "Place", "Event", "Product", "CreativeWork"]
+          "description": "Schema.org type of the entity (open vocabulary; the Semantic Extension README lists recommended values). An unrecognized value is preserved, not rejected."
         },
         "source": {
           "type": "string",

--- a/scripts/check-manifest-extension-config.ts
+++ b/scripts/check-manifest-extension-config.ts
@@ -6,7 +6,7 @@
  * The manifest leaves each extension's config slot (`legal`, `academic`,
  * `semantic`, …) an open `{type: object}` BY DESIGN, so the core manifest schema
  * carries no dependency on extension schemas. The cost of that decoupling is that
- * a malformed config — an out-of-enum citation style, a misspelled key — passes
+ * a malformed config — a wrong-typed value, a misspelled key — passes
  * the manifest schema unchecked. This gate closes that gap WITHOUT coupling the
  * core schema to the extensions: it validates every example manifest's MAPPED
  * extension config slot against that extension's config schema, and pins a set of
@@ -57,12 +57,12 @@ interface ConfigVector {
   valid: boolean;
 }
 
-// Teeth: a well-formed config MUST validate; a malformed one (out-of-enum value
+// Teeth: a well-formed config MUST validate; a malformed one (a wrong-typed value
 // or an unknown key, against the additionalProperties:false config roots) MUST be
 // rejected. These are the negative half the corpus cannot give.
 const configVectors: ConfigVector[] = [
   { slot: 'legal', description: 'valid citationStyle + jurisdiction', config: { citationStyle: 'bluebook', jurisdiction: 'US' }, valid: true },
-  { slot: 'legal', description: 'out-of-enum citationStyle rejected', config: { citationStyle: 'not-a-style' }, valid: false },
+  { slot: 'legal', description: 'wrong-type citationStyle rejected', config: { citationStyle: 123 }, valid: false },
   { slot: 'legal', description: 'unknown key rejected', config: { citationStyle: 'bluebook', bogus: 1 }, valid: false },
   { slot: 'legal', description: 'wrong-type jurisdiction rejected', config: { jurisdiction: 123 }, valid: false },
   { slot: 'academic', description: 'valid numbering path', config: { numbering: 'academic/numbering.json' }, valid: true },

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -850,6 +850,13 @@ export const closureVectors: ClosureVector[] = [
   },
   {
     schema: 'collaboration.schema.json',
+    ref: '#/$defs/crdtFormat',
+    description: 'crdtFormat is an open vocabulary (a non-enumerated CRDT library accepted); a non-string is rejected',
+    validInstance: 'loro',
+    invalidInstance: 42,
+  },
+  {
+    schema: 'collaboration.schema.json',
     ref: '#/$defs/comment',
     description: 'comment (unevaluatedProperties teeth over open baseComment)',
     validInstance: { id: 'c1', type: 'comment', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', content: 'hi' },
@@ -1246,6 +1253,20 @@ export const closureVectors: ClosureVector[] = [
     invalidInstance: { type: 'legal:cite', citation: 'Roe v. Wade', category: 'cases', bogus: 1 },
   },
   {
+    schema: 'legal.schema.json',
+    ref: '#/$defs/citationCategory',
+    description: 'citationCategory is an open vocabulary (a non-enumerated category accepted); a non-string is rejected',
+    validInstance: 'foreign-statutes',
+    invalidInstance: 42,
+  },
+  {
+    schema: 'legal.schema.json',
+    ref: '#/$defs/citationFormat',
+    description: 'citationFormat is an open vocabulary (a non-enumerated style accepted); a non-string is rejected',
+    validInstance: 'aglc',
+    invalidInstance: 42,
+  },
+  {
     schema: 'forms.schema.json',
     ref: '#/$defs/validation',
     description: 'forms validation closed',
@@ -1272,6 +1293,13 @@ export const closureVectors: ClosureVector[] = [
     description: 'semantic entityMark closed',
     validInstance: { type: 'entity', uri: 'https://www.wikidata.org/wiki/Q1' },
     invalidInstance: { type: 'entity', uri: 'https://www.wikidata.org/wiki/Q1', bogus: 1 },
+  },
+  {
+    schema: 'semantic.schema.json',
+    ref: '#/$defs/entityMark',
+    description: 'entityType is an open vocabulary (a non-enumerated Schema.org/custom type accepted); a non-string is rejected',
+    validInstance: { type: 'entity', uri: 'https://www.wikidata.org/wiki/Q5', entityType: 'Movie' },
+    invalidInstance: { type: 'entity', uri: 'https://www.wikidata.org/wiki/Q5', entityType: 42 },
   },
   {
     schema: 'semantic.schema.json',

--- a/spec/extensions/collaboration/README.md
+++ b/spec/extensions/collaboration/README.md
@@ -114,7 +114,7 @@ Documents using CRDT-based collaboration MUST declare the CRDT format in their c
 | `crdtFormat` | string | Yes | CRDT implementation identifier |
 | `crdtVersion` | string | No | Version of the CRDT library used |
 
-**Recognized `crdtFormat` values:**
+`crdtFormat` accepts any string as an open vocabulary. The following values are RECOMMENDED:
 
 | Value | Description |
 |-------|-------------|
@@ -122,7 +122,7 @@ Documents using CRDT-based collaboration MUST declare the CRDT format in their c
 | `automerge` | [Automerge](https://automerge.org/) JSON CRDT |
 | `diamond-types` | [Diamond Types](https://github.com/josephg/diamond-types) text CRDT |
 
-Implementations MAY define additional `crdtFormat` values for other CRDT libraries. Unrecognized values SHOULD be treated as opaque—implementations that do not support the format can still read static content but cannot participate in CRDT synchronization.
+Implementations MAY use additional `crdtFormat` values for other CRDT libraries. An unrecognized value SHOULD be treated as opaque—an implementation that does not support the format can still read static content but cannot participate in CRDT synchronization.
 
 ### 3.7 Synchronization Metadata
 

--- a/spec/extensions/legal/README.md
+++ b/spec/extensions/legal/README.md
@@ -66,7 +66,7 @@ The `legal:cite` mark annotates text with legal citation information for automat
 
 ### 3.3 Citation Categories
 
-Standard categories for Table of Authorities grouping:
+`citationCategory` accepts any string as an open vocabulary. The following categories are RECOMMENDED for Table of Authorities grouping; implementations MAY use additional categories for jurisdictions or authority types not covered here:
 
 | Category | Description |
 |----------|-------------|
@@ -77,6 +77,8 @@ Standard categories for Table of Authorities grouping:
 | `treatises` | Legal treatises and books |
 | `law-reviews` | Law review articles |
 | `other` | Other secondary sources |
+
+An unrecognized category is preserved and grouped under its own heading, not rejected.
 
 ### 3.4 Pinpoint Citations
 
@@ -152,7 +154,7 @@ The `legal:tableOfAuthorities` block generates an auto-indexed table of all cite
 
 ## 5. Citation Formats
 
-The Legal Extension supports common legal citation styles:
+The Legal Extension supports common legal citation styles. The `format` field (and the manifest-level `citationStyle` default) accept any string as an open vocabulary; the styles below are RECOMMENDED, and an unrecognized style degrades gracefully (see the Reader dispositions note below) rather than being rejected:
 
 > **Reader dispositions.** The cross-element relationships in this extension are resolved at render time, so their failures are rendering-degradation WARNINGs in all states, never integrity failures (State Machine section 5.4): a `legal:cite` whose `category` matches no Table of Authorities category, a Table of Authorities category with no citing `legal:cite`, and a `format` (or a default `citationStyle`) naming an unimplemented style all degrade gracefully — the reader renders the raw `citation` text and SHOULD surface the unresolved relationship, and MUST NOT invent a category or fail the document.
 

--- a/spec/extensions/semantic/README.md
+++ b/spec/extensions/semantic/README.md
@@ -343,13 +343,15 @@ Implementations MUST support either `children` (rich content) or `content` (plai
 
 ### 5.2 Entity Types
 
-Based on Schema.org types:
+`entityType` accepts any [Schema.org](https://schema.org/) type as an open vocabulary. The following values are commonly used and RECOMMENDED:
 - `Person`
 - `Organization`
 - `Place`
 - `Event`
 - `Product`
 - `CreativeWork`
+
+Implementations MAY use any other Schema.org type or custom type string. An unrecognized value is preserved and treated as opaque, not rejected (in keeping with the open-world principle in Content Blocks section 5.1).
 
 ## 6. Structured Data
 


### PR DESCRIPTION
## Summary
- Relax three closed schema enums on inherently open vocabularies to open strings, keeping the enumerated values as RECOMMENDED lists in the READMEs: semantic `entityType` (Schema.org types), legal `citationFormat`/`citationCategory` (citation styles/categories), and collaboration `crdtFormat` (CRDT libraries).
- An unrecognized value is now preserved rather than strict-rejected as malformed, consistent with the format's open-world rule.
- Add four schema-closure vectors proving a non-enumerated string is accepted while a non-string is rejected.
- Retarget the legal manifest-config slot vector to a wrong-type check, since the citation-style field is now an open string.

## Test plan
- [x] All gates green from clean `npm ci`: schemas+examples, canonicalize (74), sync, refs (174), coverage, hash-centralization, document-id (11), manifest-projection (2), jws/trust/webauthn/signature/lineage/provenance, schema-closure (186), readme-examples, manifest-extension-config (10 vectors), tsc, audit (0 vulns)
- [x] Re-freeze tripwires unmoved: 11 document ids + 2 manifest projections byte-unchanged (no example value changed)
- [x] Seed-and-revert: restoring an enum makes `check:schema-closure` reject the open-value vector