### PR TITLE
Constrain image source schemes and reconcile out-of-hash dispositions

### DIFF
--- a/schemas/content.schema.json
+++ b/schemas/content.schema.json
@@ -616,8 +616,8 @@
           "properties": {
             "type": { "const": "image" },
             "src": {
-              "type": "string",
-              "description": "Image source path or URL"
+              "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeImageUri",
+              "description": "Image source path or URL. Constrained to safe schemes (see the Renderer Safety core specification); javascript:/data:text and other dangerous schemes are rejected, and data: admits raster image types but not SVG."
             },
             "alt": {
               "type": "string",
@@ -967,8 +967,8 @@
           "properties": {
             "type": { "const": "svg" },
             "src": {
-              "type": "string",
-              "description": "Path to SVG file"
+              "$ref": "https://cdx.dev/schemas/anchor.schema.json#/$defs/safeImageUri",
+              "description": "Path to SVG file. Constrained to safe schemes (see the Renderer Safety core specification); the file's rendered SVG content is additionally subject to the sanitize-all-SVG rule (Renderer Safety section 3.1)."
             },
             "content": {
               "type": "string",

--- a/scripts/kat/schema-closure-vectors.ts
+++ b/scripts/kat/schema-closure-vectors.ts
@@ -1412,6 +1412,20 @@ export const closureVectors: ClosureVector[] = [
     validInstance: { name: 'Ada', avatar: 'https://example.com/avatars/jane.png' },
     invalidInstance: { name: 'Ada', avatar: 'javascript:alert(1)' },
   },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'image.src safe-image teeth (javascript: rejected)',
+    validInstance: { type: 'image', src: 'assets/images/figure1.avif', alt: 'x' },
+    invalidInstance: { type: 'image', src: 'javascript:alert(1)', alt: 'x' },
+  },
+  {
+    schema: 'content.schema.json',
+    ref: '#/$defs/block',
+    description: 'svg.src safe-image teeth (javascript: rejected)',
+    validInstance: { type: 'svg', src: 'assets/diagrams/d.svg', alt: 'x' },
+    invalidInstance: { type: 'svg', src: 'javascript:alert(1)', alt: 'x' },
+  },
 
   // --- documented-field representability (S8) -------------------------------
   // The optional crdt sync field is accepted on a block (and stripped before

--- a/spec/core/07-state-machine.md
+++ b/spec/core/07-state-machine.md
@@ -294,7 +294,8 @@ A second axis is **integrity-binding**. A defect in material bound to the docume
 | Unknown **bare**, non-namespaced block or mark type | REJECT | REJECT |
 | Missing the required `content` part | REJECT | REJECT |
 | Missing required metadata — the Dublin Core part or a required term | WARNING | INTEGRITY-ERROR |
-| Missing another referenced part (presentation, provenance, …) | WARNING | INTEGRITY-ERROR |
+| Missing a referenced part bound by the document hash or manifest projection — e.g. a declared `presentation` layer | WARNING | INTEGRITY-ERROR |
+| Missing a referenced part outside the document hash and manifest projection — e.g. the `provenance` record (Security Extension section 9.8) | WARNING | WARNING |
 | Structurally malformed block or mark of a **known** type | WARNING | INTEGRITY-ERROR |
 | Dangling **core anchor** reference in hashed content — a `link`/`anchor` Content Anchor (Anchors and References section 7.2) | WARNING | INTEGRITY-ERROR |
 | Dangling asset reference — a canonicalization error once the ID is computed (Document Hashing section 4.3.1) | WARNING | INTEGRITY-ERROR |
@@ -319,6 +320,7 @@ Two rules do **not** vary by state and override the table above:
 
 - **Duplicate keys always REJECT.** Any part containing an object with duplicate keys MUST be rejected before hashing or verification, in *every* state (Document Hashing section 4.3.2); an unrejected duplicate permits a split-view substitution.
 - **An unverifiable proof never rejects the document.** A verifier that cannot complete a timestamp or lineage proof MUST report *that proof* as unverified and MUST NOT, on those grounds, reject or downgrade the document itself (Provenance and Lineage sections 3.3 and 6.7). The disposition attaches to the proof, not to the document.
+- **An out-of-hash layer's internal validity is a load disposition, not an integrity failure.** A defect confined to the internal graph of an out-of-hash layer — for example a broken phantom-to-phantom `connection` target, or a duplicate phantom id (Phantoms section 4.7) — MAY stop that layer from loading or rendering coherently, but because the layer is bound by neither the document hash nor the manifest projection it MUST NOT escalate to an INTEGRITY-ERROR or downgrade the document, in *any* state. Such load "errors" are layer-validity dispositions distinct from this table's integrity axis.
 
 ## 6. Signatures and State
 

--- a/spec/extensions/phantoms/README.md
+++ b/spec/extensions/phantoms/README.md
@@ -129,7 +129,7 @@ The `version` field follows the extension version contract in the CDX Extensions
 | `created` | string | Yes | ISO 8601 creation timestamp |
 | `author` | object | No | Phantom author |
 
-Cluster `id`s MUST be unique within `phantoms/clusters.json`, and a phantom `id` MUST be unique within its cluster. These identifiers carry no document-hash weight (section 5), but connection resolution (section 4.7) depends on phantom-id uniqueness within a cluster. A loader MUST treat a duplicate id as a Warning in DRAFT/REVIEW and an Error in FROZEN/PUBLISHED (the same severity as a broken connection target, section 4.7), and a `connection` whose `target` matches more than one phantom MUST be handled as a broken target rather than resolved to an arbitrary one.
+Cluster `id`s MUST be unique within `phantoms/clusters.json`, and a phantom `id` MUST be unique within its cluster. These identifiers carry no document-hash weight (section 5), but connection resolution (section 4.7) depends on phantom-id uniqueness within a cluster. A loader MUST treat a duplicate id as a Warning in DRAFT/REVIEW and an Error in FROZEN/PUBLISHED (the same severity as a broken connection target, section 4.7 — a layer-load disposition, not a document INTEGRITY-ERROR; State Machine section 5.4.3), and a `connection` whose `target` matches more than one phantom MUST be handled as a broken target rather than resolved to an arbitrary one.
 
 ### 4.4 Position and Size
 
@@ -209,6 +209,8 @@ Connections between phantoms MUST satisfy the following rules:
 | Same cluster | Connections MUST NOT reference phantoms in other clusters | Error in all states |
 
 Implementations MUST validate connection targets when loading phantom data. Broken connection targets (referencing non-existent phantom IDs) indicate data corruption in frozen documents and partial construction in mutable documents.
+
+This `Error` is a layer-load disposition — the phantom graph will not render coherently — not the INTEGRITY-ERROR of the State Machine's integrity axis. Because the phantom layer is outside the document hash (section 5) and bound by no signature, a broken connection never changes the document ID, invalidates a signature, or downgrades the document itself; it is a validity disposition local to the out-of-hash layer (State Machine section 5.4.3).
 
 ### 4.8 Known Limitations
 


### PR DESCRIPTION
## Summary
Three consistency fixes drawn from earlier review notes (none move a document id or a manifest projection):

- **Image/SVG source schemes.** Core `image.src` and `svg.src` were unconstrained strings; they now use the shared `safeImageUri` allowlist (the same constraint already on `linkMark.href`, `author.avatar`, etc.). Relative asset paths, `https`, and `data:` raster images stay valid; `javascript:`, `data:text`, and `data:image/svg+xml` are rejected. An SVG file's rendered content remains subject to the sanitize-all-SVG rule (Renderer Safety §3.1). +2 closure vectors.
- **Out-of-hash "missing part" disposition.** The State Machine §5.4 row that treated a missing `presentation` *or* `provenance` part identically is split by the §5.4.2 integrity-binding axis: a part bound by the document hash or manifest projection (presentation) stays INTEGRITY-ERROR on a frozen document, while a part outside both (provenance) → WARNING — consistent with that axis and with Security §9.8 (provenance is path-only, unbound).
- **Phantom internal-graph dispositions.** Clarified (phantoms §4.7/§4.3 + a State Machine §5.4.3 state-invariant bullet) that a broken phantom `connection` target or duplicate phantom id is a *layer-load* disposition, not a document INTEGRITY-ERROR — the phantom layer is outside the hash and bound by no signature, so such a defect never changes the document id or invalidates a signature.

## Test plan
- [x] `image.src`/`svg.src` closure vectors (safe src accepted, `javascript:` rejected); seed-and-revert: a `javascript:` src in a real example fails `validate:examples` on the safe-image pattern.
- [x] `check:document-id` (11/11) and `check:manifest-projection` (2/2) **unmoved** — validation + prose only.
- [x] `check:refs` resolves the new "Security Extension §9.8" / "State Machine §5.4.3" cross-references.
- [x] All 19 gates green from a clean `npm ci` (verified by exit code); `tsc --noEmit` clean; `npm audit` 0 high.