### PR TITLE
Resolve cross-extension reference and citation collisions

### DIFF
--- a/spec/core/03a-anchors-and-references.md
+++ b/spec/core/03a-anchors-and-references.md
@@ -329,6 +329,6 @@ Multiple mechanisms exist for cross-referencing within CDX documents. Use the fo
 | `link` mark (with `#anchor` href) | Core | General-purpose internal links; hyperlink-style references |
 | `semantic:ref` | Semantic | Scholarly cross-references (e.g., 'see Section 3', 'as shown in Figure 2') with automatic label generation |
 | `presentation:reference` | Presentation | Layout-aware references that need presentation-specific formatting or page numbers |
-| `academic:theoremRef` / `academic:equationRef` | Academic | References to theorems, equations, or other numbered academic elements |
+| `theorem-ref` / `equation-ref` / `algorithm-ref` | Academic | References to theorems, equations, algorithms, or other numbered academic elements |
 
-For simple internal links, use the core `link` mark. For documents requiring automatic numbering and label generation (e.g., 'Figure 3', 'Theorem 2.1'), use extension-specific reference marks. When multiple reference types apply, prefer the most semantically specific mechanism.
+For simple internal links, use the core `link` mark. For documents requiring automatic numbering and label generation (e.g., 'Figure 3', 'Theorem 2.1'), use extension-specific reference marks. When multiple reference types apply, prefer the most semantically specific mechanism: an academic numbered element — a theorem, equation, or algorithm — is referenced with its academic `*-ref` mark, which renders the element's number, while `semantic:ref` is for general scholarly cross-references. When both could resolve the same target, the academic `*-ref` mark is authoritative for academic numbered targets and `semantic:ref` for all others, and a document SHOULD reference a given target through a single mechanism.

--- a/spec/extensions/legal/README.md
+++ b/spec/extensions/legal/README.md
@@ -367,7 +367,7 @@ A legal document whose `legal` configuration carries operative values SHOULD dec
 
 The Legal Extension is compatible with:
 
-- **Semantic Extension**: Legal citations can include semantic entity markup
+- **Semantic Extension**: Legal citations can include semantic entity markup. The `legal:cite` mark and the semantic `citation` mark are distinct and feed disjoint outputs — a Table of Authorities collects only `legal:cite` marks (section 8), and a bibliography collects only semantic `citation` marks. An authority cited through both systems appears in both outputs, so a document SHOULD cite a given authority through a single system to avoid duplication.
 - **Presentation Extension**: Table of Authorities uses presentation layer styling
 - **Academic Extension**: Legal documents may use academic numbering for sections
 


### PR DESCRIPTION
## Summary
- Fix the Anchors and References (§11) mark-selection table, which named the academic reference marks `academic:theoremRef` / `academic:equationRef` (a form that exists in no schema) and omitted `algorithm-ref`; the marks are the bare `theorem-ref` / `equation-ref` / `algorithm-ref`.
- Add an academic↔semantic reference precedence rule: an academic numbered element is referenced with its academic `*-ref` mark, `semantic:ref` is for general cross-references, and when both could resolve a target the academic mark is authoritative for academic numbered targets and `semantic:ref` for all others.
- Add a legal↔semantic citation coexistence rule: `legal:cite` and semantic `citation` feed disjoint outputs (Table of Authorities vs bibliography); a document SHOULD cite a given authority through one system.

(True namespacing of the academic ref marks — `theorem-ref` → `academic:theorem-ref` — is intentionally deferred to a later phase as it touches the canonicalizer; the bare form is the correct current name.)

## Test plan
- [x] All 19 gates green from clean `npm ci`
- [x] `check:refs` 183 unchanged; `check:sync` clean (the §11 table now names the real schema consts)
- [x] Re-freeze: 11 document ids + 2 manifest projections unmoved (prose-only)
- [x] Independent review: SHIP, 0 ≥80