### PR TITLE
Tighten schema closure and constrain comment and equation-line shapes

### DIFF
--- a/examples/collaboration-document/collaboration/comments.json
+++ b/examples/collaboration-document/collaboration/comments.json
@@ -52,8 +52,7 @@
       },
       "created": "2025-01-28T11:00:00Z",
       "color": "#ffeb3b",
-      "content": "This is a key differentiator from our current system.",
-      "resolved": false
+      "content": "This is a key differentiator from our current system."
     },
     {
       "id": "suggestion-1",

--- a/schemas/academic.schema.json
+++ b/schemas/academic.schema.json
@@ -317,7 +317,11 @@
           "pattern": "^[A-Za-z0-9._-]+$"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "not": {
+        "required": ["number", "tag"],
+        "$comment": "A line carries a number or a tag, not both."
+      }
     },
     "equationGroupBlock": {
       "allOf": [

--- a/schemas/collaboration.schema.json
+++ b/schemas/collaboration.schema.json
@@ -44,8 +44,7 @@
             }
           }
         }
-      ],
-      "unevaluatedProperties": false
+      ]
     },
     "commentType": {
       "type": "string",
@@ -109,18 +108,6 @@
           "type": "string",
           "format": "date-time",
           "description": "ISO 8601 last modification timestamp"
-        },
-        "resolved": {
-          "type": "boolean",
-          "description": "Whether the comment is resolved",
-          "default": false
-        },
-        "replies": {
-          "type": "array",
-          "description": "Reply comments",
-          "items": {
-            "$ref": "#/$defs/reply"
-          }
         }
       }
     },
@@ -135,6 +122,18 @@
             "content": {
               "type": "string",
               "description": "Comment text content"
+            },
+            "resolved": {
+              "type": "boolean",
+              "description": "Whether the comment is resolved",
+              "default": false
+            },
+            "replies": {
+              "type": "array",
+              "description": "Reply comments",
+              "items": {
+                "$ref": "#/$defs/reply"
+              }
             }
           }
         }
@@ -180,6 +179,18 @@
             "status": {
               "$ref": "#/$defs/suggestionStatus",
               "default": "pending"
+            },
+            "resolved": {
+              "type": "boolean",
+              "description": "Whether the suggestion thread is resolved",
+              "default": false
+            },
+            "replies": {
+              "type": "array",
+              "description": "Reply comments",
+              "items": {
+                "$ref": "#/$defs/reply"
+              }
             }
           }
         }

--- a/schemas/forms.schema.json
+++ b/schemas/forms.schema.json
@@ -4,25 +4,6 @@
   "title": "CDX Forms Extension",
   "description": "Schema for forms extension blocks and data files in a CDX document",
   "$defs": {
-    "validatorType": {
-      "type": "string",
-      "description": "Built-in validator types",
-      "enum": [
-        "required",
-        "minLength",
-        "maxLength",
-        "min",
-        "max",
-        "pattern",
-        "email",
-        "url",
-        "containsUppercase",
-        "containsLowercase",
-        "containsDigit",
-        "containsSpecial",
-        "matchesField"
-      ]
-    },
     "validation": {
       "type": "object",
       "description": "Validation rules for a form field",
@@ -109,12 +90,12 @@
               "description": "Condition is true when field does not equal this value"
             },
             "isEmpty": {
-              "type": "boolean",
-              "description": "Condition is true when field is empty"
+              "const": true,
+              "description": "Condition is true when field is empty (set to true)"
             },
             "isNotEmpty": {
-              "type": "boolean",
-              "description": "Condition is true when field is not empty"
+              "const": true,
+              "description": "Condition is true when field is not empty (set to true)"
             }
           },
           "additionalProperties": false

--- a/schemas/phantoms.schema.json
+++ b/schemas/phantoms.schema.json
@@ -19,6 +19,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "$defs": {
     "cluster": {
       "type": "object",
@@ -178,11 +179,10 @@
       "additionalProperties": false
     },
     "author": {
-      "description": "Author identity extending base person",
+      "description": "Author identity extending base person (the base person object is intentionally open to extension fields).",
       "allOf": [
         { "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/person" }
-      ],
-      "unevaluatedProperties": false
+      ]
     },
     "assetIndex": {
       "type": "object",

--- a/schemas/security.schema.json
+++ b/schemas/security.schema.json
@@ -85,8 +85,7 @@
             }
           }
         }
-      ],
-      "unevaluatedProperties": false
+      ]
     },
     "trustedTimestamp": {
       "type": "object",

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -39,6 +39,7 @@ export const CLOSED_SCHEMAS: string[] = [
   'academic.schema.json',
   'legal.schema.json',
   'forms.schema.json',
+  'phantoms.schema.json',
 ];
 
 // A syntactically valid algorithm-prefixed digest for hash-typed fields.
@@ -1541,5 +1542,47 @@ export const closureVectors: ClosureVector[] = [
     description: 'semantic:ref external target (external true) is a safe URI (https accepted, javascript rejected)',
     validInstance: { type: 'semantic:ref', target: 'https://example.com/spec', external: true },
     invalidInstance: { type: 'semantic:ref', target: 'javascript:alert(1)', external: true },
+  },
+
+  // --- schema closure hygiene ----------------------------------------------
+  // Conditional-validation sentinels are pinned to true (the false form has no
+  // defined meaning).
+  {
+    schema: 'forms.schema.json',
+    ref: '#/$defs/conditionalValidation/properties/when',
+    description: 'when.isEmpty/isNotEmpty are sentinel true (false rejected)',
+    validInstance: { field: 'pw', isEmpty: true },
+    invalidInstance: { field: 'pw', isEmpty: false },
+  },
+  // The clusters.json file root is closed (unknown top-level keys rejected).
+  {
+    schema: 'phantoms.schema.json',
+    description: 'phantoms file root closed',
+    validInstance: { version: '1.0', clusters: [] },
+    invalidInstance: { version: '1.0', clusters: [], bogus: 1 },
+  },
+  // An equation line carries a number or a tag, not both.
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'equation line number xor tag (both rejected)',
+    validInstance: { type: 'academic:equation-group', lines: [{ value: 'x', number: '1' }] },
+    invalidInstance: { type: 'academic:equation-group', lines: [{ value: 'x', number: '1', tag: '*' }] },
+  },
+  // replies/resolved are comment+suggestion fields only — a highlight/reaction
+  // cannot carry them; a comment can.
+  {
+    schema: 'collaboration.schema.json',
+    ref: '#/$defs/highlight',
+    description: 'highlight rejects resolved (comment/suggestion-only field)',
+    validInstance: { id: 'h1', type: 'highlight', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', color: '#ffeb3b' },
+    invalidInstance: { id: 'h1', type: 'highlight', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', color: '#ffeb3b', resolved: true },
+  },
+  {
+    schema: 'collaboration.schema.json',
+    ref: '#/$defs/comment',
+    description: 'comment accepts resolved + replies; stays closed',
+    validInstance: { id: 'c1', type: 'comment', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', content: 'hi', resolved: true, replies: [] },
+    invalidInstance: { id: 'c1', type: 'comment', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', content: 'hi', bogus: 1 },
   },
 ];

--- a/spec/extensions/academic/README.md
+++ b/spec/extensions/academic/README.md
@@ -369,7 +369,7 @@ Each line in the `lines` array:
 | `tag` | string | No | Custom tag (e.g., `"*"`, `"\dagger"`) instead of number |
 | `id` | string | No | Line identifier for references |
 
-**Note:** Use either `number` or `tag`, not both. If `tag` is present, it takes precedence.
+**Note:** A line carries either `number` or `tag`, not both — including both fields is invalid (a `number` of `null` still occupies the number slot). A line with neither is unnumbered.
 
 > **Renderer safety.** Equation `value` and algorithm-line `content` are LaTeX rendered by a math engine, and untrusted LaTeX is a code-execution and denial-of-service surface. A renderer MUST disable file-access and shell-escape constructs and link/HTML-emitting macros, and MUST bound macro expansion, on untrusted source — preferring a restricted (KaTeX-class) renderer over a full TeX system (Renderer Safety section 3.2).
 


### PR DESCRIPTION
## Summary
- Pin the conditional-validation sentinels (`when.isEmpty` / `when.isNotEmpty`) to `true` — their only meaningful value — and remove an unreferenced validator-type `$def`.
- Close the phantom clusters file root against unknown top-level keys (nested defs were already closed), and drop three inert `unevaluatedProperties:false` guards that constrained nothing because the shared `person` base is open to extension.
- Constrain an equation line to carry a `number` or a `tag` but not both, matching the documented rule (README note aligned).
- Move the comment `resolved` flag and `replies` onto the comment and suggestion types only, so a highlight or reaction can no longer carry them (the example highlight's vestigial `resolved` is dropped).
- Add schema-closure vectors for each tightened shape.

## Test plan
- [ ] All 19 validation gates pass from a clean `npm ci`.
- [ ] Document identifiers and manifest projections unchanged — the only example edited is the out-of-hash `collaboration/comments.json`; every other corpus instance already conforms to the tightened shapes.