### PR TITLE
Namespace the presentation footnote mark as presentation:footnote

### DIFF
--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -358,6 +358,7 @@
                   { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/equationRefMark" },
                   { "$ref": "https://cdx.dev/schemas/academic.schema.json#/$defs/algorithmRefMark" },
                   { "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/indexMark" },
+                  { "$ref": "https://cdx.dev/schemas/presentation.schema.json#/$defs/footnoteMark" },
                   { "$ref": "https://cdx.dev/schemas/legal.schema.json#/$defs/legalCiteMark" },
                   {
                     "$comment": "Open escape (mirrors the dispatch in #/$defs/block): known marks are validated strictly by the branches above; an unrecognized mark MUST be namespaced (Content Blocks section 5.1). An unknown namespaced mark passes unchecked — as either a bare string or a typed object — while a bare, non-namespaced unknown mark is rejected as malformed, so a misspelled core mark is still caught.",
@@ -392,11 +393,11 @@
       "unevaluatedProperties": false
     },
     "knownMarkTypes": {
-      "$comment": "Every mark identifier validated by a branch of textNode.marks.items.oneOf — the seven core string marks and the twelve structured marks. The open escape excludes these so an unknown namespaced mark cannot collide with (or masquerade as) a known one in either string or object form.",
+      "$comment": "Every mark identifier validated by a branch of textNode.marks.items.oneOf — the seven core string marks and the thirteen structured marks. The open escape excludes these so an unknown namespaced mark cannot collide with (or masquerade as) a known one in either string or object form.",
       "enum": [
         "bold", "italic", "underline", "strikethrough", "code", "superscript", "subscript",
         "link", "anchor", "math", "citation", "footnote", "entity", "glossary",
-        "theorem-ref", "equation-ref", "algorithm-ref", "index", "legal:cite"
+        "theorem-ref", "equation-ref", "algorithm-ref", "index", "presentation:footnote", "legal:cite"
       ]
     },
     "linkMark": {

--- a/schemas/presentation.schema.json
+++ b/schemas/presentation.schema.json
@@ -832,6 +832,21 @@
       },
       "additionalProperties": false
     },
+    "footnoteMark": {
+      "type": "object",
+      "description": "Self-contained footnote mark carrying its footnote content blocks directly, for documents that use the presentation extension without the semantic extension. When the semantic extension is active, its bare `footnote` mark is the canonical footnote model.",
+      "required": ["type", "content"],
+      "properties": {
+        "type": { "const": "presentation:footnote" },
+        "id": { "type": "string", "description": "Footnote identifier" },
+        "content": {
+          "type": "array",
+          "description": "Footnote content blocks",
+          "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/block" }
+        }
+      },
+      "additionalProperties": false
+    },
     "presentationReference": {
       "allOf": [
         { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/blockBase" },

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -1066,6 +1066,13 @@ export const closureVectors: ClosureVector[] = [
   {
     schema: 'content.schema.json',
     ref: '#/$defs/block',
+    description: 'presentation:footnote mark is dispatched strictly (content-bearing, closed), not via the open escape',
+    validInstance: { type: 'text', value: 'claim', marks: [{ type: 'presentation:footnote', id: 'fn1', content: [{ type: 'text', value: 'note' }] }] },
+    invalidInstance: { type: 'text', value: 'claim', marks: [{ type: 'presentation:footnote', id: 'fn1', content: [{ type: 'text', value: 'note' }], bogus: 1 }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
     description: 'academic:theorem wired + closed',
     validInstance: { type: 'academic:theorem', variant: 'theorem', id: 't1', children: [] },
     invalidInstance: { type: 'academic:theorem', variant: 'theorem', children: [], bogus: 1 },

--- a/scripts/lib/part-schema.ts
+++ b/scripts/lib/part-schema.ts
@@ -19,7 +19,9 @@ const schemaDependencies: Record<string, string[]> = {
   // shared safe-URI definition) for their author-controlled URI fields.
   'forms.schema.json': ['anchor.schema.json'],
   'semantic.schema.json': ['anchor.schema.json'],
-  'presentation.schema.json': ['anchor.schema.json'],
+  // presentation also embeds the content block model via footnoteMark.content
+  // (the presentation:footnote mark), so it needs content plus content's cluster.
+  'presentation.schema.json': ['anchor.schema.json', 'content.schema.json', 'semantic.schema.json', 'academic.schema.json', 'legal.schema.json', 'forms.schema.json'],
   // phantoms embeds the core content block model (phantomContent.blocks → content
   // block dispatch), so it needs content plus content's whole cross-file cluster.
   'phantoms.schema.json': ['anchor.schema.json', 'semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json', 'content.schema.json'],

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -31,7 +31,9 @@ const dependentSchemas: DependentSchema[] = [
   // their author-controlled URI fields (form action, entity uri, cross-reference target).
   { schema: 'forms.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'manifest.schema.json', refs: ['anchor.schema.json'] },
-  { schema: 'presentation.schema.json', refs: ['anchor.schema.json'] },
+  // presentation also embeds the content block model via footnoteMark.content
+  // (the presentation:footnote mark), so it needs content plus content's cluster.
+  { schema: 'presentation.schema.json', refs: ['anchor.schema.json', 'content.schema.json', 'semantic.schema.json', 'academic.schema.json', 'legal.schema.json', 'forms.schema.json'] },
   { schema: 'semantic.schema.json', refs: ['anchor.schema.json'] },
   // phantoms embeds the content block model, which dispatches across the whole
   // content + extension-schema cluster.

--- a/spec/extensions/presentation/README.md
+++ b/spec/extensions/presentation/README.md
@@ -544,18 +544,19 @@ In content:
 
 ### 10.1 Footnote Definition
 
-**Cross-Extension Note:** When both the presentation and semantic extensions are active, the semantic extension provides the canonical footnote model with separate `semantic:footnote` blocks for footnote content. In this configuration, the presentation extension's footnote marks control styling and positioning only — the inline `content` array on presentation footnote marks is not used. The inline `content` array is a simplified alternative for documents that use the presentation extension without the semantic extension.
+The presentation extension defines a self-contained `presentation:footnote` mark that carries its footnote content directly in a `content` array, for documents that use the presentation extension without the semantic extension.
+
+**Cross-Extension Note:** When both the presentation and semantic extensions are active, the semantic extension provides the canonical footnote model — the bare `footnote` mark with separate `semantic:footnote` blocks for footnote content. The bare `footnote` mark and the `presentation:footnote` mark are distinct marks; a document SHOULD use a single footnote model. Presentation footnote styling (section 10.2) applies to whichever model is in use.
 
 In content:
 
-<!-- cdx-validate: skip (illustrative; the presentation footnote mark form documented above is not yet reconciled with the core footnote mark schema) -->
 ```json
 {
   "type": "text",
   "value": "important claim",
   "marks": [
     {
-      "type": "footnote",
+      "type": "presentation:footnote",
       "id": "fn1",
       "content": [
         { "type": "text", "value": "Source: Annual Report 2024" }

--- a/spec/extensions/semantic/README.md
+++ b/spec/extensions/semantic/README.md
@@ -209,7 +209,7 @@ When `entries` is provided, each entry MAY include a `renderedText` field contai
 
 Footnotes provide numbered references to supplementary content. The semantic extension defines the footnote content; the presentation extension (section 10) controls footnote styling and positioning.
 
-> **Cross-Extension Note:** The semantic extension provides the canonical footnote model. When both the semantic and presentation extensions are active, the presentation extension's footnote styling applies to semantic footnote blocks. The presentation extension's inline `content` array on footnote marks is a simplified alternative for documents that do not use the semantic extension. See the Presentation extension for details.
+> **Cross-Extension Note:** The semantic extension provides the canonical footnote model — the bare `footnote` mark with `semantic:footnote` blocks. When both the semantic and presentation extensions are active, the presentation extension's footnote styling applies to these semantic footnote blocks. The presentation extension's distinct `presentation:footnote` mark carries inline footnote content and is a simplified alternative for documents that do not use the semantic extension. See the Presentation extension for details.
 
 #### 4.5.1 Footnote Mark
 


### PR DESCRIPTION
## Summary
- The bare `footnote` mark had two conflicting definitions (semantic's reference form vs presentation's content-bearing form); core dispatch routed bare `footnote` only to the semantic mark, so the presentation footnote failed validation in every configuration and was hidden behind the repo's only `cdx-validate:skip` opt-out.
- Add a namespaced `presentation:footnote` mark (carrying footnote content blocks), register it strictly in the core content dispatch + `knownMarkTypes`, and leave the bare `footnote` mark as the semantic canonical model. Update both cross-extension notes and remove the opt-out.
- `presentation.schema.json` now embeds the content block model (footnote content), so its schema-dependency declarations gain the content cluster in both `part-schema.ts` and `validate-schemas.ts`.

## Test plan
- [x] All 19 gates green from clean `npm ci`
- [x] `check:schema-closure` 187 → 188 (new content-level dispatch vector proving `presentation:footnote` routes strictly, not via the open escape; seed-and-revert confirmed load-bearing on `check:schema-closure` AND `check:readme-examples`)
- [x] `check:readme-examples` 54 → 55 examples, **0 opt-outs** (the last `cdx-validate:skip` removed; the example is gated again)
- [x] Re-freeze: 11 document ids + 2 manifest projections unmoved (no corpus example uses `presentation:footnote`; bare `footnote` routing unchanged)
- [x] Content↔presentation dependency cycle compiles cleanly; bare `footnote` still routes only to the semantic mark
- [x] Independent review: SHIP, 0 ≥80