### PR TITLE
Define collaboration accept/reject semantics and document-id impact

### DIFF
--- a/examples/collaboration-document/collaboration/comments.json
+++ b/examples/collaboration-document/collaboration/comments.json
@@ -83,7 +83,7 @@
       "created": "2025-01-28T11:32:00Z",
       "originalText": "$150,000",
       "suggestedText": "$200,000",
-      "status": "accepted"
+      "status": "pending"
     },
     {
       "id": "reaction-1",

--- a/spec/extensions/collaboration/README.md
+++ b/spec/extensions/collaboration/README.md
@@ -413,10 +413,13 @@ Location: `collaboration/changes.json`
 
 ### 5.5 Accepting/Rejecting Changes
 
-Changes can be:
-- `pending` - Not yet reviewed
-- `accepted` - Incorporated into content
-- `rejected` - Reverted
+A change's `status` — like a suggestion's `status` (section 4.5) — is an advisory editorial disposition recorded in the out-of-hash `collaboration/changes.json` (or `collaboration/comments.json`); like all collaboration data it is unauthenticated and forgeable (section 10):
+
+- `pending` — not yet reviewed.
+- `accepted` — a reviewer has approved the change for incorporation.
+- `rejected` — a reviewer has declined the change.
+
+A status does not by itself alter the document. The authoritative, rendered document is always the in-hash `content/document.json`, so marking a change `accepted` records a decision, not a content edit — it does not change those bytes. A change is incorporated only when its `before`→`after` edit is applied to the content. Because content is bound by the document ID, applying one or more accepted changes produces a new version of the document: the canonical content hash — and therefore the document ID — changes, so any prior signature no longer covers the result, and the new version SHOULD be recorded in the document's lineage and provenance. Who applies an accepted change, and when, is an editorial-workflow matter this specification does not constrain; consequently `changes.json` MAY carry an `accepted` change whose edit is not yet reflected in the current content, and a reader MUST NOT assume that `accepted` implies the content already contains the change.
 
 ## 6. Presence Awareness
 


### PR DESCRIPTION
## Summary
- Rewrite Collaboration §5.5: a change/suggestion `status` is an advisory editorial disposition recorded in out-of-hash side files (section 4.5, section 10). The in-hash `content/document.json` is authoritative, so `accepted` records a decision, not a content edit. Applying accepted changes produces a new version of the document (the canonical content hash — and therefore the document id — changes, so prior signatures no longer cover it) recorded in lineage and provenance. A reader MUST NOT assume `accepted` implies the content already contains the change.
- Reconcile the example: the `$200,000` budget suggestion is now `pending` (it proposes a further edit on top of the already-applied `$150,000` accepted change), so the example is materialized-consistent.

## Test plan
- [x] All 19 gates green from clean `npm ci`
- [x] Re-freeze: 11 document ids + 2 manifest projections unmoved — the example edit is to out-of-hash `collaboration/comments.json`, so the collaboration-document id is unchanged (unsigned example)
- [x] `pending` is in the suggestion-status enum; comments.json validates
- [x] Independent review: SHIP, 0 ≥80 (applied the §3.8 cross-ref and terminology polish)