### PR TITLE
Scrub legal example placeholders; document caption roles, signer fields, and jurisdiction

### DIFF
--- a/examples/legal-document/content/document.json
+++ b/examples/legal-document/content/document.json
@@ -234,13 +234,13 @@
       "id": "sig-block",
       "role": "counsel",
       "signer": {
-        "name": "Jane Smith",
+        "name": "Jane Doe",
         "title": "Counsel for Plaintiff",
-        "barNumber": "CA 123456",
-        "firm": "Smith & Associates LLP",
-        "address": "100 Market Street, Suite 500, San Francisco, CA 94105",
-        "telephone": "(415) 555-1234",
-        "email": "jsmith@smithlaw.com"
+        "barNumber": "CA 000000",
+        "firm": "Example Law LLP",
+        "address": "123 Example Street, Anytown, CA 90000",
+        "telephone": "(555) 555-0100",
+        "email": "counsel@example.com"
       },
       "date": "2025-01-30"
     }

--- a/examples/legal-document/manifest.json
+++ b/examples/legal-document/manifest.json
@@ -1,6 +1,6 @@
 {
   "cdx": "0.1",
-  "id": "sha256:a6f99cac908e8c25dff9e5631aad43670ccd5aec664deee943f41c2cd587b3cc",
+  "id": "sha256:04be2dd10992a7616dd6f148a08e47b3781d3d727d301d5cf7b5c7622103f5e9",
   "state": "draft",
   "created": "2025-01-30T10:00:00Z",
   "modified": "2025-01-30T10:00:00Z",
@@ -13,7 +13,7 @@
   ],
   "content": {
     "path": "content/document.json",
-    "hash": "sha256:d974cf53c3d9444034b534316a2fb762903532d18be881611fb333d415a193af"
+    "hash": "sha256:30c3dd419f7ff19c68997e4fbf72cabe4c7422da760d39f1f5da06146808642d"
   },
   "metadata": {
     "dublinCore": "metadata/dublin-core.json"

--- a/examples/legal-document/metadata/dublin-core.json
+++ b/examples/legal-document/metadata/dublin-core.json
@@ -2,13 +2,13 @@
   "version": "1.1",
   "terms": {
     "title": "Brief in Support of Motion for Summary Judgment",
-    "creator": ["Jane Smith, Esq."],
+    "creator": ["Jane Doe, Esq."],
     "subject": ["civil rights", "employment discrimination"],
     "description": "A demonstration of the legal extension features including caption, Table of Authorities, legal citations, and signature block.",
     "date": "2025-01-30",
     "type": "Text",
     "format": "application/vnd.cdx+zip",
     "language": "en",
-    "rights": "Confidential - Attorney Work Product"
+    "rights": "Example document for demonstration purposes"
   }
 }

--- a/spec/extensions/README.md
+++ b/spec/extensions/README.md
@@ -13,7 +13,7 @@ This directory contains specifications for CDX extensions. Each extension adds s
 | [Security](security/README.md) | `cdx.security` | 0.1 | Draft | Digital signatures, encryption, access control |
 | [Phantoms](phantoms/README.md) | `cdx.phantoms` | 0.1 | Draft | Off-page annotation clusters |
 | [Presentation](presentation/README.md) | `cdx.presentation` | 0.1 | Draft | Layout templates and rendering hints |
-| [Legal](legal/README.md) | `cdx.legal` | 0.1 | Draft | Legal citations, clause references, jurisdiction metadata |
+| [Legal](legal/README.md) | `cdx.legal` | 0.1 | Draft | Legal citations, captions, tables of authorities, jurisdiction metadata |
 
 ## Extension Compatibility
 

--- a/spec/extensions/legal/README.md
+++ b/spec/extensions/legal/README.md
@@ -206,6 +206,8 @@ A `pinpoint` is rendered after `{page}` in the reporter form (`317, 323`) and af
 
 The per-citation `format` field and the manifest-level `citationStyle` default (`manifest.legal.citationStyle`, section 2) name a house style a richer renderer MAY apply instead of the canonical rendering. They are advisory: the canonical rendering of section 5.1 is the reproducible baseline, and a reader that does not implement a named style renders the canonical form. Commonly named styles include `bluebook` (The Bluebook: A Uniform System of Citation), `alwd` (ALWD Guide to Legal Citation), `mcgill` (the Canadian McGill Guide), and `oscola` (the Oxford OSCOLA standard); `format`/`citationStyle` are an open vocabulary, so any style name is accepted.
 
+The manifest `legal` configuration MAY also carry a `jurisdiction` string (for example, a court system or governing-law selector such as `us-federal` or `uk`). It is advisory metadata that a renderer MAY use to pick jurisdiction-appropriate citation defaults; like `citationStyle` it does not change the canonical rendering of section 5.1, and it is unauthenticated unless the extension is declared `required: true` (section 9).
+
 ## 6. Legal Document Structure Blocks
 
 ### 6.1 Court Caption
@@ -223,7 +225,7 @@ The per-citation `format` field and the manifest-level `citationStyle` default (
 }
 ```
 
-The `parties` object supports the role keys `plaintiff`, `defendant`, `appellant`, `appellee`, `petitioner`, and `respondent`; the caption MAY also name the assigned `judge`. These caption fields are author-asserted content, not authenticated case identity (see section 9).
+The `parties` object supports the role keys `plaintiff`, `defendant`, `appellant`, `appellee`, `petitioner`, and `respondent`; the caption MAY also name the assigned `judge`. Each value is either a plain string (the party name) or a `party` object. A `party` object MAY carry a free-string `role` for a role the keys above do not cover (for example, `intervenor` or `amicus`); those keys are RECOMMENDED, and where a party is reached through a role key, that key is authoritative for the party's role and a `party.role` is supplementary. These caption fields are author-asserted content, not authenticated case identity (see section 9).
 
 ### 6.2 Signature Block
 
@@ -246,7 +248,7 @@ Legal documents often require specific signature block formats:
 
 The signature block `role` is one of `counsel`, `attorney`, `party`, `witness`, or `notary`; the signer object MAY also include a `fax` number. A `legal:signatureBlock` records a signatory for display; it is content, not a cryptographic signature, and attests nothing about execution or notarization (see section 9).
 
-> **Renderer safety.** Signer contact strings (name, address, telephone, fax) and party, judge, and notary names are author-asserted text. A renderer MUST render them as inert, escaped text and MUST NOT auto-linkify or otherwise promote them to a navigation target except through the safe-URI allowlist (Renderer Safety section 3.4).
+> **Renderer safety.** Signer fields (name, title, bar number, firm, address, telephone, fax, and email — the `email` is an unverified display string, not an asserting `mailto:` target) and party, judge, and notary names are author-asserted text. A renderer MUST render them as inert, escaped text and MUST NOT auto-linkify or otherwise promote them to a navigation target except through the safe-URI allowlist (Renderer Safety section 3.4).
 
 ## 7. Examples
 


### PR DESCRIPTION
## Summary
- **Example cleanup (re-freeze):** replace real-looking signer PII in the legal example with non-resolvable placeholders (`counsel@example.com`, `(555) 555-0100`, a generic address, `CA 000000`) and genericize the Dublin Core rights statement. Recompute the legal-document `id` (`a6f99cac…`→`04be2dd1…`) and `content.hash` (`d974cf53…`→`30c3dd41…`). The legal-document is unsigned; **no other corpus id or signed projection moves** (the rights edit is id-neutral — `rights` is not projected).
- **Legal prose:** document that a caption party value may be a `party` object whose free-string `role` covers a role outside the recommended keys (keys remain authoritative); name the signer fields a renderer must render inert (including `firm` and the unverified `email` display string); document the manifest `legal.jurisdiction` advisory field; drop the unimplemented "clause references" from the extensions index.

## Test plan
- [ ] Both re-frozen hashes reproduce from the canonicalizer; `check:document-id` 11/11 and `check:manifest-projection` 2/2 green.
- [ ] All 19 gates pass from clean `npm ci`.