### PR TITLE
Open semantic locator/sort vocabularies; document JSON-LD hashing and collaboration rendering

### DIFF
--- a/schemas/semantic.schema.json
+++ b/schemas/semantic.schema.json
@@ -22,12 +22,7 @@
         },
         "locatorType": {
           "type": "string",
-          "description": "Type of locator (CSL-compatible). Defaults to \"page\" if omitted.",
-          "enum": [
-            "page", "chapter", "section", "paragraph", "line",
-            "verse", "volume", "issue", "part", "book",
-            "figure", "table", "note", "opus", "sub-verbo"
-          ]
+          "description": "Type of locator (CSL-compatible; open vocabulary, the Semantic Extension README lists recommended values). Defaults to \"page\" if omitted. An unrecognized value is preserved, not rejected."
         },
         "pages": {
           "type": "string",
@@ -360,8 +355,7 @@
             },
             "sort": {
               "type": "string",
-              "description": "Sort order for terms",
-              "enum": ["alphabetical", "appearance", "none"]
+              "description": "Sort order for terms (open vocabulary; the Semantic Extension README lists recommended values). An unrecognized value is preserved; a consumer that does not recognize it applies its default ordering."
             }
           }
         }

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -1585,4 +1585,20 @@ export const closureVectors: ClosureVector[] = [
     validInstance: { id: 'c1', type: 'comment', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', content: 'hi', resolved: true, replies: [] },
     invalidInstance: { id: 'c1', type: 'comment', anchor: { blockId: 'b1' }, author: { name: 'Ada' }, created: '2025-01-01T00:00:00Z', content: 'hi', bogus: 1 },
   },
+
+  // --- open-vocabulary enums (locator type, glossary sort) ------------------
+  {
+    schema: 'semantic.schema.json',
+    ref: '#/$defs/citationMark',
+    description: 'locatorType is an open vocabulary (a non-enumerated CSL locator accepted); a non-string is rejected',
+    validInstance: { type: 'citation', refs: ['e1'], locatorType: 'column' },
+    invalidInstance: { type: 'citation', refs: ['e1'], locatorType: 42 },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'glossary sort is an open vocabulary (a non-enumerated order accepted); a non-string is rejected',
+    validInstance: { type: 'semantic:glossary', sort: 'reverse-alphabetical' },
+    invalidInstance: { type: 'semantic:glossary', sort: 42 },
+  },
 ];

--- a/spec/extensions/collaboration/README.md
+++ b/spec/extensions/collaboration/README.md
@@ -233,9 +233,11 @@ The `version` field follows the extension version contract in the CDX Extensions
 | `resolved` | boolean | No | Whether comment is resolved |
 | `replies` | array | No | Reply comments |
 
+The `resolved` and `replies` fields apply to `comment` and `suggestion` records only; a `highlight` or `reaction` MUST NOT carry them. A renderer SHOULD visually distinguish a resolved comment (for example, by collapsing or de-emphasizing it) and MUST NOT silently drop it, since the comment remains part of the archive. Because `resolved` is advisory and unauthenticated (section 4.5), a verifier MUST NOT treat it as an authenticated decision.
+
 ### 4.3a Reply Object
 
-The `replies` array contains reply objects. Replies are flat — they do not nest (a reply cannot contain further replies). Replies do not have their own anchors; they inherit the anchor context of the parent comment.
+The `replies` array contains reply objects. Replies are flat — they do not nest (a reply cannot contain further replies). Replies do not have their own anchors; they inherit the anchor context of the parent comment. There is no explicit ordering field: a renderer MUST present replies in `created` timestamp order, breaking ties by array order, so every reader shows the same thread sequence.
 
 ```json
 {
@@ -326,6 +328,8 @@ Suggestion statuses: `pending`, `accepted`, `rejected`
 ```
 
 Standard emoji identifiers using Unicode CLDR short names (without colons). Examples: `thumbsup`, `heart`, `thinking`, `rocket`. See the [Unicode CLDR annotations](https://cldr.unicode.org/translation/characters-emoji-symbols/short-names-and-keywords) for the canonical list.
+
+A reaction is identified by the pair (`author`, `emoji`) on a given anchor. A renderer that tallies reactions MUST collapse duplicates of the same pair to a single reaction (counting the author once), so a repeated record does not inflate the count.
 
 ### 4.7 Highlights
 

--- a/spec/extensions/semantic/README.md
+++ b/spec/extensions/semantic/README.md
@@ -102,7 +102,7 @@ A consumer that does expand JSON-LD MUST NOT dereference a remote `@context` fro
 | `type` | string | Yes | Always `"citation"` |
 | `refs` | array | Yes | Bibliography entry IDs to cite |
 | `locator` | string | No | Page, chapter, section, or other location reference (CSL-compatible) |
-| `locatorType` | string | No | Type of locator (CSL-compatible). One of: `page`, `chapter`, `section`, `paragraph`, `line`, `verse`, `volume`, `issue`, `part`, `book`, `figure`, `table`, `note`, `opus`, `sub-verbo`. Defaults to `"page"` if omitted. |
+| `locatorType` | string | No | Type of locator (CSL-compatible, open vocabulary). Defaults to `"page"` if omitted. Recommended values: `page`, `chapter`, `section`, `paragraph`, `line`, `verse`, `volume`, `issue`, `part`, `book`, `figure`, `table`, `note`, `opus`, `sub-verbo`. Any other CSL or custom value is preserved and treated as opaque, not rejected (open-world principle, Content Blocks section 5.1). |
 | `prefix` | string | No | Text to display before the citation (e.g., "see", "cf.") |
 | `suffix` | string | No | Text to display after the citation |
 | `suppressAuthor` | boolean | No | If true, omit the author name from the rendered citation |
@@ -453,6 +453,8 @@ Internal references use Content Anchor URI syntax (see core Anchors and Referenc
 }
 ```
 
+An external reference MUST set `external: true`. An internal reference (the default — `external` false or absent) MUST give `target` as a Content Anchor URI (a `#`-prefixed reference, section 7.1); an absolute or external URL written without `external: true` is rejected as a malformed internal reference, so set the flag whenever `target` leaves the document.
+
 > **Renderer safety.** An entity `uri` and a cross-reference `target` are constrained to safe schemes (Renderer Safety section 2.1); fragment and relative references remain permitted, but dangerous schemes such as `javascript:` are rejected. A JSON-LD `@context` (section 3) MUST NOT be dereferenced from an untrusted document by default — a processor MUST resolve it offline or from an operator allowlist (Renderer Safety section 5).
 
 ## 8. Glossary
@@ -512,7 +514,7 @@ In-document `semantic:term` blocks remain valid content when an external glossar
 |-------|------|----------|-------------|
 | `type` | string | Yes | Always `"semantic:glossary"` |
 | `title` | string | No | Section heading for the glossary |
-| `sort` | string | No | Sort order for terms. One of: `alphabetical` (sort by term name, A-Z), `appearance` (document order), `none` (no sorting applied). Defaults to implementation-defined behavior. |
+| `sort` | string | No | Sort order for terms (open vocabulary). Defaults to implementation-defined behavior. Recommended values: `alphabetical` (sort by term name, A-Z), `appearance` (document order), `none` (no sorting applied). An unrecognized value is preserved; a consumer that does not recognize it applies its default ordering, not a rejection (open-world principle, Content Blocks section 5.1). |
 
 ## 9. Provenance
 
@@ -596,7 +598,7 @@ With JSON-LD:
 
 The semantic extension stores some constructs in the document and others in side files; only the former are covered by the document hash (see the extensions overview, Integrity Status of Extension Data).
 
-**In the document hash.** A block-level `semantic` annotation (the JSON-LD object carried on a content block, section 3.2), the citation, footnote, glossary, entity, and reference marks, and the `semantic:*` blocks are part of the content tree, so their bytes are bound by the document ID.
+**In the document hash.** A block-level `semantic` annotation (the JSON-LD object carried on a content block, section 3.2), the citation, footnote, glossary, entity, and reference marks, and the `semantic:*` blocks are part of the content tree, so their bytes are bound by the document ID. A block-level `semantic` annotation is hashed as opaque JSON through the core canonicalization (Document Hashing specification, section 4.3): object key order does not matter (JCS sorts keys), but JSON-LD's own equivalences beyond key order are NOT honored. Two semantically equivalent graphs that serialize differently — a compacted form versus an expanded one, a different `@context` phrasing, or a different array ordering of the members of an unordered `@set` — produce different document IDs. Authors who need a stable ID across equivalent graphs MUST serialize the annotation consistently.
 
 **Outside the document hash — advisory.** The bibliography (`semantic/bibliography.json`), the glossary (`semantic/glossary.json`), and the document-level JSON-LD (`metadata/jsonld.json`) are referenced by path only, with no hash, and the metadata projection keeps only the five Dublin Core terms — so none of these files is in the document hash or the manifest projection. Every entry they carry — a citation's author, year, title, and DOI; a term's definition; a JSON-LD author, ORCID, publisher, or citation edge — is advisory and stays mutable on a `frozen` or `published` document. An archive writer can rewrite a definition or a machine-readable authorship claim, and every signature still verifies with the document ID unchanged.
 


### PR DESCRIPTION
## Summary
- Open the citation `locatorType` and glossary `sort` fields from closed enums to open strings with RECOMMENDED lists, so a non-enumerated locator or sort order is preserved rather than rejected (open-world, mirroring the earlier enum relaxations). +2 schema-closure vectors.
- Document that a block-level JSON-LD `semantic` annotation is hashed as opaque JSON: object key order is normalized by JCS, but JSON-LD equivalences beyond it (compaction/expansion, `@context` phrasing, unordered-`@set` ordering) are not preserved across document IDs.
- Document the `semantic:ref` internal/external rule (an external target MUST set `external: true`; an internal target is a Content Anchor URI).
- Pin collaboration rendering with RFC 2119: replies render in `created` order, duplicate reactions collapse, a resolved comment is distinguished but not silently dropped, and `resolved`/`replies` apply to comment and suggestion records only.

## Test plan
- [ ] All 19 validation gates pass from a clean `npm ci`.
- [ ] Document ids and manifest projections unchanged — opening the enums is validation-only; the example's in-enum `locatorType`/`sort` values are unchanged.