### PR TITLE
Give known-answer vectors portable defect codes

### DIFF
--- a/conformance/errors.json
+++ b/conformance/errors.json
@@ -1,0 +1,85 @@
+{
+  "$comment": "NON-NORMATIVE. This vocabulary is a conformance-suite diagnostic aid, not part of the CDX specification. The specification mandates DISPOSITIONS (State Machine section 5.4) and OUTCOMES (Provenance and Lineage section 3.3) — never error identifiers. A conforming implementation is free to use its own internal errors and map them to these codes in its conformance adapter; it is never required to adopt this vocabulary. A code is therefore a diagnostic that sharpens a failure report, and is never the pass criterion for a MUST.",
+  "version": "0.1",
+  "specVersion": "0.1",
+  "codes": {
+    "CDX-E-ID-PENDING": {
+      "summary": "A manifest projection was requested for a document whose id is still `pending`.",
+      "clause": "Security Extension section 9.7",
+      "note": "The projection is defined only once the document id is fixed."
+    },
+    "CDX-E-HASH-MALFORMED": {
+      "summary": "A declared content hash is not a well-formed `algorithm:hexdigest`.",
+      "clause": "Security Extension section 9.7"
+    },
+    "CDX-E-PATH-TRAVERSAL": {
+      "summary": "A declared path is not a safe archive-relative path (escapes the archive root).",
+      "clause": "Security Extension section 9.7; Container Format section 9.1"
+    },
+    "CDX-E-CDX-VERSION-MALFORMED": {
+      "summary": "`manifest.cdx` is not a \"<major>.<minor>\" version string.",
+      "clause": "Security Extension section 9.7"
+    },
+    "CDX-E-STATE-UNKNOWN": {
+      "summary": "`manifest.state` is outside the lifecycle enum.",
+      "clause": "State Machine section 3.1; Security Extension section 9.7"
+    },
+    "CDX-E-EXTENSION-DUPLICATE": {
+      "summary": "Two `manifest.extensions[]` entries share an id, making the projection ambiguous.",
+      "clause": "Security Extension section 9.7"
+    },
+    "CDX-E-PRESENTATION-TYPE-UNKNOWN": {
+      "summary": "A `manifest.presentation[]` entry declares a type outside the enum.",
+      "clause": "Security Extension section 9.7"
+    },
+    "CDX-E-REFERENCE-HASH-CONFLICT": {
+      "summary": "The same declared path appears twice with conflicting hashes.",
+      "clause": "Security Extension section 9.7",
+      "note": "Applies to both the config-file references and the asset-index references."
+    },
+    "CDX-E-REQUIRED-SIGNER-SET-EMPTY": {
+      "summary": "`signaturePolicy.requiredSigners` is present but empty.",
+      "clause": "Security Extension sections 3.12, 9.7",
+      "note": "Forbidden so an absent policy and an empty policy are not both expressible."
+    },
+    "CDX-E-REQUIRED-SIGNER-DUPLICATE": {
+      "summary": "Two `requiredSigners` entries declare the same identity.",
+      "clause": "Security Extension sections 3.12, 9.7"
+    },
+    "CDX-E-REQUIRED-SIGNER-KIND-AMBIGUOUS": {
+      "summary": "A `requiredSigners` entry carries zero, or more than one, identity kind.",
+      "clause": "Security Extension section 3.12"
+    },
+    "CDX-E-REQUIRED-SIGNER-ID-MALFORMED": {
+      "summary": "A `requiredSigners` identity value is malformed for its declared kind.",
+      "clause": "Security Extension section 3.12"
+    },
+    "CDX-E-LINEAGE-CYCLE": {
+      "summary": "The lineage walk revisited a document already on the current path.",
+      "clause": "Provenance and Lineage section 3.3",
+      "outcome": "REJECTED"
+    },
+    "CDX-E-LINEAGE-ANCESTORS-CONTRADICT": {
+      "summary": "A declared `ancestors` entry contradicts the resolved parent chain (forged tail).",
+      "clause": "Provenance and Lineage section 3.3",
+      "outcome": "REJECTED"
+    },
+    "CDX-E-LINEAGE-ROOT-WITH-ANCESTORS": {
+      "summary": "A document declaring no parent also declares a non-empty ancestors chain.",
+      "clause": "Provenance and Lineage section 3.3",
+      "outcome": "REJECTED"
+    },
+    "CDX-E-LINEAGE-UNRESOLVABLE": {
+      "summary": "A link in the chain could not be resolved, so the chain cannot be fully walked.",
+      "clause": "Provenance and Lineage section 3.3",
+      "outcome": "INCOMPLETE",
+      "note": "Unverified, never endorsed — and never grounds to reject the document."
+    },
+    "CDX-E-LINEAGE-BOUND-REACHED": {
+      "summary": "The traversal depth or breadth bound was reached before the walk completed.",
+      "clause": "Provenance and Lineage section 3.3",
+      "outcome": "INCOMPLETE",
+      "note": "A legitimately deep or wide history is not an inconsistency."
+    }
+  }
+}

--- a/scripts/check-lineage.ts
+++ b/scripts/check-lineage.ts
@@ -26,6 +26,7 @@ import {
   type LineageResolver,
 } from './lib/lineage-chain.js';
 import { lineageVectors } from './kat/lineage-chain-vectors.js';
+import { unregisteredCodes } from './lib/error-codes.js';
 
 let failures = 0;
 const fail = (msg: string): void => {
@@ -43,6 +44,10 @@ for (const vec of lineageVectors) {
   const problems: string[] = [];
   if (got.outcome !== e.outcome) problems.push(`outcome ${got.outcome} != ${e.outcome}`);
   if (e.resolvedDepth !== undefined && got.resolvedDepth !== e.resolvedDepth) problems.push(`resolvedDepth ${got.resolvedDepth} != ${e.resolvedDepth}`);
+  // reasonCode is the portable assertion; reasonIncludes additionally pins THIS
+  // implementation's wording, so a code that starts being emitted from a
+  // different site than the one it was assigned to is caught, not masked.
+  if (e.reasonCode !== undefined && got.reasonCode !== e.reasonCode) problems.push(`reasonCode ${JSON.stringify(got.reasonCode)} != ${JSON.stringify(e.reasonCode)}`);
   if (e.reasonIncludes !== undefined && !(got.reason ?? '').includes(e.reasonIncludes)) problems.push(`reason ${JSON.stringify(got.reason)} lacks ${JSON.stringify(e.reasonIncludes)}`);
   if (e.warnings !== undefined && got.warnings.length !== e.warnings) problems.push(`warnings ${got.warnings.length} != ${e.warnings}`);
   if (problems.length > 0) {
@@ -200,6 +205,15 @@ const GRID_LEVELS = 15; // ~2^15 resolve-calls under the old walk (the finding's
   } else if (res) {
     console.log(`  ✓ ${fanout}-way mergedFrom fan-out → incomplete in ${count()} resolutions (no crash)`);
   }
+}
+
+// Defence-in-depth: every reasonCode a vector expects must be REGISTERED in the
+// vocabulary shipped to external implementations, so a typo'd code cannot
+// assert against something no implementation could ever emit.
+for (const problem of unregisteredCodes(
+  lineageVectors.map((v) => v.expected.reasonCode).filter((c): c is string => c !== undefined),
+)) {
+  fail(`lineage vectors — ${problem}`);
 }
 
 if (failures > 0) {

--- a/scripts/check-manifest-projection.ts
+++ b/scripts/check-manifest-projection.ts
@@ -26,7 +26,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { jcsOf } from './lib/canonicalize.js';
+import { jcsOf, CanonicalizationError } from './lib/canonicalize.js';
+import { unregisteredCodes } from './lib/error-codes.js';
 import { projectManifest, projectManifestToJcs } from './lib/manifest-projection.js';
 import { projectionVectors, scopeVectors, errorVectors } from './kat/manifest-projection-vectors.js';
 import { getValidator } from './lib/part-schema.js';
@@ -106,15 +107,32 @@ console.log('\nProjection error vectors:');
 for (const v of errorVectors) {
   try {
     projectManifest(v.manifest);
-    fail(`${v.name} — expected an error containing "${v.expectedError}", but none was thrown`);
+    fail(`${v.name} — expected ${v.expectedCode}, but no error was thrown`);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.includes(v.expectedError)) {
-      fail(`${v.name} — error "${msg}" does not contain "${v.expectedError}"`);
+    // Assert the TYPE, the CODE, and the message. The code is the portable
+    // assertion; the message pins the specific throw site, so a vector that
+    // starts failing closed at a *different* site than the one its code was
+    // assigned to is caught rather than silently passing on the wrong defect.
+    if (!(err instanceof CanonicalizationError)) {
+      fail(`${v.name} — expected a CanonicalizationError, got ${err instanceof Error ? err.name : typeof err}: ${String(err)}`);
+      continue;
+    }
+    const problems: string[] = [];
+    if (err.code !== v.expectedCode) problems.push(`code "${err.code ?? '(none)'}" != "${v.expectedCode}"`);
+    if (!err.message.includes(v.expectedError)) problems.push(`message "${err.message}" does not contain "${v.expectedError}"`);
+    if (problems.length > 0) {
+      fail(`${v.name} — ${problems.join('; ')}`);
     } else {
-      console.log(`  ✓ ${v.name}`);
+      console.log(`  ✓ ${v.name} (${err.code})`);
     }
   }
+}
+
+// Defence-in-depth: every code a vector expects must be REGISTERED in the
+// vocabulary shipped to external implementations — otherwise a typo'd code
+// would assert against something no implementation could ever emit.
+for (const problem of unregisteredCodes(errorVectors.map((v) => v.expectedCode))) {
+  fail(`projection error vectors — ${problem}`);
 }
 
 // --- Part 4: example corpus ------------------------------------------------

--- a/scripts/kat/lineage-chain-vectors.ts
+++ b/scripts/kat/lineage-chain-vectors.ts
@@ -23,6 +23,10 @@ export interface LineageVector {
     outcome: LineageOutcome;
     resolvedDepth?: number;
     /** A substring the `reason` must contain (rejected/incomplete). */
+    /** Stable defect code the result must carry — the portable assertion. */
+    reasonCode?: string;
+    /** Substring of the human-readable reason. Advisory: pins THIS
+     * implementation's wording, not portable across implementations. */
     reasonIncludes?: string;
     /** Expected number of advisory warnings. */
     warnings?: number;
@@ -116,7 +120,7 @@ export const lineageVectors: LineageVector[] = [
       { id: B, parent: A, ancestors: [A] },
     ],
     subject: A,
-    expected: { outcome: 'rejected', reasonIncludes: 'cycle' },
+    expected: { outcome: 'rejected', reasonCode: 'CDX-E-LINEAGE-CYCLE', reasonIncludes: 'cycle' },
   },
   {
     name: 'rejected-forged-tail',
@@ -127,7 +131,7 @@ export const lineageVectors: LineageVector[] = [
       { id: B, parent: A, ancestors: [A, FAKE] },
     ],
     subject: B,
-    expected: { outcome: 'rejected', reasonIncludes: 'contradicts' },
+    expected: { outcome: 'rejected', reasonCode: 'CDX-E-LINEAGE-ANCESTORS-CONTRADICT', reasonIncludes: 'contradicts' },
   },
   {
     name: 'rejected-ancestors-first-mismatch',
@@ -137,28 +141,28 @@ export const lineageVectors: LineageVector[] = [
       { id: A, parent: ROOT, ancestors: [FAKE] },
     ],
     subject: A,
-    expected: { outcome: 'rejected', reasonIncludes: 'ancestors[0]' },
+    expected: { outcome: 'rejected', reasonCode: 'CDX-E-LINEAGE-ANCESTORS-CONTRADICT', reasonIncludes: 'ancestors[0]' },
   },
   {
     name: 'rejected-root-with-ancestors',
     description: 'A root (parent:null) declaring a non-empty ancestors chain is inconsistent.',
     docs: [{ id: ROOT, parent: null, ancestors: [FAKE] }],
     subject: ROOT,
-    expected: { outcome: 'rejected', reasonIncludes: 'non-empty ancestors' },
+    expected: { outcome: 'rejected', reasonCode: 'CDX-E-LINEAGE-ROOT-WITH-ANCESTORS', reasonIncludes: 'non-empty ancestors' },
   },
   {
     name: 'incomplete-unresolvable-parent',
     description: 'A parent the verifier cannot resolve yields incomplete (NOT valid), with no claim about it.',
     docs: [{ id: A, parent: GHOST, ancestors: [GHOST] }],
     subject: A,
-    expected: { outcome: 'incomplete', resolvedDepth: 1, reasonIncludes: 'could not be resolved' },
+    expected: { outcome: 'incomplete', resolvedDepth: 1, reasonCode: 'CDX-E-LINEAGE-UNRESOLVABLE', reasonIncludes: 'could not be resolved' },
   },
   {
     name: 'incomplete-subject-unresolvable',
     description: 'A subject the verifier cannot resolve yields incomplete at depth 0.',
     docs: [],
     subject: A,
-    expected: { outcome: 'incomplete', resolvedDepth: 0, reasonIncludes: 'subject' },
+    expected: { outcome: 'incomplete', resolvedDepth: 0, reasonCode: 'CDX-E-LINEAGE-UNRESOLVABLE', reasonIncludes: 'subject' },
   },
   {
     name: 'incomplete-depth-cap',
@@ -171,7 +175,7 @@ export const lineageVectors: LineageVector[] = [
     ],
     subject: C,
     maxDepth: 2,
-    expected: { outcome: 'incomplete', reasonIncludes: 'traversal bound' },
+    expected: { outcome: 'incomplete', reasonCode: 'CDX-E-LINEAGE-BOUND-REACHED', reasonIncludes: 'traversal bound' },
   },
   {
     name: 'verified-merge-diamond',
@@ -208,7 +212,7 @@ export const lineageVectors: LineageVector[] = [
       { id: D, parent: B, mergedFrom: [GHOST] },
     ],
     subject: D,
-    expected: { outcome: 'incomplete', reasonIncludes: 'could not be resolved' },
+    expected: { outcome: 'incomplete', reasonCode: 'CDX-E-LINEAGE-UNRESOLVABLE', reasonIncludes: 'could not be resolved' },
   },
   {
     name: 'rejected-merge-parent-forged',
@@ -220,6 +224,6 @@ export const lineageVectors: LineageVector[] = [
       { id: D, parent: B, mergedFrom: [C] },
     ],
     subject: D,
-    expected: { outcome: 'rejected', reasonIncludes: 'ancestors[0]' },
+    expected: { outcome: 'rejected', reasonCode: 'CDX-E-LINEAGE-ANCESTORS-CONTRADICT', reasonIncludes: 'ancestors[0]' },
   },
 ];

--- a/scripts/kat/manifest-projection-vectors.ts
+++ b/scripts/kat/manifest-projection-vectors.ts
@@ -50,7 +50,11 @@ export interface ErrorVector {
   name: string;
   description: string;
   manifest: string;
-  /** Substring the thrown CanonicalizationError message must contain. */
+  /** Stable defect code the thrown CanonicalizationError must carry — the
+   * portable assertion (`conformance/errors.json`). */
+  expectedCode: string;
+  /** Substring the message must contain. Advisory: pins THIS implementation's
+   * wording so a code stays tied to the site it was assigned at; not portable. */
   expectedError: string;
 }
 
@@ -197,90 +201,105 @@ export const errorVectors: ErrorVector[] = [
     name: 'pending-id-forbidden',
     description: 'A draft manifest (id:"pending") has no fixed identity, so a projection over it is forbidden.',
     manifest: `{"cdx":"0.1","id":"pending","state":"draft","content":{"path":"content/document.json","hash":"${sha('1')}"}}`,
+    expectedCode: 'CDX-E-ID-PENDING',
     expectedError: 'pending',
   },
   {
     name: 'malformed-content-hash',
     description: 'A content hash that is not a well-formed algorithm:hexdigest is rejected.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"sha256:1234"}}`,
+    expectedCode: 'CDX-E-HASH-MALFORMED',
     expectedError: 'malformed',
   },
   {
     name: 'duplicate-extension-id',
     description: 'Two extensions with the same id make the projection ambiguous and are rejected.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"extensions":[{"id":"cdx.security","version":"0.1","required":true},{"id":"cdx.security","version":"0.2","required":false}]}`,
+    expectedCode: 'CDX-E-EXTENSION-DUPLICATE',
     expectedError: 'duplicate extension id',
   },
   {
     name: 'unknown-state-rejected',
     description: 'A state outside the lifecycle enum fails closed rather than binding a bogus state into a signature.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"archived","content":{"path":"content/document.json","hash":"${sha('2')}"}}`,
+    expectedCode: 'CDX-E-STATE-UNKNOWN',
     expectedError: 'manifest.state must be one of',
   },
   {
     name: 'duplicate-required-signer',
     description: 'Two identical required-signer entries make the required set ambiguous and are rejected.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"signaturePolicy":{"requiredSigners":[{"did":"did:key:zABC"},{"did":"did:key:zABC"}]}}`,
+    expectedCode: 'CDX-E-REQUIRED-SIGNER-DUPLICATE',
     expectedError: 'duplicate manifest.signaturePolicy.requiredSigners',
   },
   {
     name: 'empty-required-signers',
     description: 'An empty required-signer set is forbidden so "absent policy" and "empty policy" are not both expressible.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"signaturePolicy":{"requiredSigners":[]}}`,
+    expectedCode: 'CDX-E-REQUIRED-SIGNER-SET-EMPTY',
     expectedError: 'must be a non-empty array',
   },
   {
     name: 'required-signer-two-kinds',
     description: 'A required-signer entry carrying two identity kinds is malformed and fails closed.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"signaturePolicy":{"requiredSigners":[{"did":"did:key:zABC","jkt":"thumbprint"}]}}`,
+    expectedCode: 'CDX-E-REQUIRED-SIGNER-KIND-AMBIGUOUS',
     expectedError: 'exactly one of',
   },
   {
     name: 'config-file-conflicting-hash',
     description: 'The same config-file path declared with two different hashes (across config slots) makes the binding ambiguous and is rejected.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"academic":{"numbering":{"path":"shared.json","hash":"${sha('a')}"}},"semantic":{"bibliography":{"path":"shared.json","hash":"${sha('b')}"}}}`,
+    expectedCode: 'CDX-E-REFERENCE-HASH-CONFLICT',
     expectedError: 'conflicting hashes',
   },
   {
     name: 'asset-index-missing-hash',
     description: 'An asset category declared without a well-formed index hash would escape the transitive asset binding, so the projection fails closed rather than dropping it.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"assets":{"images":{"count":2,"totalSize":170,"index":"assets/images/index.json"}}}`,
+    expectedCode: 'CDX-E-HASH-MALFORMED',
     expectedError: 'index hash',
   },
   {
     name: 'malformed-cdx-version',
     description: 'A `cdx` that is not a "<major>.<minor>" string fails closed rather than binding a bogus version into the projection.',
     manifest: `{"cdx":"0.1.2","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"}}`,
+    expectedCode: 'CDX-E-CDX-VERSION-MALFORMED',
     expectedError: 'version string',
   },
   {
     name: 'presentation-unknown-type',
     description: 'A presentation entry whose type is outside the enum fails closed.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"presentation":[{"type":"pdf","path":"presentation/x.json","hash":"${sha('3')}"}]}`,
+    expectedCode: 'CDX-E-PRESENTATION-TYPE-UNKNOWN',
     expectedError: 'is not one of',
   },
   {
     name: 'presentation-traversal-path',
     description: 'A presentation entry whose path escapes the archive root fails closed.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"presentation":[{"type":"paginated","path":"../evil.json","hash":"${sha('3')}"}]}`,
+    expectedCode: 'CDX-E-PATH-TRAVERSAL',
     expectedError: 'archive-relative path',
   },
   {
     name: 'required-signer-malformed-did',
     description: 'A required-signer `did` that is not a well-formed did:(key|jwk|web) fails closed rather than binding a bogus credential into the required set.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"signaturePolicy":{"requiredSigners":[{"did":"not-a-did"}]}}`,
+    expectedCode: 'CDX-E-REQUIRED-SIGNER-ID-MALFORMED',
     expectedError: 'malformed for its identity kind',
   },
   {
     name: 'access-control-malformed-hash',
     description: 'A security.accessControl reference whose hash is not a valid content hash fails closed rather than binding an unverifiable policy reference.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"security":{"accessControl":{"path":"security/access-control.json","hash":"notahash"}}}`,
+    expectedCode: 'CDX-E-HASH-MALFORMED',
     expectedError: 'valid content hash',
   },
   {
     name: 'access-control-traversal-path',
     description: 'A security.accessControl reference whose path escapes the archive root fails closed.',
     manifest: `{"cdx":"0.1","id":"${sha('1')}","state":"frozen","content":{"path":"content/document.json","hash":"${sha('2')}"},"security":{"accessControl":{"path":"../evil.json","hash":"${sha('a')}"}}}`,
+    expectedCode: 'CDX-E-PATH-TRAVERSAL',
     expectedError: 'archive-relative path',
   },
 ];

--- a/scripts/lib/block-merkle.ts
+++ b/scripts/lib/block-merkle.ts
@@ -30,9 +30,14 @@ import * as crypto from 'crypto';
 import { jcsOf } from './canonicalize.js';
 
 export class BlockMerkleError extends Error {
-  constructor(message: string) {
+  /** Stable defect identifier from the conformance vocabulary
+   * (`conformance/errors.json`); diagnostics only, never normativity —
+   * see CanonicalizationError in ./canonicalize.ts. */
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'BlockMerkleError';
+    this.code = code;
   }
 }
 

--- a/scripts/lib/canonicalize.ts
+++ b/scripts/lib/canonicalize.ts
@@ -24,11 +24,26 @@
 import canonicalize from 'canonicalize';
 import * as crypto from 'crypto';
 
-/** Thrown for any input that cannot be canonicalized per §4.3. */
+/**
+ * Thrown for any input that cannot be canonicalized per §4.3.
+ *
+ * The optional `code` is a stable, language-independent defect identifier from
+ * the conformance vocabulary (`conformance/errors.json`). It exists so a
+ * known-answer vector can assert *which defect* was detected without asserting
+ * on an English message — the message stays free to change, the code does not.
+ *
+ * Codes are **diagnostics, not normativity**: the specification mandates
+ * dispositions (State Machine §5.4), never error identifiers, and a conforming
+ * implementation is free to use its own internal errors. Codes are assigned at
+ * the throw sites a conformance vector exercises; sites without a vector carry
+ * no code yet, and `code` is therefore optional by design.
+ */
 export class CanonicalizationError extends Error {
-  constructor(message: string) {
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'CanonicalizationError';
+    this.code = code;
   }
 }
 

--- a/scripts/lib/error-codes.ts
+++ b/scripts/lib/error-codes.ts
@@ -1,0 +1,65 @@
+/**
+ * Loader for the conformance defect-code vocabulary (`conformance/errors.json`).
+ *
+ * The codes are a **non-normative** diagnostic aid: the specification mandates
+ * dispositions (State Machine §5.4) and lineage outcomes (09 §3.3), never error
+ * identifiers. A conforming implementation maps its own internal errors to these
+ * codes in its conformance adapter; it never has to adopt them internally.
+ *
+ * This module exists so the gates can assert that every code a known-answer
+ * vector expects is actually registered — otherwise a typo'd code in a vector
+ * would silently assert against a code no implementation could ever emit.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface ErrorCodeEntry {
+  summary: string;
+  clause: string;
+  outcome?: string;
+  note?: string;
+}
+
+interface ErrorVocabulary {
+  version: string;
+  specVersion: string;
+  codes: Record<string, ErrorCodeEntry>;
+}
+
+const VOCAB_PATH = path.join(__dirname, '..', '..', 'conformance', 'errors.json');
+
+let cached: ErrorVocabulary | undefined;
+
+export function errorVocabulary(): ErrorVocabulary {
+  if (cached === undefined) {
+    const raw = fs.readFileSync(VOCAB_PATH, 'utf8');
+    cached = JSON.parse(raw) as ErrorVocabulary;
+  }
+  return cached;
+}
+
+/** Shape of a well-formed defect code. */
+export const ERROR_CODE_PATTERN = /^CDX-E-[A-Z0-9]+(-[A-Z0-9]+)*$/;
+
+/** True iff `code` is well-formed AND registered in conformance/errors.json. */
+export function isRegisteredCode(code: unknown): code is string {
+  if (typeof code !== 'string' || !ERROR_CODE_PATTERN.test(code)) return false;
+  return Object.prototype.hasOwnProperty.call(errorVocabulary().codes, code);
+}
+
+/**
+ * Assert every code in `codes` is registered. Returns the problems found so a
+ * caller can fold them into its own failure reporting.
+ */
+export function unregisteredCodes(codes: Iterable<unknown>): string[] {
+  const problems: string[] = [];
+  for (const c of codes) {
+    if (typeof c !== 'string' || !ERROR_CODE_PATTERN.test(c)) {
+      problems.push(`"${String(c)}" is not a well-formed CDX-E-* defect code`);
+    } else if (!isRegisteredCode(c)) {
+      problems.push(`"${c}" is not registered in conformance/errors.json`);
+    }
+  }
+  return problems;
+}

--- a/scripts/lib/jws-envelope.ts
+++ b/scripts/lib/jws-envelope.ts
@@ -34,9 +34,14 @@ import { jcsOf, parseStrictJson } from './canonicalize.js';
 
 /** Thrown for a malformed JWS envelope or protected header. */
 export class JwsEnvelopeError extends Error {
-  constructor(message: string) {
+  /** Stable defect identifier from the conformance vocabulary
+   * (`conformance/errors.json`); diagnostics only, never normativity —
+   * see CanonicalizationError in ./canonicalize.ts. */
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'JwsEnvelopeError';
+    this.code = code;
   }
 }
 

--- a/scripts/lib/keyid-resolution.ts
+++ b/scripts/lib/keyid-resolution.ts
@@ -27,9 +27,14 @@ import * as crypto from 'crypto';
 import { jcsOf } from './canonicalize.js';
 
 export class KeyResolutionError extends Error {
-  constructor(message: string) {
+  /** Stable defect identifier from the conformance vocabulary
+   * (`conformance/errors.json`); diagnostics only, never normativity —
+   * see CanonicalizationError in ./canonicalize.ts. */
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'KeyResolutionError';
+    this.code = code;
   }
 }
 

--- a/scripts/lib/lineage-chain.ts
+++ b/scripts/lib/lineage-chain.ts
@@ -38,9 +38,14 @@
  */
 
 export class LineageError extends Error {
-  constructor(message: string) {
+  /** Stable defect identifier from the conformance vocabulary
+   * (`conformance/errors.json`); diagnostics only, never normativity —
+   * see CanonicalizationError in ./canonicalize.ts. */
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'LineageError';
+    this.code = code;
   }
 }
 
@@ -67,6 +72,13 @@ export interface LineageResult {
   resolvedDepth: number;
   /** For `incomplete`/`rejected`: a human-readable explanation. */
   reason?: string;
+  /**
+   * Stable defect identifier accompanying `reason` (`conformance/errors.json`).
+   * Lets a conformance vector assert *which* inconsistency was found without
+   * asserting on English prose. Diagnostics only — the normative outcome is
+   * `outcome` (09 §3.3); a conforming verifier need not use these identifiers.
+   */
+  reasonCode?: string;
   /** For `incomplete`: the id whose link could not be resolved (chain unverified from here up). */
   brokenAt?: string;
   /** Advisory, non-fatal observations (claimed depth/version mismatches). */
@@ -107,6 +119,7 @@ interface VisitResult {
   /** Verified: the longest resolved path to a root; otherwise where the walk stopped. */
   depth: number;
   reason?: string;
+  reasonCode?: string;
   brokenAt?: string;
 }
 
@@ -143,7 +156,7 @@ export function verifyLineageChain(subjectId: string, resolve: LineageResolver, 
     if (onPath.has(id)) {
       // A content-addressed chain cannot revisit an id on one path — a document
       // cannot be its own ancestor — so this is a proven inconsistency.
-      return { outcome: 'rejected', depth: d - 1, reason: `cycle detected at ${id}` };
+      return { outcome: 'rejected', depth: d - 1, reason: `cycle detected at ${id}`, reasonCode: 'CDX-E-LINEAGE-CYCLE' };
     }
     const cached = memo.get(id);
     if (cached !== undefined) return { outcome: 'verified', depth: cached };
@@ -153,13 +166,13 @@ export function verifyLineageChain(subjectId: string, resolve: LineageResolver, 
     // whose nodes never verify (an unresolvable base, or every node at the depth
     // bound) is not memoised, so its re-walk is what this cap stops.
     if (++resolveCount > maxNodes) {
-      return { outcome: 'incomplete', depth: d - 1, reason: `traversal node bound (${maxNodes}) reached`, brokenAt: id };
+      return { outcome: 'incomplete', depth: d - 1, reason: `traversal node bound (${maxNodes}) reached`, reasonCode: 'CDX-E-LINEAGE-BOUND-REACHED', brokenAt: id };
     }
 
     const doc = resolve(id);
     if (doc === undefined) {
       const what = d === 1 ? 'subject' : 'ancestor';
-      return { outcome: 'incomplete', depth: d - 1, reason: `${what} ${id} could not be resolved`, brokenAt: id };
+      return { outcome: 'incomplete', depth: d - 1, reason: `${what} ${id} could not be resolved`, reasonCode: 'CDX-E-LINEAGE-UNRESOLVABLE', brokenAt: id };
     }
 
     const parents: string[] = [];
@@ -176,7 +189,7 @@ export function verifyLineageChain(subjectId: string, resolve: LineageResolver, 
       // Root. (The root test precedes the bound test, so a root sitting exactly
       // at the bound still verifies; a non-root at the bound is incomplete.)
       if (Array.isArray(doc.ancestors) && doc.ancestors.length > 0) {
-        return { outcome: 'rejected', depth: d, reason: `root ${id} declares a non-empty ancestors chain` };
+        return { outcome: 'rejected', depth: d, reason: `root ${id} declares a non-empty ancestors chain`, reasonCode: 'CDX-E-LINEAGE-ROOT-WITH-ANCESTORS' };
       }
       if (typeof doc.depth === 'number' && doc.depth !== 1) {
         warnings.push(`root ${id} claims depth ${doc.depth}, expected 1`);
@@ -186,7 +199,7 @@ export function verifyLineageChain(subjectId: string, resolve: LineageResolver, 
     }
 
     if (d >= maxDepth) {
-      return { outcome: 'incomplete', depth: d, reason: `traversal bound (${maxDepth}) reached`, brokenAt: parents[0] };
+      return { outcome: 'incomplete', depth: d, reason: `traversal bound (${maxDepth}) reached`, reasonCode: 'CDX-E-LINEAGE-BOUND-REACHED', brokenAt: parents[0] };
     }
 
     // Cross-check the advisory ancestors array against the resolved PRIMARY
@@ -197,13 +210,13 @@ export function verifyLineageChain(subjectId: string, resolve: LineageResolver, 
       const parent = resolve(doc.parent);
       if (parent !== undefined) {
         if (doc.ancestors.length === 0 || doc.ancestors[0] !== doc.parent) {
-          return { outcome: 'rejected', depth: d, reason: `ancestors[0] does not equal parent at ${id}` };
+          return { outcome: 'rejected', depth: d, reason: `ancestors[0] does not equal parent at ${id}`, reasonCode: 'CDX-E-LINEAGE-ANCESTORS-CONTRADICT' };
         }
         const expected = [doc.parent, ...(Array.isArray(parent.ancestors) ? parent.ancestors : [])];
         const overlap = Math.min(doc.ancestors.length, expected.length);
         for (let i = 0; i < overlap; i++) {
           if (doc.ancestors[i] !== expected[i]) {
-            return { outcome: 'rejected', depth: d, reason: `ancestors chain at index ${i} of ${id} contradicts the resolved parent's committed chain` };
+            return { outcome: 'rejected', depth: d, reason: `ancestors chain at index ${i} of ${id} contradicts the resolved parent's committed chain`, reasonCode: 'CDX-E-LINEAGE-ANCESTORS-CONTRADICT' };
           }
         }
       }
@@ -249,5 +262,5 @@ export function verifyLineageChain(subjectId: string, resolve: LineageResolver, 
   }
 
   const r = visit(subjectId, 1);
-  return { outcome: r.outcome, resolvedDepth: r.depth, reason: r.reason, brokenAt: r.brokenAt, warnings };
+  return { outcome: r.outcome, resolvedDepth: r.depth, reason: r.reason, reasonCode: r.reasonCode, brokenAt: r.brokenAt, warnings };
 }

--- a/scripts/lib/manifest-projection.ts
+++ b/scripts/lib/manifest-projection.ts
@@ -120,7 +120,7 @@ function projectRequiredSigner(entry: unknown): Record<string, unknown> {
   }
   const present = REQUIRED_SIGNER_KINDS.filter((k) => entry[k] !== undefined);
   if (present.length !== 1) {
-    throw new CanonicalizationError(`each requiredSigners entry must carry exactly one of: ${REQUIRED_SIGNER_KINDS.join(', ')}`);
+    throw new CanonicalizationError(`each requiredSigners entry must carry exactly one of: ${REQUIRED_SIGNER_KINDS.join(', ')}`, 'CDX-E-REQUIRED-SIGNER-KIND-AMBIGUOUS');
   }
   const keys = Object.keys(entry);
   if (keys.length !== 1) {
@@ -129,7 +129,7 @@ function projectRequiredSigner(entry: unknown): Record<string, unknown> {
   const kind = present[0];
   const value = entry[kind];
   if (typeof value !== 'string' || !REQUIRED_SIGNER_PATTERNS[kind].test(value)) {
-    throw new CanonicalizationError(`requiredSigners ${kind} is malformed for its identity kind`);
+    throw new CanonicalizationError(`requiredSigners ${kind} is malformed for its identity kind`, 'CDX-E-REQUIRED-SIGNER-ID-MALFORMED');
   }
   return { [kind]: value };
 }
@@ -168,11 +168,11 @@ function collectConfigFileReferences(manifest: Record<string, unknown>): Array<{
   const visit = (v: unknown): void => {
     if (isFileReference(v)) {
       if (!RELATIVE_PATH.test(v.path)) {
-        throw new CanonicalizationError(`config file path "${v.path}" is not a valid archive-relative path`);
+        throw new CanonicalizationError(`config file path "${v.path}" is not a valid archive-relative path`, 'CDX-E-PATH-TRAVERSAL');
       }
       const existing = byPath.get(v.path);
       if (existing !== undefined && existing !== v.hash) {
-        throw new CanonicalizationError(`config file "${v.path}" is declared with conflicting hashes`);
+        throw new CanonicalizationError(`config file "${v.path}" is declared with conflicting hashes`, 'CDX-E-REFERENCE-HASH-CONFLICT');
       }
       byPath.set(v.path, v.hash);
       return; // a file reference's members are scalars; nothing to recurse into
@@ -223,7 +223,7 @@ function collectAssetIndexReferences(manifest: Record<string, unknown>): Array<{
       throw new CanonicalizationError(`manifest.assets category "${category}" index path "${cat.index}" is not a valid archive-relative path`);
     }
     if (!isValidContentHash(cat.hash)) {
-      throw new CanonicalizationError(`manifest.assets category "${category}" index hash "${String(cat.hash)}" is malformed`);
+      throw new CanonicalizationError(`manifest.assets category "${category}" index hash "${String(cat.hash)}" is malformed`, 'CDX-E-HASH-MALFORMED');
     }
     const existing = byPath.get(cat.index);
     if (existing !== undefined && existing !== cat.hash) {
@@ -255,7 +255,7 @@ export function projectManifest(manifestText: string): Record<string, unknown> {
   // carries `id: "pending"` (07 §5.3) and is never signed; forbid it explicitly
   // rather than project an unstable manifest.
   if (manifest.id === 'pending') {
-    throw new CanonicalizationError('manifest id is "pending"; a manifest projection is undefined until the document id is assigned');
+    throw new CanonicalizationError('manifest id is "pending"; a manifest projection is undefined until the document id is assigned', 'CDX-E-ID-PENDING');
   }
 
   // Bound nesting depth before the recursive walks (config-ref collection, byte-invariant
@@ -269,13 +269,13 @@ export function projectManifest(manifestText: string): Record<string, unknown> {
   // Pattern-checked, not merely typed: a signer skipping manifest-schema validation
   // must not bind a malformed version into the signed projection (fail closed).
   if (typeof manifest.cdx !== 'string' || !VERSION_PATTERN.test(manifest.cdx)) {
-    throw new CanonicalizationError('manifest.cdx must be a "<major>.<minor>" version string');
+    throw new CanonicalizationError('manifest.cdx must be a "<major>.<minor>" version string', 'CDX-E-CDX-VERSION-MALFORMED');
   }
   projection.cdx = manifest.cdx;
 
   // --- state (lifecycle) — always present ------------------------------------
   if (typeof manifest.state !== 'string' || !MANIFEST_STATES.has(manifest.state)) {
-    throw new CanonicalizationError(`manifest.state must be one of: ${[...MANIFEST_STATES].join(', ')}`);
+    throw new CanonicalizationError(`manifest.state must be one of: ${[...MANIFEST_STATES].join(', ')}`, 'CDX-E-STATE-UNKNOWN');
   }
   projection.state = manifest.state;
 
@@ -285,10 +285,10 @@ export function projectManifest(manifestText: string): Record<string, unknown> {
     throw new CanonicalizationError('manifest.content must be an object with string path and hash');
   }
   if (!RELATIVE_PATH.test(content.path)) {
-    throw new CanonicalizationError(`manifest.content path "${content.path}" is not a valid archive-relative path`);
+    throw new CanonicalizationError(`manifest.content path "${content.path}" is not a valid archive-relative path`, 'CDX-E-PATH-TRAVERSAL');
   }
   if (!isValidContentHash(content.hash)) {
-    throw new CanonicalizationError(`manifest.content.hash "${content.hash}" is malformed`);
+    throw new CanonicalizationError(`manifest.content.hash "${content.hash}" is malformed`, 'CDX-E-HASH-MALFORMED');
   }
   projection.content = { path: content.path, hash: content.hash };
 
@@ -309,10 +309,10 @@ export function projectManifest(manifestText: string): Record<string, unknown> {
         throw new CanonicalizationError('each manifest.presentation[] entry must have string type, path and hash');
       }
       if (!PRESENTATION_TYPES.has(entry.type)) {
-        throw new CanonicalizationError(`manifest.presentation[] type "${entry.type}" is not one of: ${[...PRESENTATION_TYPES].join(', ')}`);
+        throw new CanonicalizationError(`manifest.presentation[] type "${entry.type}" is not one of: ${[...PRESENTATION_TYPES].join(', ')}`, 'CDX-E-PRESENTATION-TYPE-UNKNOWN');
       }
       if (!RELATIVE_PATH.test(entry.path)) {
-        throw new CanonicalizationError(`manifest.presentation[] path "${entry.path}" is not a valid archive-relative path`);
+        throw new CanonicalizationError(`manifest.presentation[] path "${entry.path}" is not a valid archive-relative path`, 'CDX-E-PATH-TRAVERSAL');
       }
       if (!isValidContentHash(entry.hash)) {
         throw new CanonicalizationError(`presentation "${entry.path}" has a malformed hash "${entry.hash}"`);
@@ -343,7 +343,7 @@ export function projectManifest(manifestText: string): Record<string, unknown> {
         throw new CanonicalizationError('each manifest.extensions[] entry must have a string id, string version and boolean required');
       }
       if (seen.has(entry.id)) {
-        throw new CanonicalizationError(`duplicate extension id "${entry.id}"`);
+        throw new CanonicalizationError(`duplicate extension id "${entry.id}"`, 'CDX-E-EXTENSION-DUPLICATE');
       }
       seen.add(entry.id);
       const projected: Record<string, unknown> = { id: entry.id, version: entry.version, required: entry.required };
@@ -389,13 +389,13 @@ export function projectManifest(manifestText: string): Record<string, unknown> {
     }
     const required = policy.requiredSigners;
     if (!Array.isArray(required) || required.length === 0) {
-      throw new CanonicalizationError('manifest.signaturePolicy.requiredSigners must be a non-empty array');
+      throw new CanonicalizationError('manifest.signaturePolicy.requiredSigners must be a non-empty array', 'CDX-E-REQUIRED-SIGNER-SET-EMPTY');
     }
     const items = required.map((entry) => projectRequiredSigner(entry));
     items.sort(byJcs);
     for (let i = 1; i < items.length; i++) {
       if (jcsOf(items[i]) === jcsOf(items[i - 1])) {
-        throw new CanonicalizationError('duplicate manifest.signaturePolicy.requiredSigners entry');
+        throw new CanonicalizationError('duplicate manifest.signaturePolicy.requiredSigners entry', 'CDX-E-REQUIRED-SIGNER-DUPLICATE');
       }
     }
     projection.signaturePolicy = { requiredSigners: items };
@@ -439,10 +439,10 @@ export function projectManifest(manifestText: string): Record<string, unknown> {
   if (isPlainObject(security) && security.accessControl !== undefined && security.accessControl !== null) {
     const ref = security.accessControl;
     if (!isPlainObject(ref) || typeof ref.path !== 'string' || !isValidContentHash(ref.hash)) {
-      throw new CanonicalizationError('manifest.security.accessControl must carry a string path and a valid content hash');
+      throw new CanonicalizationError('manifest.security.accessControl must carry a string path and a valid content hash', 'CDX-E-HASH-MALFORMED');
     }
     if (!RELATIVE_PATH.test(ref.path)) {
-      throw new CanonicalizationError(`manifest.security.accessControl path "${ref.path}" is not a valid archive-relative path`);
+      throw new CanonicalizationError(`manifest.security.accessControl path "${ref.path}" is not a valid archive-relative path`, 'CDX-E-PATH-TRAVERSAL');
     }
     projection.accessControl = { path: ref.path, hash: ref.hash };
   }

--- a/scripts/lib/provenance-timestamp.ts
+++ b/scripts/lib/provenance-timestamp.ts
@@ -34,9 +34,14 @@
 import * as crypto from 'crypto';
 
 export class ProvenanceTimestampError extends Error {
-  constructor(message: string) {
+  /** Stable defect identifier from the conformance vocabulary
+   * (`conformance/errors.json`); diagnostics only, never normativity —
+   * see CanonicalizationError in ./canonicalize.ts. */
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'ProvenanceTimestampError';
+    this.code = code;
   }
 }
 

--- a/scripts/lib/signature-set.ts
+++ b/scripts/lib/signature-set.ts
@@ -37,9 +37,14 @@
 import type { SignatureState } from './signature-state.js';
 
 export class SignatureSetError extends Error {
-  constructor(message: string) {
+  /** Stable defect identifier from the conformance vocabulary
+   * (`conformance/errors.json`); diagnostics only, never normativity —
+   * see CanonicalizationError in ./canonicalize.ts. */
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'SignatureSetError';
+    this.code = code;
   }
 }
 

--- a/scripts/lib/timestamp.ts
+++ b/scripts/lib/timestamp.ts
@@ -35,9 +35,14 @@ const IMPRINT_HASHES: Record<string, string> = {
 const BASE64URL = /^[A-Za-z0-9_-]*$/;
 
 export class TimestampError extends Error {
-  constructor(message: string) {
+  /** Stable defect identifier from the conformance vocabulary
+   * (`conformance/errors.json`); diagnostics only, never normativity —
+   * see CanonicalizationError in ./canonicalize.ts. */
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'TimestampError';
+    this.code = code;
   }
 }
 

--- a/scripts/lib/webauthn.ts
+++ b/scripts/lib/webauthn.ts
@@ -26,9 +26,14 @@ import * as crypto from 'crypto';
 import { jcsOf, parseStrictJson } from './canonicalize.js';
 
 export class WebauthnError extends Error {
-  constructor(message: string) {
+  /** Stable defect identifier from the conformance vocabulary
+   * (`conformance/errors.json`); diagnostics only, never normativity —
+   * see CanonicalizationError in ./canonicalize.ts. */
+  readonly code?: string;
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'WebauthnError';
+    this.code = code;
   }
 }
 


### PR DESCRIPTION
## Summary

First PR of the conformance-suite plan (**A1**). Prerequisite for exporting vectors to a language-agnostic suite: today's error assertions are substrings of English messages, which no third-party implementation can be tested against.

- **Mechanism on all 9 `lib/*` error classes** (optional `code`), plus `reasonCode` on `LineageResult`. Values assigned only at the sites the 15 projection error vectors and 9 lineage expectations exercise — the other ~100 throw sites stay uncoded until a vector needs one, hence the field is optional.
- **`conformance/errors.json`** registers the 17 codes with spec-clause references, and states **in the file** that it is non-normative: the spec mandates dispositions (State Machine §5.4) and lineage outcomes (09 §3.3), never error identifiers. Implementations map native errors to codes **in their adapter** (Wycheproof's model) and never adopt the vocabulary internally — a code sharpens a failure report, it is never the pass criterion for a MUST.
- **Gates now assert type + code + message.** Keeping the message substring is deliberate: the code is the portable assertion, the message pins the *specific throw site*, so a vector that starts failing closed somewhere other than where its code was assigned is caught rather than silently passing on the wrong defect. `scripts/lib/error-codes.ts` additionally asserts every expected code is registered, so a typo can't assert against a code nothing could emit.

The review that shaped this plan predicted some vectors were passing on the wrong throw site. **That did not bear out** — all 15 landed where expected. The value delivered is lock-in going forward, not a bug found.

## Verification

- All 19 gates + `tsc --noEmit` green.
- **Mutation-tested** (seed-and-revert, per repo convention), all three caught:
  - drifted code at a throw site → `code "CDX-E-STATE-UNKNOWN" != "CDX-E-ID-PENDING"`
  - unregistered code in a vector → `"CDX-E-NOT-REGISTERED" is not registered in conformance/errors.json`
  - drifted lineage reason → `reasonCode "CDX-E-LINEAGE-UNRESOLVABLE" != "CDX-E-LINEAGE-CYCLE"`

## Test plan
- [ ] `npm run check:manifest-projection` — 15 error vectors report their codes
- [ ] `npm run check:lineage` — 9 reasonCode assertions
- [ ] Full suite: `npm test` + all `check:*` gates