### PR TITLE
Define a per-extension version contract

### DIFF
--- a/spec/extensions/README.md
+++ b/spec/extensions/README.md
@@ -121,12 +121,22 @@ When implementing CDX support, consider the following priority order:
 
 ## Versioning
 
-- Each extension specifies its version in the manifest declaration
-- Data files include a `version` field matching the extension version
-- Version changes follow semantic versioning principles:
-  - Patch: Bug fixes, clarifications
-  - Minor: New optional features, backward-compatible
-  - Major: Breaking changes
+Each extension carries a `version` in two places: its manifest declaration (`extensions[].version`, see Extension Declaration above) and a `version` field inside each of its data files. Both use `MAJOR.MINOR` and follow semantic versioning:
+
+- Patch: Bug fixes, clarifications
+- Minor: New optional features, backward-compatible
+- Major: Breaking changes
+
+### Reader behavior on version skew
+
+Core version rules govern only the `cdx` document version (Manifest section 4.1). Each extension version follows the same MAJOR/MINOR discipline, applied per extension:
+
+- **Higher minor, same major** (the reader supports the major version): the reader MUST NOT reject the extension. It SHOULD process the fields and constructs it recognizes and ignore unrecognized additions — a warning disposition (State Machine section 5.4), never an error.
+- **Higher major, or an extension the reader does not support at all**: the reader treats the extension as unsupported, and the consequence follows the manifest `required` flag. An unsupported `required: true` extension means the reader MUST refuse to process the document; an unsupported `required: false` extension is ignored — the reader drops that extension's data and renders the rest, degrading gracefully. These are the existing unsupported-required and unsupported-optional rows of State Machine section 5.4; a version the reader cannot process is never, by itself, an integrity failure.
+
+**Out-of-hash version skew is never an integrity error.** An extension's data files, and the `config` object of any extension not declared `required: true`, are outside the document hash and the manifest projection (Integrity Status of Extension Data above). A version carried in that out-of-hash data degrades rendering at most: a missing or unparseable out-of-hash data part is a WARNING in all states (State Machine section 5.4), and a version the reader cannot process MUST NOT be reported as an INTEGRITY-ERROR.
+
+**Manifest declaration vs data-file version.** The `{id, version, required}` an extension declares in the manifest is bound by the manifest projection for every extension, so on a `frozen` or `published` document it is authenticated; a data file's own `version`, by contrast, is out-of-hash tier-three data. The data-file `version` SHOULD equal the manifest declaration. A reader that finds the two inconsistent applies the skew rules above (using the higher of the two to decide minor/major handling) and SHOULD surface the inconsistency, but MUST NOT escalate it to an integrity failure: the discrepancy can only be observed by reading the unauthenticated data file, so it cannot signal tampering and degrades rendering at most.
 
 **Note:** Most extensions are at version 0.1 (initial draft). The Collaboration extension is at version 0.2 because it underwent breaking changes to its comment threading model during development. This version difference is intentional and reflects actual specification maturity.
 

--- a/spec/extensions/academic/README.md
+++ b/spec/extensions/academic/README.md
@@ -671,6 +671,8 @@ Location: `academic/numbering.json`
 }
 ```
 
+The `version` field follows the extension version contract in the CDX Extensions overview (Versioning): a higher minor is processed with unrecognized fields ignored; a higher major — or a reader without academic support — follows the manifest `required` flag; and because `academic/numbering.json` is outside the document hash, a version mismatch degrades rendering (a WARNING), never an integrity error.
+
 ### 10.1 Numbering Styles
 
 | Style | Example | Description |

--- a/spec/extensions/collaboration/README.md
+++ b/spec/extensions/collaboration/README.md
@@ -217,6 +217,8 @@ Location: `collaboration/comments.json`
 }
 ```
 
+The `version` field follows the extension version contract in the CDX Extensions overview (Versioning): a higher minor is processed with unrecognized fields ignored; a higher major — or a reader without collaboration support — follows the manifest `required` flag; and because the collaboration data files are outside the document hash, a version mismatch degrades rendering (a WARNING), never an integrity error.
+
 ### 4.3 Comment Fields
 
 | Field | Type | Required | Description |

--- a/spec/extensions/forms/README.md
+++ b/spec/extensions/forms/README.md
@@ -400,6 +400,8 @@ Form values are stored in `forms/data.json`:
 }
 ```
 
+The `version` field follows the extension version contract in the CDX Extensions overview (Versioning): a higher minor is processed with unrecognized fields ignored; a higher major — or a reader without forms support — follows the manifest `required` flag; and because `forms/data.json` is outside the document hash, a version mismatch degrades rendering (a WARNING), never an integrity error.
+
 ### 5.2 Submission
 
 ```json

--- a/spec/extensions/phantoms/README.md
+++ b/spec/extensions/phantoms/README.md
@@ -98,6 +98,8 @@ Location: `phantoms/clusters.json`
 }
 ```
 
+The `version` field follows the extension version contract in the CDX Extensions overview (Versioning): a higher minor is processed with unrecognized fields ignored; a higher major — or a reader with no phantom support at all — follows the manifest `required` flag, so for a `required: false` phantom layer the reader ignores `phantoms/clusters.json` and the manifest's phantom layer reference and renders the rest of the document; and because the phantom data is outside the document hash, a version mismatch degrades rendering (a WARNING), never an integrity error.
+
 ### 4.2 Cluster Fields
 
 | Field | Type | Required | Description |


### PR DESCRIPTION
## Summary
- Add a normative "Reader behavior on version skew" rule to the extensions overview (`spec/extensions/README.md`), mirroring the core `cdx`-version rule (Manifest section 4.1) per extension: higher minor → process known / ignore unknown (a warning disposition); higher major or unsupported extension → follow the manifest `required` flag (unsupported `required: true` MUST refuse to process the document; unsupported `required: false` is ignored and the rest renders).
- State that out-of-hash version skew is never an INTEGRITY-ERROR (it reuses the existing State Machine section 5.4 out-of-hash-data-part WARNING disposition; no new row).
- Define the manifest-declaration (`extensions[].{id,version,required}`, bound by the projection) vs data-file `version` (out-of-hash) relationship, resting the non-integrity reasoning on the data file being unauthenticated.
- Add concise pointers from the forms, academic, collaboration, and phantoms data-file `version` fields.

## Test plan
- [x] All 19 gates green from clean `npm ci`
- [x] `check:refs` 174 → 178 (new validated "Manifest section 4.1" + "State Machine section 5.4" refs resolve; the by-name pointers carry no numeric section and don't form validated refs)
- [x] Re-freeze tripwires unmoved: 11 document ids + 2 manifest projections (prose-only, no schema/example change)
- [x] No new JSON fences (`check:readme-examples` unchanged at 54 + 1 opt-out)