### PR TITLE
Document form field references and academic cross-reference resolution

### DIFF
--- a/spec/extensions/academic/README.md
+++ b/spec/extensions/academic/README.md
@@ -522,7 +522,7 @@ Each line in the `lines` array:
 
 ## 9. Cross-References
 
-> **Reader dispositions.** Although a `*-ref` `target` uses Content Anchor syntax, the `theorem-ref`, `equation-ref`, and `algorithm-ref` marks are extension cross-references resolved at render time, so a dangling target is a rendering-degradation WARNING in all states (State Machine section 5.4), not the INTEGRITY-ERROR of a dangling core anchor. When a placeholder cannot be filled — `{number}` for an unnumbered target, `{title}` for an untitled one — the reader substitutes the authored display text carried by the text node the mark is on, otherwise the bare target id, and never renders an empty string or the literal `{number}`/`{title}` token.
+> **Reader dispositions.** Although a `*-ref` `target` uses Content Anchor syntax, the `theorem-ref`, `equation-ref`, and `algorithm-ref` marks are extension cross-references resolved at render time, so a dangling target is a rendering-degradation WARNING in all states (State Machine section 5.4), not the INTEGRITY-ERROR of a dangling core anchor. A reader MUST fill each placeholder from the resolved target at render time; the authored display text carried by the mark's text node is a fallback, used only when the target is unresolvable or a placeholder cannot be filled, and a value resolved from the target takes precedence over any disagreeing cached text. When a placeholder cannot be filled — `{number}` for an unnumbered target, `{title}` for an untitled one — the reader substitutes that authored display text, otherwise the bare target id, and never renders an empty string or the literal `{number}`/`{title}` token.
 
 ### 9.1 theorem-ref Mark
 
@@ -577,6 +577,8 @@ Reference a numbered equation:
 | `target` | string | Yes | Content Anchor URI to the equation |
 | `format` | string | No | Display format (default: `"({number})"`) |
 
+`{number}` resolves to the target line's displayed identifier: its `number`, or — when the line is displayed by a `tag` instead (section 7.2) — that `tag`. If the target line is both unnumbered and untagged, `{number}` cannot be filled and the reader uses the fallback in section 9.
+
 ### 9.3 algorithm-ref Mark
 
 Reference an algorithm or algorithm line:
@@ -600,7 +602,7 @@ For line references:
 ```json
 {
   "type": "text",
-  "value": "line 3",
+  "value": "line 1",
   "marks": [
     {
       "type": "algorithm-ref",
@@ -618,6 +620,8 @@ For line references:
 | `target` | string | Yes | Content Anchor URI to the algorithm |
 | `line` | string | No | Line label for line-specific references |
 | `format` | string | No | Display format |
+
+`{number}` resolves to the target algorithm's own number. `{line}` names a target line by its `label` (section 8.2) and resolves to that line's displayed line number: `startLine` (section 8.1, default 1) plus the line's zero-based position in the algorithm's `lines` array. When the target algorithm sets `lineNumbering: false` it displays no line numbers, so `{line}` cannot be filled and the reader uses the fallback in section 9. A `line` label that matches no line in the target algorithm is a dangling reference — a rendering-degradation WARNING (section 9), resolved to the fallback text.
 
 ## 10. Numbering Configuration
 

--- a/spec/extensions/forms/README.md
+++ b/spec/extensions/forms/README.md
@@ -30,9 +30,13 @@ The Forms Extension enables interactive form fields within documents:
 
 ## 3. Form Block Types
 
+Every form block also carries the standard block `id` (and `attributes`) defined by the core content model. A block's `id` is its identifier in the document-wide anchor namespace (so a field can be a cross-reference target); it is distinct from a field's `name`, which is the key under which the field's value is stored in the form data (section 5). The field tables below omit `id` because it is shared by all blocks.
+
+The `placeholder` field is meaningful only for the text-bearing inputs `forms:textInput` and `forms:textArea`. On other field types it has no defined rendering and SHOULD be omitted.
+
 ### 3.0a Form Container
 
-The `forms:form` block is a container that groups form fields together. It wraps child form field blocks and provides submission configuration.
+The `forms:form` block is a container that groups form fields together and provides submission configuration. Its `children` are content blocks: typically form field blocks and submit buttons, but any content block is permitted — for example, headings or paragraphs that structure the form.
 
 ```json
 {
@@ -52,7 +56,7 @@ The `forms:form` block is a container that groups form fields together. It wraps
 | `action` | string (URI) | No | Form submission endpoint/handler URL |
 | `method` | string | No | HTTP method for submission. One of: `GET`, `POST`. Defaults to `"POST"`. |
 | `encoding` | string | No | Form encoding type. Defaults to `"application/json"`. |
-| `children` | array | Yes | Array of form field blocks and submit buttons |
+| `children` | array | Yes | Array of content blocks (typically form field blocks and submit buttons; any content block is permitted) |
 
 > **Renderer safety.** The form `action` is constrained to safe schemes (Renderer Safety section 2.1): a `javascript:` or `data:` action carried in signed content would otherwise be a signed code-execution primitive, so it is rejected. A field's `validation.pattern` is a client-side convenience, not a trust boundary — the receiving endpoint MUST re-validate every submitted value, and a renderer MUST bound pattern evaluation against catastrophic backtracking (Renderer Safety section 4).
 
@@ -335,6 +339,8 @@ For cross-field validation (e.g., password confirmation):
   }
 }
 ```
+
+Field references — `matchesField` here and `when.field` in section 4.3 — resolve by `name`, scoped to the enclosing `forms:form`. A field's `name` MUST be unique within its `forms:form`; a producer MUST NOT emit two fields sharing a `name` in one form. A reference to a `name` that is absent, or ambiguous because of a collision, is unresolvable: a renderer MUST NOT treat the field as valid on the strength of that rule (it fails closed), and because client-side validation is not a trust boundary the receiving endpoint re-validates every value regardless (section 3.0a).
 
 ### 4.3 Conditional Validation
 


### PR DESCRIPTION
## Summary
**Forms:** clarify that a `forms:form` accepts any content block (not only field blocks and submit buttons); document the shared block `id` and how it differs from a field `name`; scope `placeholder` to the text inputs; and require field `name`s to be unique within a form, with a fail-closed disposition for an unresolvable or colliding `matchesField`/`when.field` reference.

**Academic:** state that cross-reference marks fill their placeholders from the resolved target at render time (the authored text node is only a fallback); define how `equation-ref` renders a tag-displayed line, and how `algorithm-ref` resolves a line label to a displayed line number (`startLine` + zero-based position), including the `lineNumbering:false` and unknown-label cases. Corrected the §9.3 line-reference example to match the formula.

## Test plan
- [ ] Prose-only — two README files; all validation gates pass, document ids/projections unchanged.
- [ ] The stated algorithm-ref line formula matches every corpus and README example (verified: `alg-bisection` loop→line 1, `alg-binary-search` loop-start→line 3).