### PR TITLE
Constrain block IDs and reference targets to the content-anchor namespace

### DIFF
--- a/schemas/academic.schema.json
+++ b/schemas/academic.schema.json
@@ -127,10 +127,6 @@
               "type": "string",
               "description": "Variant name (built-in or custom)"
             },
-            "id": {
-              "type": "string",
-              "description": "Unique identifier for cross-referencing"
-            },
             "number": {
               "type": "string",
               "description": "Explicit number (e.g., '2.3.8')"
@@ -147,7 +143,7 @@
             "uses": {
               "type": "array",
               "description": "Content Anchor URIs of dependencies",
-              "items": { "type": "string" }
+              "items": { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentAnchorUri" }
             },
             "restate": {
               "type": "boolean",
@@ -174,7 +170,7 @@
           "properties": {
             "type": { "const": "academic:proof" },
             "of": {
-              "type": "string",
+              "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentAnchorUri",
               "description": "Content Anchor URI to the theorem being proved"
             },
             "title": {
@@ -244,10 +240,6 @@
           "required": ["type", "children"],
           "properties": {
             "type": { "const": "academic:exercise" },
-            "id": {
-              "type": "string",
-              "description": "Unique identifier"
-            },
             "number": {
               "type": "string",
               "description": "Exercise number"
@@ -283,10 +275,6 @@
           "required": ["type", "exercises"],
           "properties": {
             "type": { "const": "academic:exercise-set" },
-            "id": {
-              "type": "string",
-              "description": "Unique identifier"
-            },
             "title": {
               "type": "string",
               "description": "Set title"
@@ -325,7 +313,8 @@
         },
         "id": {
           "type": "string",
-          "description": "Line identifier for references"
+          "description": "Line identifier for references",
+          "pattern": "^[A-Za-z0-9._-]+$"
         }
       },
       "additionalProperties": false
@@ -340,10 +329,6 @@
           "properties": {
             "type": { "const": "academic:equation-group" },
             "environment": { "$ref": "#/$defs/equationEnvironment" },
-            "id": {
-              "type": "string",
-              "description": "Group identifier"
-            },
             "lines": {
               "type": "array",
               "description": "Array of equation lines",
@@ -405,10 +390,6 @@
           "required": ["type", "lines"],
           "properties": {
             "type": { "const": "academic:algorithm" },
-            "id": {
-              "type": "string",
-              "description": "Unique identifier"
-            },
             "number": {
               "type": "string",
               "description": "Algorithm number"
@@ -459,7 +440,7 @@
       "properties": {
         "type": { "const": "theorem-ref" },
         "target": {
-          "type": "string",
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentAnchorUri",
           "description": "Content Anchor URI to the theorem"
         },
         "format": {
@@ -476,7 +457,7 @@
       "properties": {
         "type": { "const": "equation-ref" },
         "target": {
-          "type": "string",
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentAnchorUri",
           "description": "Content Anchor URI to the equation"
         },
         "format": {
@@ -493,7 +474,7 @@
       "properties": {
         "type": { "const": "algorithm-ref" },
         "target": {
-          "type": "string",
+          "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentAnchorUri",
           "description": "Content Anchor URI to the algorithm"
         },
         "line": {

--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -285,7 +285,8 @@
         },
         "id": {
           "type": "string",
-          "description": "Unique block identifier (shares the document-wide ID namespace with anchor IDs)"
+          "description": "Unique block identifier (shares the document-wide ID namespace with anchor IDs)",
+          "pattern": "^[A-Za-z0-9._-]+$"
         },
         "attributes": {
           "$ref": "#/$defs/blockAttributes"
@@ -1117,7 +1118,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Unique subfigure identifier for cross-referencing"
+          "description": "Unique subfigure identifier for cross-referencing",
+          "pattern": "^[A-Za-z0-9._-]+$"
         },
         "label": {
           "type": "string",

--- a/schemas/forms.schema.json
+++ b/schemas/forms.schema.json
@@ -166,10 +166,6 @@
       "type": "object",
       "description": "Base properties shared by all form fields",
       "properties": {
-        "id": {
-          "type": "string",
-          "description": "Unique block identifier"
-        },
         "name": {
           "type": "string",
           "description": "Field name for form data"
@@ -212,10 +208,6 @@
           "required": ["type", "children"],
           "properties": {
             "type": { "const": "forms:form" },
-            "id": {
-              "type": "string",
-              "description": "Unique form identifier"
-            },
             "action": {
               "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeUri",
               "description": "Form submission URL. Constrained to safe schemes (see the Renderer Safety core specification): a javascript:/data: action would otherwise be a signed code-execution primitive when carried in signed content."
@@ -437,10 +429,6 @@
           "required": ["type"],
           "properties": {
             "type": { "const": "forms:submit" },
-            "id": {
-              "type": "string",
-              "description": "Unique block identifier"
-            },
             "label": {
               "type": "string",
               "description": "Button label",

--- a/schemas/legal.schema.json
+++ b/schemas/legal.schema.json
@@ -107,10 +107,6 @@
           "required": ["type"],
           "properties": {
             "type": { "const": "legal:tableOfAuthorities" },
-            "id": {
-              "type": "string",
-              "description": "Block identifier"
-            },
             "title": {
               "type": "string",
               "description": "Section title",
@@ -160,10 +156,6 @@
           "required": ["type", "court"],
           "properties": {
             "type": { "const": "legal:caption" },
-            "id": {
-              "type": "string",
-              "description": "Block identifier"
-            },
             "court": {
               "type": "string",
               "description": "Court name"
@@ -275,10 +267,6 @@
           "required": ["type", "role", "signer"],
           "properties": {
             "type": { "const": "legal:signatureBlock" },
-            "id": {
-              "type": "string",
-              "description": "Block identifier"
-            },
             "role": {
               "type": "string",
               "description": "Role of the signatory",

--- a/schemas/presentation.schema.json
+++ b/schemas/presentation.schema.json
@@ -838,7 +838,7 @@
       "required": ["type", "content"],
       "properties": {
         "type": { "const": "presentation:footnote" },
-        "id": { "type": "string", "description": "Footnote identifier" },
+        "id": { "type": "string", "description": "Footnote identifier", "pattern": "^[A-Za-z0-9._-]+$" },
         "content": {
           "type": "array",
           "description": "Footnote content blocks",

--- a/schemas/semantic.schema.json
+++ b/schemas/semantic.schema.json
@@ -67,7 +67,8 @@
         },
         "id": {
           "type": "string",
-          "description": "Unique footnote identifier for cross-referencing"
+          "description": "Unique footnote identifier for cross-referencing",
+          "pattern": "^[A-Za-z0-9._-]+$"
         }
       },
       "additionalProperties": false,
@@ -128,10 +129,6 @@
               "type": "string",
               "description": "Symbol-based footnote marker (must match corresponding mark)",
               "enum": ["asterisk", "dagger", "ddagger", "section", "parallel", "paragraph"]
-            },
-            "id": {
-              "type": "string",
-              "description": "Unique identifier (must match mark if present)"
             },
             "children": {
               "type": "array",
@@ -292,10 +289,6 @@
           "required": ["type", "term", "definition"],
           "properties": {
             "type": { "const": "semantic:term" },
-            "id": {
-              "type": "string",
-              "description": "Unique term identifier"
-            },
             "term": {
               "type": "string",
               "description": "The term being defined"
@@ -342,6 +335,12 @@
               "items": { "$ref": "https://cdx.dev/schemas/content.schema.json#/$defs/textNode" }
             }
           }
+        },
+        {
+          "description": "Internal references (external false or absent) MUST target a Content Anchor URI; external references (external true) MAY target any safe URI.",
+          "if": { "properties": { "external": { "const": true } }, "required": ["external"] },
+          "then": { "properties": { "target": { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeUri" } } },
+          "else": { "properties": { "target": { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/contentAnchorUri" } } }
         }
       ],
       "unevaluatedProperties": false

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -1438,4 +1438,108 @@ export const closureVectors: ClosureVector[] = [
     validInstance: { id: 'a', path: 'phantoms/assets/x.png', type: 'image/png', size: 1 },
     invalidInstance: { id: 'a', path: 'phantoms/assets/x.png', type: 'image/png', size: 1, bogus: 1 },
   },
+
+  // --- referenceable-id namespace + reference-target shape ------------------
+  // Every block id shares the document-wide anchor namespace, so blockBase.id is
+  // charset-constrained; a stray-character id is rejected. Reference targets are
+  // constrained to the Content Anchor URI shape so a malformed internal target
+  // fails at authoring time.
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'core blockBase.id charset (bad-character id rejected)',
+    validInstance: { type: 'paragraph', id: 'sec.1-intro', children: [] },
+    invalidInstance: { type: 'paragraph', id: 'bad id', children: [] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/subfigure',
+    description: 'subfigure.id charset (bad-character id rejected)',
+    validInstance: { id: 'fig-a', children: [{ type: 'paragraph', children: [] }] },
+    invalidInstance: { id: 'fig a', children: [{ type: 'paragraph', children: [] }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'academic block id inherits patterned blockBase (no local redeclaration); bad-character id rejected',
+    validInstance: { type: 'academic:theorem', variant: 'theorem', id: 'thm-ivt', children: [] },
+    invalidInstance: { type: 'academic:theorem', variant: 'theorem', id: 'thm ivt', children: [] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'legal block id inherits patterned blockBase (no local redeclaration); bad-character id rejected',
+    validInstance: { type: 'legal:tableOfAuthorities', id: 'toa-1' },
+    invalidInstance: { type: 'legal:tableOfAuthorities', id: 'toa 1' },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'equationLine.id charset (sub-block id, not blockBase); bad-character id rejected',
+    validInstance: { type: 'academic:equation-group', lines: [{ value: 'x', id: 'eq-exp' }] },
+    invalidInstance: { type: 'academic:equation-group', lines: [{ value: 'x', id: 'eq exp' }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic footnote mark id charset (bad-character id rejected)',
+    validInstance: { type: 'text', value: 'x', marks: [{ type: 'footnote', number: 1, id: 'fn-1' }] },
+    invalidInstance: { type: 'text', value: 'x', marks: [{ type: 'footnote', number: 1, id: 'fn 1' }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'presentation:footnote mark id charset (bad-character id rejected)',
+    validInstance: { type: 'text', value: 'x', marks: [{ type: 'presentation:footnote', id: 'pf-1', content: [{ type: 'text', value: 'n' }] }] },
+    invalidInstance: { type: 'text', value: 'x', marks: [{ type: 'presentation:footnote', id: 'pf 1', content: [{ type: 'text', value: 'n' }] }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'theorem-ref target = Content Anchor URI (bare non-anchor target rejected)',
+    validInstance: { type: 'text', value: 'x', marks: [{ type: 'theorem-ref', target: '#thm-ivt' }] },
+    invalidInstance: { type: 'text', value: 'x', marks: [{ type: 'theorem-ref', target: 'thm-ivt' }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'equation-ref target = Content Anchor URI (bare non-anchor target rejected)',
+    validInstance: { type: 'text', value: 'x', marks: [{ type: 'equation-ref', target: '#eq-exp' }] },
+    invalidInstance: { type: 'text', value: 'x', marks: [{ type: 'equation-ref', target: 'eq-exp' }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'algorithm-ref target = Content Anchor URI (bare non-anchor target rejected)',
+    validInstance: { type: 'text', value: 'x', marks: [{ type: 'algorithm-ref', target: '#alg-bisection' }] },
+    invalidInstance: { type: 'text', value: 'x', marks: [{ type: 'algorithm-ref', target: 'alg-bisection' }] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'proof.of = Content Anchor URI (bare non-anchor target rejected)',
+    validInstance: { type: 'academic:proof', of: '#thm-ivt', children: [] },
+    invalidInstance: { type: 'academic:proof', of: 'thm-ivt', children: [] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'theorem.uses items = Content Anchor URIs (bare non-anchor target rejected)',
+    validInstance: { type: 'academic:theorem', variant: 'theorem', id: 'thm-1', uses: ['#def-continuous'], children: [] },
+    invalidInstance: { type: 'academic:theorem', variant: 'theorem', id: 'thm-1', uses: ['def-continuous'], children: [] },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:ref internal target (external false/absent) MUST be a Content Anchor URI (non-anchor rejected)',
+    validInstance: { type: 'semantic:ref', target: '#sec-3' },
+    invalidInstance: { type: 'semantic:ref', target: 'section-3' },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'semantic:ref external target (external true) is a safe URI (https accepted, javascript rejected)',
+    validInstance: { type: 'semantic:ref', target: 'https://example.com/spec', external: true },
+    invalidInstance: { type: 'semantic:ref', target: 'javascript:alert(1)', external: true },
+  },
 ];

--- a/scripts/lib/part-schema.ts
+++ b/scripts/lib/part-schema.ts
@@ -14,6 +14,9 @@ import { createAjv, loadSchema } from './ajv-utils.js';
 // cross-file $refs resolve at compile time).
 const schemaDependencies: Record<string, string[]> = {
   'content.schema.json': ['anchor.schema.json', 'semantic.schema.json', 'academic.schema.json', 'presentation.schema.json', 'legal.schema.json', 'forms.schema.json'],
+  // academic references anchor.schema.json#/$defs/contentAnchorUri for its
+  // cross-reference target fields (theorem/equation/algorithm-ref target, uses, of).
+  'academic.schema.json': ['anchor.schema.json'],
   'collaboration.schema.json': ['anchor.schema.json'],
   // forms/semantic/presentation reference anchor.schema.json#/$defs/safeUri (the
   // shared safe-URI definition) for their author-controlled URI fields.

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -13,7 +13,6 @@ interface DependentSchema {
 
 // Standalone schemas (no cross-references)
 const standaloneSchemas: string[] = [
-  'academic.schema.json',
   'anchor.schema.json',
   'legal.schema.json',
 ];
@@ -22,6 +21,7 @@ const standaloneSchemas: string[] = [
 // precise-layout reference anchor.schema.json#/$defs/contentHash (the shared
 // content-hash definition).
 const dependentSchemas: DependentSchema[] = [
+  { schema: 'academic.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'annotations.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'asset-index.schema.json', refs: ['anchor.schema.json'] },
   { schema: 'collaboration.schema.json', refs: ['anchor.schema.json'] },


### PR DESCRIPTION
## Summary
- Pattern the shared block identifier (blockBase.id) and the standalone subfigure, equation-line, footnote-mark, and presentation footnote identifiers to the Content Anchor charset, so every identifier in the document-wide anchor namespace is expressible as a Content Anchor URI. Academic, legal, semantic, and forms block definitions drop their redundant local `id` redeclarations and inherit the shared constraint via composition.
- Constrain internal reference targets to the Content Anchor URI shape: the academic theorem/equation/algorithm reference marks, theorem dependencies (`uses`), and proof targets (`of`); and the semantic cross-reference target, which requires a Content Anchor URI for internal references and a safe URI for external ones.
- Add schema-closure vectors covering the identifier charset and reference-target shapes, and wire the academic schema's anchor dependency into the validators.

## Test plan
- [ ] All 19 validation gates pass from a clean `npm ci` (schemas, examples, schema-closure, document-id, manifest-projection, tsc, audit, and the rest).
- [ ] Document identifiers and manifest projections are unchanged — this is a validation-only tightening that alters no stored bytes; every existing identifier and reference target already conforms.