### PR TITLE
Add Level-0 conformance suite skeleton and adapter contract

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Check conformance vectors
         run: npm run check:conformance-vectors
 
+      - name: Check conformance suite
+        run: npm run check:conformance
+
       - name: Check block merkle
         run: npm run check:block-merkle
 

--- a/conformance/ADAPTER.md
+++ b/conformance/ADAPTER.md
@@ -1,0 +1,219 @@
+# Writing a CDX Conformance Adapter
+
+> **NON-NORMATIVE.** This document describes how to test an implementation
+> against the CDX conformance suite. Nothing here is part of the CDX
+> specification; the specification (`spec/`) and the published schemas
+> (`schemas/`) are the only normative artifacts. Where anything here appears to
+> disagree with `spec/`, the specification governs.
+
+An **adapter** is a small program *you* write that wraps *your* implementation.
+The suite hands it deterministic inputs and asks what your implementation
+produced; the suite — never the adapter — decides pass or fail. You never adopt
+the suite's error vocabulary internally: you map your native errors to suite
+codes at the adapter boundary, and nowhere else.
+
+## The one idea
+
+The suite owns every assertion. Your adapter only reports **what happened** —
+the bytes it produced, the id it computed, or the error it raised (mapped to a
+suite code). This keeps the pass criterion in one place (the suite) so no
+implementation can pass by asserting the wrong thing.
+
+## Levels
+
+The contract is tiered so the common case is trivial and the intrusive hooks are
+required only where a case genuinely needs them. A **case** declares the lowest
+level it needs; an **adapter** declares the highest level it implements
+(`adapter.level` in the report).
+
+| Level | Adds | Status |
+|-------|------|--------|
+| **0 — Vectors** | Pure known-answer vectors: deterministic input → deterministic output. No archive, no clock, no trust store, no network. | **shipped** |
+| 1 — Fixtures + clock | Whole-document archive fixtures verified against a per-case virtual clock. | planned |
+| 2 — Trust + resolver injection | Fixtures whose verdict depends on an injected trust store and identity resolver. | planned |
+
+Everything below is Level 0. Levels 1 and 2 arrive in later phases; their hooks
+are described here only far enough to show why the tiering exists.
+
+## The minimal Level-0 adapter
+
+At Level 0 you do not even need a separate process. Load the vectors, run your
+function, compare. In pseudocode:
+
+```
+for file in conformance/vectors/*.json (skip *.schema.json):
+    for vector in file.vectors:
+        actual = my_implementation(vector)          # your code
+        assert actual == expected_field(vector)     # your test runner
+        # one kind inverts this: manifest-projection-errors expects your code to
+        # RAISE — assert it raises and that the error maps to expect.code
+```
+
+That is the JSON-Schema-Test-Suite adoption shape: a few dozen lines, your own
+assertions, no protocol. Most implementations start here. The fields each kind
+carries are listed in [the per-kind contract](#per-kind-contract) below.
+
+## The file-based protocol (for a machine-checkable verdict)
+
+To get a verdict *from the suite* — and to run across a language boundary, the
+way this repository checks a Rust implementation from a TypeScript harness — an
+adapter is an **executable** that:
+
+1. **Reads the suite root** (the directory containing `suite.json` and
+   `vectors/`), passed as its first argument.
+2. **Runs your implementation** over every vector, recording what it produced.
+3. **Writes one report object to stdout** — schema:
+   [`report.schema.json`](report.schema.json).
+
+The suite harness runs your adapter, reads the report, and renders the verdict.
+Nothing is written anywhere else; stdout is the whole interface.
+
+### The report
+
+```jsonc
+{
+  "suite": "cdx-conformance",
+  "suiteVersion": "0.1.0",        // must equal the suite you ran against
+  "specVersion": "0.1",
+  "adapter": { "name": "my-impl", "version": "1.2.3", "level": 0 },
+  "capabilities": ["core", "hash:sha-384"],   // must include "core"
+  "results": [
+    { "kind": "document-id", "name": "spec-4-5-heading",
+      "outcome": "value", "values": { "canonicalJcs": "…", "id": "sha256:…" } },
+    { "kind": "manifest-projection-errors", "name": "hash-missing",
+      "outcome": "error", "error": { "code": "CDX-E-MANIFEST-HASH-MALFORMED" } },
+    { "kind": "jwk-thumbprint", "name": "…",
+      "outcome": "skip", "skip": { "reason": "algorithm not implemented" } }
+  ]
+}
+```
+
+Each result has one of three outcomes:
+
+- **`value`** — the operation ran; `values` holds the actuals (keys per the
+  contract below).
+- **`error`** — the operation raised; put the suite code your native error maps
+  to in `error.code` (or `null` if you have no mapping). Only the
+  error-expecting kinds treat this as anything but a failure.
+- **`skip`** — your adapter declined this vector. Surfaced in the verdict,
+  never counted as a pass. Prefer capability declaration (below) over ad-hoc
+  skips so the suite can scope cases for you.
+
+You must report a result for every vector the suite considers in scope for your
+declared capabilities; a vector left unreported is a failure, not a silent pass.
+
+## Per-kind contract
+
+For each kind: the input fields your adapter reads from the vector, the outcome
+it reports, and the `values` keys the suite compares (against the vector's
+expected field, shown in parentheses). All twelve are pure functions — no clock,
+key, or network is required at Level 0.
+
+| Kind | Reads | Outcome | `values` key → (expected field) |
+|------|-------|---------|--------------------------------|
+| `document-id` | `parts` (`manifest`,`content`,`dublinCore`,`assetIndexes?`), `algorithm?` | value | `canonicalJcs` → (`expectedCanonicalJcs`); `id` → (`expectedId`) |
+| `manifest-projection` | `manifest` (raw JSON text) | value | `jcs` → (`expectedJcs`); `sha256` → (`expectedSha256`) |
+| `manifest-scope` | `scope` | value | `jcs` → (`expectedJcs`); `sha256` → (`expectedSha256`) |
+| `manifest-projection-errors` | `manifest` (raw JSON text) | **error** | `error.code` → (`expect.code`) |
+| `jws-header` | `header` | value | `protectedHeader` → (`expectedProtected`) |
+| `jws-signing-input` | `header`, `scope` | value | `signingInputSha256` → (`expectedSha256`) — the `sha256:`-prefixed digest of the signing-input string |
+| `jwk-thumbprint` | `jwk` | value | `thumbprint` → (`expectedJkt`) |
+| `multibase` | `multibase` | value | `jwk` → (`expectedJwk`, by value); `thumbprint` → (`expectedJkt`) |
+| `block-merkle-root` | `leaves` | value | `root` → (`root`) |
+| `block-merkle-inclusion` | `leaf`, `path`, `root` | value | `included` → (`expected`, boolean) |
+| `block-merkle-leaf` | `block` | value | `leafJcs` → (`jcs`); `leafHash` → (`hash`) |
+| `provenance-timestamp` | `documentId`, `timestamp` | value | `boundToDocument`, `merkleVerified?`, `leaf?`, `problemsEmpty` → (`expected.*`) |
+
+Notes that bite:
+
+- **`multibase.jwk` is compared by value, not member order.** RFC 7638 sorts the
+  required members before hashing, so member order does not affect the thumbprint;
+  the suite normalises both sides before comparing. Emit the required members
+  (`kty`, `crv`, `x`, and `y` for EC) with correct values — the order is yours to
+  choose. The `thumbprint` comparison carries the cryptographic assertion.
+- **`provenance-timestamp`**: `merkleVerified` and `leaf` are asserted only where
+  the vector's `expected` defines them (aggregated timestamps carry them; single
+  tokens do not). `problemsEmpty` is `true` iff your structural binding check
+  produced no problems. The suite asserts *whether* problems are present, not
+  *which* — a deliberate Level-0 granularity limit, so a rejection for the wrong
+  reason still satisfies `problemsEmpty: false`.
+- **`manifest-projection-errors`** is the only kind that expects an error. Report
+  `outcome: "error"` with the mapped `code`; reporting a value fails the case.
+
+## Capabilities and scoping
+
+Your adapter declares the capabilities it supports (keys from
+[`capabilities.json`](capabilities.json)). The catalogue names optional
+features — extra hash algorithms, signature algorithms, DID methods,
+timestamping, extensions.
+
+- **`core` is mandatory.** Every adapter declares it; it is the baseline every
+  CDX reader implements. A report without `core` is rejected.
+- A vector may carry `requires: [key, …]`. If you declare every required
+  capability, the vector runs. If not:
+  - **Vector cases (Level 0)** are **skipped** — reported explicitly, counted on
+    their own, never a silent pass.
+  - **Document-fixture cases (Level 1+)** are *not* skipped for a missing
+    **extension**: they take the specification's own degradation path as an
+    alternate expectation — a *required* extension you do not support MUST make
+    the document REJECT, an *optional* one MUST be IGNORED (State Machine §5.4.2,
+    the unsupported-required-extension and unsupported-optional-extension rows;
+    Extensions README, forward-compatibility). This tests the degradation path
+    instead of leaving a hole. (Fixtures arrive later; the rule is stated here so
+    the contract is complete.)
+- **Experimental constructs** (e.g. ML-DSA-65, blockchain anchors) are a
+  normative exclusion, not a capability: no case depends on one.
+
+Declare only what you genuinely support. This repository's reference adapter, for
+instance, does **not** declare `hash:blake3` — it recognises the identifier but
+cannot compute the digest, and claiming it would be a false report.
+
+The shipped Level-0 vectors gate on these capabilities: `document-id` is pure
+`core`; the manifest projection/scope/errors, JWS, JWK, and multibase vectors
+require `ext:security`; the block-Merkle and provenance-timestamp vectors require
+`provenance`; and the two SHA-384 vectors additionally require `hash:sha-384`. A
+reader that declares only `core` therefore runs the document-ID vectors and is
+scoped out of the rest — a truthful, narrow conformance statement, not a failure.
+
+## MUST vs SHOULD
+
+A vector defaults to **MUST**: a failure is fatal to the run. A vector marked
+`severity: "SHOULD"` is **advisory** — a failure is reported separately and never
+sinks an otherwise-conformant run. SHOULDs are surfaced, never fatal.
+
+## Running the suite
+
+This repository ships a reference Level-0 adapter and a harness.
+
+```sh
+# Produce a report from the reference adapter (the file-based protocol):
+npx tsx scripts/conformance-reference-adapter.ts conformance/ > report.json
+
+# Run the whole gate (engine self-test + suite integrity + end-to-end):
+npm run check:conformance
+```
+
+The reference adapter (`scripts/conformance-reference-adapter.ts`) is the
+smallest complete worked example of everything above. It wraps this
+repository's own libraries; yours wraps your implementation.
+
+## What a PASS means
+
+A passing run is **evidence, not a certificate**. In full, see `suite.json`'s
+`conformanceClaim`; in short:
+
+- A PASS means your implementation reproduced the suite's expected outputs for
+  the cases it ran, at the `(suiteVersion, specVersion)` in the report. It is not
+  a certification, endorsement, or warranty.
+- The suite is a floor, not a ceiling: passing every shipped case does not prove
+  the absence of defects the suite does not exercise.
+- No trademark or "CDX conformant" badge is conferred. Do not represent a PASS as
+  certification by the specification's authors.
+- A conformance claim MUST state the suite version, spec version, adapter level,
+  and declared capabilities under which it was produced.
+
+## Redistribution
+
+The artifacts in this directory may be vendored into your test tree and
+redistributed, provided the non-normative disclaimers and `suite.json`'s
+`conformanceClaim` travel with them. See `suite.json`'s `license`.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -10,11 +10,29 @@
 
 | File | Purpose |
 |------|---------|
+| `suite.json` | The suite manifest: binds a suite version to the specification version its expectations were derived against, defines the adapter levels, and states what a passing run does and does not certify. Start here. |
+| `ADAPTER.md` | How to write an adapter for your implementation — the tiered levels, the file-based protocol, the per-kind report contract, capability scoping, and what a PASS means. |
+| `capabilities.json` | The catalogue of capability keys an adapter declares support for. `core` is mandatory; optional capabilities scope the cases that require them. |
+| `vectors/` | Portable known-answer vectors (`vectors/*.json`), validated by `vectors/vectors.schema.json`. The source of truth for the Level-0 track. |
+| `report.schema.json` | Schema for the JSON an adapter writes to stdout under the file-based protocol. |
 | `errors.json` | The defect-code vocabulary — stable identifiers for defect classes, each carrying the specification clause it comes from and the load-time disposition the specification assigns. |
 | `errors.schema.json` | Schema for `errors.json`, enforced by `check:enumeration-coverage`. Lives here rather than in `schemas/` because everything in `schemas/` describes normative CDX structures. |
 
-More arrives as the conformance suite is built out (portable known-answer
-vectors, document fixtures, test trust material, and an adapter contract).
+The reference Level-0 adapter and the enforcing harness are repo-internal test
+infrastructure: `scripts/conformance-reference-adapter.ts` (the worked example
+that wraps this repository's libraries) and `scripts/check-conformance.ts` (the
+`check:conformance` gate that self-tests the verdict engine and runs the
+reference adapter end-to-end over every published vector).
+
+Document fixtures, test trust material, and the Level-1/2 tracks arrive in later
+phases; `suite.json` records their status.
+
+## The Level-0 vector track
+
+The vectors are deterministic input → deterministic output: no archive, no
+clock, no trust store, no network. An adapter loads them, runs the
+implementation, and reports the actuals; the suite owns every assertion. See
+`ADAPTER.md` for the full contract and the smallest working adapter.
 
 ## The defect-code vocabulary
 

--- a/conformance/capabilities.json
+++ b/conformance/capabilities.json
@@ -1,0 +1,182 @@
+{
+  "normative": false,
+  "$comment": "NON-NORMATIVE. Catalog of capability keys a conformance adapter may declare support for. This is a suite artifact, not part of the CDX specification; it names optional features so a case that depends on one can be scoped, never a skip in disguise. The `clause` on each entry cites where the specification defines the feature and whether it is mandatory to implement.",
+  "suite": "cdx-conformance",
+  "version": "0.1.0",
+  "specVersion": "0.1",
+  "model": {
+    "summary": "An adapter declares the capabilities it supports; the suite scopes each case to what the adapter can actually run.",
+    "rules": [
+      "Every adapter MUST declare `core`. The core baseline is mandatory to implement and is never optional; an adapter that cannot run the core vectors is not a CDX implementation.",
+      "`baseline: true` marks a capability the specification makes mandatory to implement for the track it belongs to (SHA-256 for hashing; ES256 for the security-extension signature track). An adapter that claims a track but omits its baseline capability MUST be reported as non-conformant for that track, not scoped out of it.",
+      "A case may carry `requires: [<key>, ...]`. If the adapter declares every required capability, the case runs normally. Otherwise the outcome depends on the case's track:",
+      "  • Vector cases (Level 0) with an unmet requirement are SKIPPED — reported explicitly, never silently, and counted separately from passes and failures.",
+      "  • Document-fixture cases (Level 1+) with an unmet EXTENSION requirement are not skipped: they take the specification's own degradation path as an alternate expectation — an unsupported required extension MUST make the document REJECT and an unsupported optional extension MUST be IGNORED (State Machine section 5.4.2, the unsupported-required-extension and unsupported-optional-extension rows; Extensions README, forward-compatibility). This tests the degradation path instead of leaving a hole. (Fixtures arrive in a later phase; the rule is stated here so the contract is complete.)",
+      "Experimental constructs are a normative exclusion, not a capability: a case MUST NOT depend on one. They are listed with `experimental: true` for documentation only and carry no vectors.",
+      "Any RFC 2119 keyword (MUST / SHOULD) in this file either restates a disposition the specification already assigns or governs suite-claim etiquette; it never imposes a new CDX-format requirement. This artifact is non-normative."
+    ]
+  },
+  "capabilities": {
+    "core": {
+      "group": "core",
+      "baseline": true,
+      "summary": "The mandatory baseline every CDX reader implements: content canonicalization (RFC 8785 JCS), document-ID computation, and SHA-256. Signature, key, and manifest-projection machinery is NOT core — it belongs to the security extension (ext:security); provenance verification is its own capability (provenance).",
+      "clause": "Document Hashing sections 2-4 (canonicalization, hash format, and document ID; SHA-256 is the one mandatory algorithm, section 3.2)"
+    },
+    "hash:sha-384": {
+      "group": "hash",
+      "baseline": false,
+      "summary": "SHA-384 digest algorithm, selected by a `sha384:` value prefix.",
+      "clause": "Document Hashing section 3.2 (SHA-256 mandatory; other algorithms OPTIONAL)"
+    },
+    "hash:sha-512": {
+      "group": "hash",
+      "baseline": false,
+      "summary": "SHA-512 digest algorithm, selected by a `sha512:` value prefix.",
+      "clause": "Document Hashing section 3.2"
+    },
+    "hash:sha3-256": {
+      "group": "hash",
+      "baseline": false,
+      "summary": "SHA3-256 digest algorithm, selected by a `sha3-256:` value prefix.",
+      "clause": "Document Hashing section 3.2"
+    },
+    "hash:sha3-512": {
+      "group": "hash",
+      "baseline": false,
+      "summary": "SHA3-512 digest algorithm, selected by a `sha3-512:` value prefix.",
+      "clause": "Document Hashing section 3.2"
+    },
+    "hash:blake3": {
+      "group": "hash",
+      "baseline": false,
+      "summary": "BLAKE3 digest algorithm, selected by a `blake3:` value prefix.",
+      "clause": "Document Hashing section 3.2"
+    },
+    "sig:es256": {
+      "group": "signature",
+      "baseline": true,
+      "summary": "ECDSA P-256 with SHA-256 (COSE/JOSE ES256). Mandatory to support for any implementation of the security extension.",
+      "clause": "Security Extension README (Implementations MUST support ES256)"
+    },
+    "sig:es384": {
+      "group": "signature",
+      "baseline": false,
+      "summary": "ECDSA P-384 with SHA-384 (ES384).",
+      "clause": "Security Extension README (other algorithms RECOMMENDED)"
+    },
+    "sig:eddsa": {
+      "group": "signature",
+      "baseline": false,
+      "summary": "Edwards-curve signatures (EdDSA / Ed25519).",
+      "clause": "Security Extension README"
+    },
+    "sig:ps256": {
+      "group": "signature",
+      "baseline": false,
+      "summary": "RSASSA-PSS with SHA-256 (PS256).",
+      "clause": "Security Extension README"
+    },
+    "provenance": {
+      "group": "provenance",
+      "baseline": false,
+      "summary": "Provenance and lineage verification constructs: the cdx-bmt-1 block-Merkle tree (leaf/root/inclusion) and the RFC 3161 / aggregated provenance-timestamp binding. An implementation that does not verify these is scoped out of the provenance vectors rather than failed.",
+      "clause": "Provenance and Lineage sections 4-6 (block Merkle, sections 4-5; timestamp binding, section 6)"
+    },
+    "did:key": {
+      "group": "identity",
+      "baseline": false,
+      "summary": "did:key identity resolution (self-certifying, offline).",
+      "clause": "Security Extension section 3.11 (key identity resolution)"
+    },
+    "did:jwk": {
+      "group": "identity",
+      "baseline": false,
+      "summary": "did:jwk identity resolution (self-certifying, offline).",
+      "clause": "Security Extension section 3.11 (key identity resolution)"
+    },
+    "did:web": {
+      "group": "identity",
+      "baseline": false,
+      "summary": "did:web identity resolution. Network resolution and its SSRF surface are out of scope for the suite; only offline/static did:web is exercisable.",
+      "clause": "Security Extension section 3.11 (key identity resolution)"
+    },
+    "webauthn": {
+      "group": "identity",
+      "baseline": false,
+      "summary": "WebAuthn/passkey credential verification.",
+      "clause": "Security Extension section 6 (WebAuthn signatures)"
+    },
+    "timestamp:rfc3161": {
+      "group": "timestamp",
+      "baseline": false,
+      "summary": "RFC 3161 trusted-timestamp-authority verification (validating a TSA token and its chain), as distinct from the structural binding the `provenance` capability covers.",
+      "clause": "Provenance and Lineage section 6.3 (RFC 3161 timestamps)"
+    },
+    "encryption": {
+      "group": "encryption",
+      "baseline": false,
+      "summary": "Encrypted-part handling (security extension encryption.json).",
+      "clause": "Security Extension section 4 (encryption)"
+    },
+    "ext:semantic": {
+      "group": "extension",
+      "baseline": false,
+      "summary": "The `semantic` extension namespace (bibliography, glossary).",
+      "clause": "Extensions README (namespace registry)"
+    },
+    "ext:academic": {
+      "group": "extension",
+      "baseline": false,
+      "summary": "The `academic` extension namespace (theorems, equations, numbering).",
+      "clause": "Extensions README (namespace registry)"
+    },
+    "ext:forms": {
+      "group": "extension",
+      "baseline": false,
+      "summary": "The `forms` extension namespace.",
+      "clause": "Extensions README (namespace registry)"
+    },
+    "ext:collaboration": {
+      "group": "extension",
+      "baseline": false,
+      "summary": "The `collaboration` extension namespace (comments, changes).",
+      "clause": "Extensions README (namespace registry)"
+    },
+    "ext:security": {
+      "group": "extension",
+      "baseline": false,
+      "summary": "The `security` extension: manifest projection, JWS protected header and signing input, JWK thumbprint, multibase key decoding, signatures and encryption. A reader without it rejects a required-security document rather than verifying signatures.",
+      "clause": "Security Extension sections 3.3-3.4, 3.11, 9.5, 9.7; Extensions README (namespace registry)"
+    },
+    "ext:phantoms": {
+      "group": "extension",
+      "baseline": false,
+      "summary": "The `phantoms` extension namespace (clusters).",
+      "clause": "Extensions README (namespace registry)"
+    },
+    "ext:presentation": {
+      "group": "extension",
+      "baseline": false,
+      "summary": "The `presentation` extension namespace.",
+      "clause": "Extensions README (namespace registry)"
+    },
+    "ext:legal": {
+      "group": "extension",
+      "baseline": false,
+      "summary": "The `legal` extension namespace.",
+      "clause": "Extensions README (namespace registry)"
+    }
+  },
+  "experimental": {
+    "$comment": "Experimental constructs are a NORMATIVE EXCLUSION (Introduction section on experimental status): the suite carries no cases for them and no adapter is asked about them. Listed for documentation only.",
+    "sig:ml-dsa-65": {
+      "summary": "ML-DSA-65 post-quantum signatures.",
+      "clause": "Security Extension (experimental); Introduction (experimental constructs excluded from conformance)"
+    },
+    "anchor:blockchain": {
+      "summary": "Blockchain anchoring of provenance.",
+      "clause": "Provenance and Lineage (experimental)"
+    }
+  }
+}

--- a/conformance/report.schema.json
+++ b/conformance/report.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdx.dev/conformance/report.schema.json",
+  "title": "CDX Conformance Adapter Report",
+  "description": "NON-NORMATIVE. The JSON an adapter writes to stdout under the file-based conformance protocol. It reports what the implementation under test PRODUCED for each vector; it never states pass or fail. The suite decides the verdict (see conformance/ADAPTER.md).",
+  "type": "object",
+  "required": ["suite", "suiteVersion", "specVersion", "adapter", "capabilities", "results"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "suite": { "const": "cdx-conformance" },
+    "suiteVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "The suite version the adapter ran against. The harness rejects a report whose suiteVersion is not the running suite's."
+    },
+    "specVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+$"
+    },
+    "adapter": {
+      "type": "object",
+      "required": ["name", "version", "level"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "level": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2,
+          "description": "The highest adapter level implemented (0 = vectors, 1 = fixtures + clock, 2 = trust + resolver injection)."
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[a-z0-9]+(:[a-z0-9-]+)?$" },
+      "uniqueItems": true,
+      "contains": { "const": "core" },
+      "description": "Capability keys the adapter declares (from capabilities.json). MUST contain `core`. A vector whose `requires[]` names a key absent here is scoped out."
+    },
+    "results": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/result" }
+    }
+  },
+  "$defs": {
+    "result": {
+      "type": "object",
+      "required": ["kind", "name", "outcome"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "outcome": {
+          "enum": ["value", "error", "skip"],
+          "description": "`value`: the operation produced `values`. `error`: it raised (report the mapped suite code in `error`). `skip`: the adapter declined this vector."
+        },
+        "values": {
+          "type": "object",
+          "description": "The actual outputs, keyed as the kind's contract defines (see ADAPTER.md). Present when outcome is `value`."
+        },
+        "error": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "type": ["string", "null"],
+              "description": "The suite defect code (conformance/errors.json) the adapter mapped its native error to, or null if it has no mapping."
+            }
+          },
+          "description": "Present when outcome is `error`."
+        },
+        "skip": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": { "type": "string" }
+          },
+          "description": "Present when outcome is `skip`."
+        }
+      }
+    }
+  }
+}

--- a/conformance/suite.json
+++ b/conformance/suite.json
@@ -1,0 +1,86 @@
+{
+  "normative": false,
+  "$comment": "NON-NORMATIVE. This is the entry-point manifest for the CDX conformance suite, a testing artifact that references the specification and never extends it. The specification (spec/) and the published schemas (schemas/) are the only normative artifacts. Where anything here appears to disagree with spec/, the specification governs.",
+  "suite": "cdx-conformance",
+  "suiteVersion": "0.1.0",
+  "specVersion": "0.1",
+  "title": "CDX Conformance Suite",
+  "description": "An independently-runnable suite that lets a third-party implementation check itself against the CDX specification. This manifest binds a suite version to the specification version its expectations were derived against.",
+  "versioning": {
+    "summary": "suiteVersion is the suite's own semantic version; specVersion is the CDX specification version every expectation in the suite was derived against.",
+    "rules": [
+      "suiteVersion follows semantic versioning. A patch bump fixes a vector or a harness bug without changing any expectation an implementation is held to; a minor bump adds cases or capabilities; a major bump changes or removes an existing expectation.",
+      "specVersion pins the specification revision the suite's clause citations and expectations resolve against. A suite release targets exactly one specVersion.",
+      "An implementation claims conformance against a (suiteVersion, specVersion) pair, never against 'the suite' unqualified."
+    ]
+  },
+  "levels": {
+    "$comment": "The adapter contract is tiered so the common case is trivial to adopt and the intrusive hooks are only required where a case actually needs them. A case declares the lowest level it requires; an adapter declares the highest level it implements. `hooks` names the harness injection points a level needs — distinct from the vector-level capability keys in capabilities.json.",
+    "0": {
+      "title": "Vectors",
+      "summary": "Pure known-answer vectors: deterministic input in, deterministic output out. No document archive, no clock, no trust store, no network. Adoptable in a few dozen lines — load the vectors, run your function, compare.",
+      "hooks": [],
+      "status": "shipped"
+    },
+    "1": {
+      "title": "Fixtures + clock",
+      "summary": "Whole-document archive fixtures verified against a per-case virtual reference clock. Adds an archive reader and an injectable clock.",
+      "hooks": ["archive-reader", "virtual-clock"],
+      "status": "planned"
+    },
+    "2": {
+      "title": "Trust + resolver injection",
+      "summary": "Fixtures whose verdict depends on an injected trust store and an injected identity resolver (DID / key resolution). The intrusive hooks most implementations hard-wire.",
+      "hooks": ["trust-store-injection", "resolver-injection"],
+      "status": "planned"
+    }
+  },
+  "tracks": {
+    "vectors": {
+      "level": 0,
+      "status": "shipped",
+      "location": "vectors/",
+      "schema": "vectors/vectors.schema.json",
+      "summary": "Portable known-answer vectors. Each file's `oracle` field records how its expected values were derived — never from the implementation under test."
+    },
+    "fixtures": {
+      "level": 1,
+      "status": "planned",
+      "summary": "Whole-document archive fixtures with per-finding verdicts. Requires the reference reader and test trust material that later phases add."
+    }
+  },
+  "artifacts": {
+    "readme": "README.md",
+    "adapterContract": "ADAPTER.md",
+    "vectors": "vectors/",
+    "vectorSchema": "vectors/vectors.schema.json",
+    "capabilities": "capabilities.json",
+    "errorVocabulary": "errors.json",
+    "errorVocabularySchema": "errors.schema.json",
+    "reportSchema": "report.schema.json"
+  },
+  "referenceAdapter": {
+    "$comment": "This repository's own Level-0 adapter, which wraps its reference libraries and is the subject of the check:conformance gate. It is repo-internal test infrastructure, not a redistributable artifact — a third-party implementation writes its own adapter (see ADAPTER.md).",
+    "path": "../scripts/conformance-reference-adapter.ts",
+    "level": 0
+  },
+  "conformanceClaim": {
+    "$comment": "What a passing run does and does not mean. This mirrors the specification's own honesty about the limits of what a signature attests (Security Extension section 8.5).",
+    "summary": "A passing run is evidence, not a certificate.",
+    "statements": [
+      "A PASS means the implementation reproduced the suite's expected outputs for the cases it ran, at the (suiteVersion, specVersion) recorded in the report. It is not a certification, an endorsement, or a warranty of specification conformance.",
+      "The suite is a floor, not a ceiling: passing every shipped case does not prove the absence of defects the suite does not exercise.",
+      "No trademark, certification mark, or 'CDX conformant' badge is conferred by a PASS. An implementation MUST NOT represent a suite PASS as certification by the specification's authors.",
+      "A claim MUST state the suiteVersion, the specVersion, the adapter level, and the declared capabilities under which it was produced. A claim that omits these is unfalsifiable and MUST NOT be made."
+    ]
+  },
+  "license": {
+    "$comment": "Redistribution terms for the suite artifacts, so an implementation may vendor and ship the vectors with its own test tree.",
+    "summary": "The conformance artifacts in this directory may be copied, embedded, and redistributed for the purpose of testing and demonstrating CDX implementations, provided this notice and the non-normative disclaimers are preserved.",
+    "terms": [
+      "The artifacts under conformance/ are licensed under the same terms as the specification repository (see the repository LICENSE).",
+      "Redistribution — vendored into an implementation's test tree, republished, or embedded — is permitted, provided the NON-NORMATIVE disclaimers and this manifest's conformanceClaim are carried with them.",
+      "Redistribution does not grant any right to represent the redistribution, or an implementation that passes it, as certified or endorsed by the specification's authors."
+    ]
+  }
+}

--- a/conformance/vectors/block-merkle-inclusion.json
+++ b/conformance/vectors/block-merkle-inclusion.json
@@ -6,6 +6,9 @@
   "clause": "Provenance and Lineage section 5.2",
   "description": "cdx-bmt-1 inclusion-proof verification, including must-NOT-verify cases: the legacy duplicate-odd root (CVE-2012-2459 pattern) and an untagged fold value.",
   "oracle": "Expected values were computed by an INDEPENDENT Python oracle (json + hashlib), not by the library under test, so a serializer or folding bug is caught rather than snapshotted.",
+  "requires": [
+    "provenance"
+  ],
   "vectors": [
     {
       "name": "a-in-two-leaf-tree",

--- a/conformance/vectors/block-merkle-leaf.json
+++ b/conformance/vectors/block-merkle-leaf.json
@@ -6,6 +6,9 @@
   "clause": "Provenance and Lineage section 4.2",
   "description": "The tagged leaf hash H(0x00 || JCS(block)) of a content block.",
   "oracle": "Expected values were computed by an INDEPENDENT Python oracle (json + hashlib), not by the library under test, so a serializer or folding bug is caught rather than snapshotted.",
+  "requires": [
+    "provenance"
+  ],
   "vectors": [
     {
       "name": "paragraph-leaf",

--- a/conformance/vectors/block-merkle-root.json
+++ b/conformance/vectors/block-merkle-root.json
@@ -6,6 +6,9 @@
   "clause": "Provenance and Lineage section 4.3",
   "description": "cdx-bmt-1 tagged Merkle roots, including the single-leaf identity and odd-node promotion.",
   "oracle": "Expected values were computed by an INDEPENDENT Python oracle (json + hashlib), not by the library under test, so a serializer or folding bug is caught rather than snapshotted.",
+  "requires": [
+    "provenance"
+  ],
   "vectors": [
     {
       "name": "single-leaf-root-leaf",

--- a/conformance/vectors/document-id.json
+++ b/conformance/vectors/document-id.json
@@ -137,6 +137,9 @@
     {
       "name": "sha384-document",
       "description": "The document-ID algorithm follows the id prefix (sha384), not a hardcoded default.",
+      "requires": [
+        "hash:sha-384"
+      ],
       "algorithm": "sha384",
       "parts": {
         "manifest": "{}",

--- a/conformance/vectors/jwk-thumbprint.json
+++ b/conformance/vectors/jwk-thumbprint.json
@@ -6,6 +6,9 @@
   "clause": "Security Extension section 3.11",
   "description": "RFC 7638 JWK thumbprints over the canonical member set (RFC 8037 for OKP).",
   "oracle": "Expected bytes are HAND-AUTHORED and their digests were computed from exactly those bytes by an out-of-band tool (shasum), never by this repository's implementation — so a mistyped vector cannot pass by matching a wrong implementation.",
+  "requires": [
+    "ext:security"
+  ],
   "vectors": [
     {
       "name": "ed25519-rfc8037",

--- a/conformance/vectors/jws-header.json
+++ b/conformance/vectors/jws-header.json
@@ -6,6 +6,9 @@
   "clause": "Security Extension section 3.3",
   "description": "JWS protected-header base64url encoding.",
   "oracle": "Expected bytes are HAND-AUTHORED and their digests were computed from exactly those bytes by an out-of-band tool (shasum), never by this repository's implementation — so a mistyped vector cannot pass by matching a wrong implementation.",
+  "requires": [
+    "ext:security"
+  ],
   "vectors": [
     {
       "name": "minimal-es256",

--- a/conformance/vectors/jws-signing-input.json
+++ b/conformance/vectors/jws-signing-input.json
@@ -6,6 +6,9 @@
   "clause": "Security Extension section 3.4",
   "description": "The detached signing input BASE64URL(protected) + \".\" + JCS(scope).",
   "oracle": "Expected bytes are HAND-AUTHORED and their digests were computed from exactly those bytes by an out-of-band tool (shasum), never by this repository's implementation — so a mistyped vector cannot pass by matching a wrong implementation.",
+  "requires": [
+    "ext:security"
+  ],
   "vectors": [
     {
       "name": "min-content-only",
@@ -63,6 +66,9 @@
     },
     {
       "name": "eddsa-sha384-content-only",
+      "requires": [
+        "hash:sha-384"
+      ],
       "description": "EdDSA + a sha384 document id, confirming alg-agility and a longer hash flow through the construction unchanged.",
       "header": {
         "alg": "EdDSA",

--- a/conformance/vectors/manifest-projection-errors.json
+++ b/conformance/vectors/manifest-projection-errors.json
@@ -6,6 +6,9 @@
   "clause": "Security Extension section 9.7",
   "description": "Manifests a conforming projector MUST reject, each with the defect code it fails closed on (see ../errors.json for each code's disposition).",
   "oracle": "Expected outcomes are hand-derived from the specification's written rule table; the rule text itself is the independent oracle.",
+  "requires": [
+    "ext:security"
+  ],
   "vectors": [
     {
       "name": "pending-id-forbidden",

--- a/conformance/vectors/manifest-projection.json
+++ b/conformance/vectors/manifest-projection.json
@@ -6,6 +6,9 @@
   "clause": "Security Extension section 9.7",
   "description": "The signed manifest projection: the canonical JCS bytes a manifest projects to, and their digest. Several vectors assert on exact key ORDER and carry astral/PUA identifiers to pin UTF-16 code-unit sorting.",
   "oracle": "Expected values were computed by an INDEPENDENT Python oracle (json + hashlib), not by the library under test, so a serializer or folding bug is caught rather than snapshotted.",
+  "requires": [
+    "ext:security"
+  ],
   "vectors": [
     {
       "name": "signed-document-corpus",

--- a/conformance/vectors/manifest-scope.json
+++ b/conformance/vectors/manifest-scope.json
@@ -6,6 +6,9 @@
   "clause": "Security Extension section 9.5",
   "description": "JCS(scope) — the detached payload bytes a signature is computed over.",
   "oracle": "Expected values were computed by an INDEPENDENT Python oracle (json + hashlib), not by the library under test, so a serializer or folding bug is caught rather than snapshotted.",
+  "requires": [
+    "ext:security"
+  ],
   "vectors": [
     {
       "name": "scope-content-only",

--- a/conformance/vectors/multibase.json
+++ b/conformance/vectors/multibase.json
@@ -6,6 +6,9 @@
   "clause": "Security Extension section 3.11",
   "description": "did:key multibase decoding.",
   "oracle": "Expected bytes are HAND-AUTHORED and their digests were computed from exactly those bytes by an out-of-band tool (shasum), never by this repository's implementation — so a mistyped vector cannot pass by matching a wrong implementation.",
+  "requires": [
+    "ext:security"
+  ],
   "vectors": [
     {
       "name": "ed25519-multikey",

--- a/conformance/vectors/provenance-timestamp.json
+++ b/conformance/vectors/provenance-timestamp.json
@@ -6,6 +6,9 @@
   "clause": "Provenance and Lineage section 6",
   "description": "Provenance timestamp binding: which member each type keys on, and the untagged section 6.5 aggregated Merkle fold.",
   "oracle": "Expected values were computed by an INDEPENDENT Python oracle (json + hashlib), not by the library under test, so a serializer or folding bug is caught rather than snapshotted.",
+  "requires": [
+    "provenance"
+  ],
   "vectors": [
     {
       "name": "rfc3161-bound",

--- a/conformance/vectors/vectors.schema.json
+++ b/conformance/vectors/vectors.schema.json
@@ -53,6 +53,15 @@
       "minLength": 20,
       "description": "How the expected values were derived. Required because a vector whose expectations came from the implementation under test proves nothing — it snapshots a bug instead of catching it."
     },
+    "requires": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(:[a-z0-9-]+)?$"
+      },
+      "uniqueItems": true,
+      "description": "Capability keys (capabilities.json) that EVERY vector in this file needs — the file exercises a feature gated on them (e.g. the security extension, or provenance verification). Merged with each vector's own `requires`. Absent means the file is pure core and always in scope."
+    },
     "vectors": {
       "type": "array",
       "minItems": 1,
@@ -105,6 +114,22 @@
             }
           },
           "additionalProperties": false
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(:[a-z0-9-]+)?$"
+          },
+          "uniqueItems": true,
+          "description": "Capability keys (from capabilities.json) this vector needs. An adapter that does not declare all of them has the vector SKIPPED — reported explicitly, never counted as a pass. Absent means the vector is pure core and always in scope."
+        },
+        "severity": {
+          "enum": [
+            "MUST",
+            "SHOULD"
+          ],
+          "description": "Normative weight of this vector. Absent defaults to MUST: a failure is fatal. SHOULD failures are advisory and never fatal."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check:lineage": "npx tsx scripts/check-lineage.ts",
     "check:provenance-timestamp": "npx tsx scripts/check-provenance-timestamp.ts",
     "check:conformance-vectors": "npx tsx scripts/check-conformance-vectors.ts",
+    "check:conformance": "npx tsx scripts/check-conformance.ts",
     "check:block-merkle": "npx tsx scripts/check-block-merkle.ts",
     "check:schema-closure": "npx tsx scripts/check-schema-closure.ts",
     "check:spec-examples": "npx tsx scripts/check-spec-examples.ts",

--- a/scripts/check-conformance-vectors.ts
+++ b/scripts/check-conformance-vectors.ts
@@ -91,8 +91,11 @@ console.log('\nDigest self-consistency:');
 {
   const before = failures;
   let checked = 0;
+  // Node's digest names carry the hyphen for the SHA-3 family ('sha3-256'), so
+  // the algorithm prefix is used verbatim — stripping the hyphen would turn
+  // 'sha3-256' into the invalid name 'sha3256'.
   const digest = (alg: string, s: string): string =>
-    `${alg}:${crypto.createHash(alg.replace('-', '')).update(s, 'utf8').digest('hex')}`;
+    `${alg}:${crypto.createHash(alg).update(s, 'utf8').digest('hex')}`;
 
   for (const kind of kinds) {
     for (const v of loadVectorFile<Record<string, string>>(kind).vectors) {

--- a/scripts/check-conformance.ts
+++ b/scripts/check-conformance.ts
@@ -1,0 +1,324 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Enforcing gate for the conformance suite skeleton (Level 0).
+ *
+ * Part 1 — Engine self-test: drives the comparison engine
+ *   (scripts/lib/conformance-suite.ts) through EVERY verdict branch on synthetic
+ *   in-memory fixtures — pass, MUST-fail, SHOULD-advisory, capability-skip,
+ *   adapter self-skip, missing result, error-kind match/mismatch, extra result,
+ *   and the requires-key lint. This is what makes the gate provably able to
+ *   FAIL: without it, an all-green integration run cannot distinguish "the
+ *   engine verified everything" from "the engine can't detect anything".
+ *
+ * Part 2 — Suite integrity: the suite's own artifacts are coherent — every
+ *   published vector kind has a comparator and vice versa; suite.json,
+ *   capabilities.json and report.schema.json are present and internally
+ *   consistent; every vector's `requires[]` names a real capability.
+ *
+ * Part 3 — End-to-end: runs the reference adapter as a SUBPROCESS over the real
+ *   suite (the exact file-based protocol a third-party adapter uses — read the
+ *   suite, write a report to stdout), validates the report against
+ *   report.schema.json, and evaluates it. The reference implementation must PASS
+ *   every published vector, with no skips, no advisories, no missing and no
+ *   extra results — anything else is a real divergence between the reference
+ *   libraries and their own published vectors, surfaced through the very path an
+ *   outside implementation will exercise.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { createAjv } from './lib/ajv-utils.js';
+import { allVectorKinds, loadVectorFile } from './lib/conformance-vectors.js';
+import {
+  comparableKinds,
+  evaluate,
+  scopeOf,
+  validateRequiresKeys,
+  type AdapterReport,
+  type AdapterResult,
+  type SuiteCaseGroup,
+  type SuiteVector,
+} from './lib/conformance-suite.js';
+
+const CONFORMANCE_DIR = path.join(__dirname, '..', 'conformance');
+const ADAPTER = path.join(__dirname, 'conformance-reference-adapter.ts');
+
+let failures = 0;
+const fail = (msg: string): void => {
+  console.log(`  ✗ ${msg}`);
+  failures++;
+};
+const ok = (msg: string): void => console.log(`  ✓ ${msg}`);
+
+// --- Part 1: engine self-test ----------------------------------------------
+console.log('Engine self-test (synthetic fixtures):');
+
+const val = (values: Record<string, unknown>): Pick<AdapterResult, 'outcome' | 'values'> => ({ outcome: 'value', values });
+const err = (code: string): Pick<AdapterResult, 'outcome' | 'error'> => ({ outcome: 'error', error: { code } });
+
+// 1a. Verdict bucketing: one group whose vectors trigger every verdict branch.
+{
+  const groups: SuiteCaseGroup[] = [
+    {
+      kind: 'document-id',
+      vectors: [
+        { name: 'pass', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' },
+        { name: 'must-fail', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' },
+        { name: 'should-fail', severity: 'SHOULD', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' },
+        { name: 'cap-skip', requires: ['hash:blake3'], expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' },
+        { name: 'must-missing', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' },
+        { name: 'should-missing', severity: 'SHOULD', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' },
+        { name: 'self-skip-must', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' },
+      ] as SuiteVector[],
+    },
+    {
+      kind: 'manifest-projection-errors',
+      vectors: [
+        { name: 'err-pass', expect: { code: 'CDX-E-MANIFEST-HASH-MALFORMED' } },
+        { name: 'err-fail', expect: { code: 'CDX-E-MANIFEST-HASH-MALFORMED' } },
+      ] as unknown as SuiteVector[],
+    },
+  ];
+
+  const report: AdapterReport = {
+    suite: 'cdx-conformance',
+    suiteVersion: '0.1.0',
+    specVersion: '0.1',
+    adapter: { name: 'synthetic', version: '0', level: 0 },
+    capabilities: ['core'], // deliberately WITHOUT hash:blake3, so cap-skip skips
+    results: [
+      { kind: 'document-id', name: 'pass', ...val({ canonicalJcs: '{}', id: 'sha256:aa' }) },
+      { kind: 'document-id', name: 'must-fail', ...val({ canonicalJcs: '{}', id: 'sha256:WRONG' }) },
+      { kind: 'document-id', name: 'should-fail', ...val({ canonicalJcs: '{}', id: 'sha256:WRONG' }) },
+      // cap-skip: no result (scoped out before lookup regardless)
+      // must-missing, should-missing: no result
+      { kind: 'document-id', name: 'self-skip-must', outcome: 'skip', skip: { reason: 'demonstration' } },
+      { kind: 'manifest-projection-errors', name: 'err-pass', ...err('CDX-E-MANIFEST-HASH-MALFORMED') },
+      { kind: 'manifest-projection-errors', name: 'err-fail', ...val({}) },
+      { kind: 'document-id', name: 'ghost', ...val({}) }, // extra: no such vector
+    ],
+  };
+
+  const v = evaluate(groups, report);
+  const status = (name: string): string | undefined => v.cases.find((c) => c.name === name)?.status;
+  const expectStatus = (name: string, want: string): void => {
+    const got = status(name);
+    if (got === want) ok(`${name} → ${want}`);
+    else fail(`${name} → expected ${want}, got ${got ?? '(no case)'}`);
+  };
+
+  expectStatus('pass', 'pass');
+  expectStatus('must-fail', 'fail');
+  expectStatus('should-fail', 'fail');
+  expectStatus('cap-skip', 'skip');
+  expectStatus('must-missing', 'missing');
+  expectStatus('should-missing', 'missing');
+  expectStatus('self-skip-must', 'missing'); // a self-skip of an in-scope MUST is a shortfall, not a skip
+  expectStatus('err-pass', 'pass');
+  expectStatus('err-fail', 'fail');
+
+  const check = (label: string, got: number, want: number): void =>
+    got === want ? ok(`${label} = ${want}`) : fail(`${label} = ${got}, expected ${want}`);
+  check('passed', v.passed, 2); // pass, err-pass
+  check('failed (fatal)', v.failed, 4); // must-fail, must-missing, self-skip-must, err-fail
+  check('advisory (non-fatal)', v.advisory, 2); // should-fail, should-missing
+  check('skipped', v.skipped, 1); // cap-skip only (self-skip of a MUST is fatal, not a skip)
+  if (v.extraResults.length === 1 && v.extraResults[0] === 'document-id/ghost') ok('extraResults surfaced');
+  else fail(`extraResults = ${JSON.stringify(v.extraResults)}, expected ["document-id/ghost"]`);
+  if (v.ok === false) ok('overall ok=false (fatal failures present)');
+  else fail('overall ok should be false when fatal failures exist');
+
+  // A clean report over the same groups (all in-scope and matching) must be ok=true.
+  const clean: AdapterReport = {
+    ...report,
+    capabilities: ['core', 'hash:blake3'],
+    results: groups.flatMap((g) =>
+      g.vectors.map((vec) =>
+        g.kind === 'manifest-projection-errors'
+          ? { kind: g.kind, name: vec.name, ...err('CDX-E-MANIFEST-HASH-MALFORMED') }
+          : { kind: g.kind, name: vec.name, ...val({ canonicalJcs: '{}', id: 'sha256:aa' }) },
+      ),
+    ),
+  };
+  const cleanV = evaluate(groups, clean);
+  if (cleanV.ok && cleanV.failed === 0 && cleanV.skipped === 0 && cleanV.passed === 9) ok('clean report → ok=true, 9 passed, 0 fatal, 0 skip');
+  else fail(`clean report verdict wrong: ${JSON.stringify({ ok: cleanV.ok, passed: cleanV.passed, failed: cleanV.failed, skipped: cleanV.skipped })}`);
+}
+
+// 1b. Every comparator's FAIL path fires. The end-to-end run only ever feeds a
+// correct reference, so without this a toothless or wrong-field comparator for
+// 10 of 12 kinds would go undetected. Each row feeds a deliberately-wrong actual
+// and asserts the single case FAILS — one perturbation per asserted field.
+{
+  const NEG: Array<[string, string, SuiteVector, Pick<AdapterResult, 'outcome' | 'values' | 'error'>]> = [
+    ['document-id id', 'document-id', { name: 'n', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' }, val({ canonicalJcs: '{}', id: 'sha256:bb' })],
+    ['document-id jcs', 'document-id', { name: 'n', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' }, val({ canonicalJcs: '{"x":1}', id: 'sha256:aa' })],
+    ['document-id returned-error', 'document-id', { name: 'n', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' }, err('CDX-E-X')],
+    ['manifest-projection jcs', 'manifest-projection', { name: 'n', expectedJcs: '{}', expectedSha256: 'sha256:aa' }, val({ jcs: '{"x":1}', sha256: 'sha256:aa' })],
+    ['manifest-projection sha', 'manifest-projection', { name: 'n', expectedJcs: '{}', expectedSha256: 'sha256:aa' }, val({ jcs: '{}', sha256: 'sha256:bb' })],
+    ['manifest-scope jcs', 'manifest-scope', { name: 'n', expectedJcs: '{}', expectedSha256: 'sha256:aa' }, val({ jcs: '{"x":1}', sha256: 'sha256:aa' })],
+    ['manifest-scope sha', 'manifest-scope', { name: 'n', expectedJcs: '{}', expectedSha256: 'sha256:aa' }, val({ jcs: '{}', sha256: 'sha256:bb' })],
+    ['mpe wrong-code', 'manifest-projection-errors', { name: 'n', expect: { code: 'CDX-E-A' } } as unknown as SuiteVector, err('CDX-E-B')],
+    ['mpe returned-value', 'manifest-projection-errors', { name: 'n', expect: { code: 'CDX-E-A' } } as unknown as SuiteVector, val({})],
+    ['jws-header', 'jws-header', { name: 'n', expectedProtected: 'eyAA' }, val({ protectedHeader: 'eyBB' })],
+    ['jws-signing-input', 'jws-signing-input', { name: 'n', expectedSha256: 'sha256:aa' }, val({ signingInputSha256: 'sha256:bb' })],
+    ['jwk-thumbprint', 'jwk-thumbprint', { name: 'n', expectedJkt: 'aa' }, val({ thumbprint: 'bb' })],
+    ['multibase jwk', 'multibase', { name: 'n', expectedJwk: { kty: 'EC', crv: 'P-256' }, expectedJkt: 'aa' }, val({ jwk: { kty: 'OKP', crv: 'P-256' }, thumbprint: 'aa' })],
+    ['multibase thumbprint', 'multibase', { name: 'n', expectedJwk: { kty: 'EC' }, expectedJkt: 'aa' }, val({ jwk: { kty: 'EC' }, thumbprint: 'bb' })],
+    ['block-merkle-root', 'block-merkle-root', { name: 'n', root: 'sha256:aa' }, val({ root: 'sha256:bb' })],
+    ['block-merkle-inclusion', 'block-merkle-inclusion', { name: 'n', expected: true }, val({ included: false })],
+    ['block-merkle-leaf jcs', 'block-merkle-leaf', { name: 'n', jcs: '{}', hash: 'sha256:aa' }, val({ leafJcs: '{"x":1}', leafHash: 'sha256:aa' })],
+    ['block-merkle-leaf hash', 'block-merkle-leaf', { name: 'n', jcs: '{}', hash: 'sha256:aa' }, val({ leafJcs: '{}', leafHash: 'sha256:bb' })],
+    ['provenance boundToDocument', 'provenance-timestamp', { name: 'n', expected: { boundToDocument: true, problemsEmpty: true } } as unknown as SuiteVector, val({ boundToDocument: false, problemsEmpty: true })],
+    ['provenance problemsEmpty', 'provenance-timestamp', { name: 'n', expected: { boundToDocument: true, problemsEmpty: true } } as unknown as SuiteVector, val({ boundToDocument: true, problemsEmpty: false })],
+    ['provenance merkleVerified', 'provenance-timestamp', { name: 'n', expected: { boundToDocument: true, merkleVerified: true, problemsEmpty: true } } as unknown as SuiteVector, val({ boundToDocument: true, merkleVerified: false, problemsEmpty: true })],
+    ['provenance leaf', 'provenance-timestamp', { name: 'n', expected: { boundToDocument: true, leaf: 'sha256:aa', problemsEmpty: true } } as unknown as SuiteVector, val({ boundToDocument: true, leaf: 'sha256:bb', problemsEmpty: true })],
+  ];
+  const report = (kind: string, result: Pick<AdapterResult, 'outcome' | 'values' | 'error'>): AdapterReport => ({
+    suite: 'cdx-conformance', suiteVersion: '0.1.0', specVersion: '0.1',
+    adapter: { name: 'synthetic', version: '0', level: 0 }, capabilities: ['core'],
+    results: [{ kind, name: 'n', ...result }],
+  });
+  const kindsCovered = new Set<string>();
+  let allFail = true;
+  for (const [label, kind, vector, result] of NEG) {
+    kindsCovered.add(kind);
+    const verdict = evaluate([{ kind, vectors: [vector] }], report(kind, result));
+    if (verdict.cases[0]?.status !== 'fail') { fail(`negative fixture "${label}" did not FAIL (got ${verdict.cases[0]?.status})`); allFail = false; }
+  }
+  if (allFail) ok(`all ${NEG.length} negative fixtures FAILED as required`);
+  const uncovered = comparableKinds().filter((k) => !kindsCovered.has(k));
+  if (uncovered.length === 0) ok(`every comparable kind (${comparableKinds().length}) has a negative fixture`);
+  else fail(`kinds with no negative fixture: ${uncovered.join(', ')}`);
+
+  // multibase JWK compare is by VALUE, not member order: a reordered-but-equal
+  // JWK must PASS (the spec's canonical order is crv,kty,x,y, not the emit order).
+  const reorder = evaluate(
+    [{ kind: 'multibase', vectors: [{ name: 'n', expectedJwk: { kty: 'EC', crv: 'P-256', x: 'a', y: 'b' }, expectedJkt: 'aa' } as SuiteVector] }],
+    report('multibase', val({ jwk: { crv: 'P-256', kty: 'EC', y: 'b', x: 'a' }, thumbprint: 'aa' })),
+  );
+  if (reorder.cases[0]?.status === 'pass') ok('multibase JWK compared by value (member order ignored)');
+  else fail(`multibase reordered JWK should PASS, got ${reorder.cases[0]?.status}: ${reorder.cases[0]?.detail}`);
+}
+
+// 1c. Scoping helpers, file-level requires, and the requires-key lint.
+{
+  const caps = new Set(['core', 'hash:sha-384']);
+  if (scopeOf(['hash:sha-384'], caps).inScope) ok('scopeOf: declared requirement in scope');
+  else fail('scopeOf: declared requirement should be in scope');
+  const s = scopeOf(['hash:blake3'], caps);
+  if (!s.inScope && s.missing[0] === 'hash:blake3') ok('scopeOf: undeclared requirement out of scope');
+  else fail('scopeOf: undeclared requirement should be out of scope');
+
+  // A file-level requirement scopes every vector in the file.
+  const fileGroups: SuiteCaseGroup[] = [{ kind: 'document-id', requires: ['ext:security'], vectors: [{ name: 'n', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' } as SuiteVector] }];
+  const rep = (capsArr: string[]): AdapterReport => ({
+    suite: 'cdx-conformance', suiteVersion: '0.1.0', specVersion: '0.1',
+    adapter: { name: 's', version: '0', level: 0 }, capabilities: capsArr,
+    results: [{ kind: 'document-id', name: 'n', ...val({ canonicalJcs: '{}', id: 'sha256:aa' }) }],
+  });
+  if (evaluate(fileGroups, rep(['core'])).cases[0]?.status === 'skip') ok('file-level requires scopes out an undeclared adapter');
+  else fail('file-level requires should scope out an adapter lacking the capability');
+  if (evaluate(fileGroups, rep(['core', 'ext:security'])).cases[0]?.status === 'pass') ok('file-level requires runs for a declaring adapter');
+  else fail('file-level requires should run for an adapter that declares the capability');
+
+  const catalog = new Set(['core', 'hash:sha-384', 'ext:security']);
+  const lintBad = validateRequiresKeys([{ kind: 'k', requires: ['bogus'], vectors: [{ name: 'v' } as SuiteVector] }], catalog);
+  if (lintBad.length === 1) ok('requires-key lint flags an unknown file-level capability');
+  else fail(`requires-key lint should flag unknown key, got ${JSON.stringify(lintBad)}`);
+  const lintGood = validateRequiresKeys([{ kind: 'k', requires: ['ext:security'], vectors: [{ name: 'v', requires: ['hash:sha-384'] } as SuiteVector] }], catalog);
+  if (lintGood.length === 0) ok('requires-key lint accepts known file- and vector-level capabilities');
+  else fail(`requires-key lint should accept known keys, got ${JSON.stringify(lintGood)}`);
+}
+
+// --- Part 2: suite integrity -----------------------------------------------
+console.log('\nSuite integrity:');
+const suite = JSON.parse(fs.readFileSync(path.join(CONFORMANCE_DIR, 'suite.json'), 'utf8'));
+const capabilitiesDoc = JSON.parse(fs.readFileSync(path.join(CONFORMANCE_DIR, 'capabilities.json'), 'utf8'));
+const catalog = new Set<string>(Object.keys(capabilitiesDoc.capabilities ?? {}));
+
+if (!catalog.has('core')) fail('capabilities.json does not define the mandatory `core` capability');
+else ok('capabilities.json defines `core`');
+
+// Every published vector kind has a comparator, and every comparator kind is published.
+const publishedKinds = allVectorKinds();
+const engineKinds = comparableKinds();
+const missingComparator = publishedKinds.filter((k) => !engineKinds.includes(k));
+const orphanComparator = engineKinds.filter((k) => !publishedKinds.includes(k));
+if (missingComparator.length > 0) fail(`vector kinds with no comparator: ${missingComparator.join(', ')}`);
+if (orphanComparator.length > 0) fail(`comparators with no published vectors: ${orphanComparator.join(', ')}`);
+if (missingComparator.length === 0 && orphanComparator.length === 0) ok(`${publishedKinds.length} kinds each have a comparator`);
+
+// Load every vector file (schema-validated) and lint its requires[] and severities.
+const groups: SuiteCaseGroup[] = [];
+let totalVectors = 0;
+for (const kind of publishedKinds) {
+  const file = loadVectorFile<SuiteVector>(kind);
+  groups.push({ kind, requires: file.requires, vectors: file.vectors });
+  totalVectors += file.vectors.length;
+  for (const v of file.vectors) {
+    if (v.severity !== undefined && v.severity !== 'MUST' && v.severity !== 'SHOULD') {
+      fail(`${kind}/${v.name} has invalid severity ${JSON.stringify(v.severity)}`);
+    }
+  }
+}
+const requiresProblems = validateRequiresKeys(groups, catalog);
+for (const p of requiresProblems) fail(`requires lint — ${p}`);
+if (requiresProblems.length === 0) ok(`${totalVectors} vectors; every requires[] names a real capability`);
+
+// report.schema.json compiles.
+let validateReport: ((r: unknown) => boolean) & { errors?: unknown };
+try {
+  const schema = JSON.parse(fs.readFileSync(path.join(CONFORMANCE_DIR, 'report.schema.json'), 'utf8'));
+  validateReport = createAjv().compile(schema) as typeof validateReport;
+  ok('report.schema.json compiles');
+} catch (err) {
+  fail(`report.schema.json does not compile: ${err instanceof Error ? err.message : String(err)}`);
+  validateReport = () => true;
+}
+
+// --- Part 3: end-to-end reference adapter ----------------------------------
+console.log('\nReference adapter (subprocess, file-based protocol):');
+let report: AdapterReport;
+try {
+  const stdout = execFileSync('npx', ['tsx', ADAPTER, CONFORMANCE_DIR], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  report = JSON.parse(stdout);
+  ok('reference adapter produced a report');
+} catch (err) {
+  fail(`reference adapter failed to run: ${err instanceof Error ? err.message : String(err)}`);
+  report = { suite: 'cdx-conformance', suiteVersion: '', specVersion: '', adapter: { name: '', version: '', level: 0 }, capabilities: ['core'], results: [] };
+}
+
+if (!validateReport(report)) {
+  fail(`adapter report does not validate against report.schema.json: ${JSON.stringify(validateReport.errors)}`);
+} else {
+  ok('report validates against report.schema.json');
+}
+
+// Version binding: the report must target the running suite.
+if (report.suiteVersion !== suite.suiteVersion) fail(`report suiteVersion ${JSON.stringify(report.suiteVersion)} != suite ${JSON.stringify(suite.suiteVersion)}`);
+if (report.specVersion !== suite.specVersion) fail(`report specVersion ${JSON.stringify(report.specVersion)} != suite ${JSON.stringify(suite.specVersion)}`);
+if (report.suiteVersion === suite.suiteVersion && report.specVersion === suite.specVersion) ok(`report binds to suite ${suite.suiteVersion} / spec ${suite.specVersion}`);
+
+const verdict = evaluate(groups, report);
+console.log(`  reference verdict: ${verdict.passed}/${totalVectors} passed, ${verdict.failed} failed, ${verdict.advisory} advisory, ${verdict.skipped} skipped`);
+for (const c of verdict.cases.filter((c) => c.status === 'fail' || c.status === 'missing')) {
+  fail(`${c.kind}/${c.name} — ${c.status}${c.detail ? `: ${c.detail}` : ''}`);
+}
+// The reference implementation must reproduce EVERY published vector: no skips,
+// no advisories, no extras, full pass count.
+if (verdict.skipped > 0) fail(`reference adapter skipped ${verdict.skipped} vector(s); it must run them all`);
+if (verdict.advisory > 0) fail(`reference adapter has ${verdict.advisory} advisory failure(s); it must pass them all`);
+if (verdict.extraResults.length > 0) fail(`reference adapter reported ${verdict.extraResults.length} result(s) with no matching vector: ${verdict.extraResults.join(', ')}`);
+if (verdict.passed !== totalVectors) fail(`reference adapter passed ${verdict.passed} of ${totalVectors} vectors`);
+if (verdict.ok && verdict.passed === totalVectors && verdict.skipped === 0 && verdict.advisory === 0 && verdict.extraResults.length === 0) {
+  ok(`reference implementation conforms to all ${totalVectors} published vectors via the adapter protocol`);
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} failure(s). Conformance check failed.`);
+  process.exit(1);
+}
+console.log('\nConformance suite skeleton verified.');

--- a/scripts/conformance-reference-adapter.ts
+++ b/scripts/conformance-reference-adapter.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Reference conformance adapter (Level 0) for the CDX conformance suite.
+ *
+ * This is a worked example of the file-based adapter protocol AND the subject of
+ * the `check:conformance` gate. It wraps THIS repository's reference libraries;
+ * a third-party adapter wraps its own implementation instead. The shape is the
+ * whole contract:
+ *
+ *   1. Read the suite root (its `suite.json` and `vectors/`), given as argv[2]
+ *      or defaulting to ./conformance.
+ *   2. For each vector, run the implementation and record what it PRODUCED — a
+ *      computed value, or (for the error kind) a native error mapped to a suite
+ *      code. The adapter never decides pass or fail.
+ *   3. Write one report object to stdout (schema: conformance/report.schema.json).
+ *      The suite harness reads it and renders the verdict.
+ *
+ * A minimal adapter in another language does exactly this: loop the vectors,
+ * call your functions, print the actuals. See conformance/ADAPTER.md.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { canonicalContent, computeDocumentId, jcsOf } from './lib/canonicalize.js';
+import { projectManifest, projectManifestToJcs } from './lib/manifest-projection.js';
+import { encodeProtectedHeader, jwsSigningInput } from './lib/jws-envelope.js';
+import { jwkThumbprint, multibaseKeyToJwk } from './lib/keyid-resolution.js';
+import { blockLeafHash, blockMerkleRoot, verifyBlockInclusion } from './lib/block-merkle.js';
+import { checkTimestampBinding } from './lib/provenance-timestamp.js';
+import type { AdapterReport, AdapterResult } from './lib/conformance-suite.js';
+
+const sha256Of = (s: string): string => 'sha256:' + crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+
+/**
+ * Capabilities this implementation genuinely supports at Level 0. Only what the
+ * reference libraries can actually compute or implement is declared:
+ *   - `core` — content canonicalization, document ID, SHA-256 (mandatory).
+ *   - `ext:security` — the security-extension functions (manifest projection,
+ *     JWS protected header / signing input, JWK thumbprint, multibase key).
+ *   - `provenance` — cdx-bmt-1 block-Merkle and RFC 3161 timestamp binding.
+ *   - the optional hash algorithms the platform can compute.
+ * BLAKE3 is deliberately absent: the identifier is recognised but the digest is
+ * not available here (canonicalize.ts throws "not available"), so declaring it
+ * would be a false claim.
+ */
+const CAPABILITIES = ['core', 'ext:security', 'provenance', 'hash:sha-384', 'hash:sha-512', 'hash:sha3-256', 'hash:sha3-512'];
+const CAP_SET = new Set(CAPABILITIES);
+
+/** Outcome of running one vector, minus the kind/name the driver fills in. */
+type RunOutcome = Pick<AdapterResult, 'outcome' | 'values' | 'error'>;
+
+/** One runner per vector kind: vector input in, produced actuals (or a mapped error) out. */
+const RUNNERS: Record<string, (v: Record<string, any>) => RunOutcome> = {
+  'document-id': (v) => ({
+    outcome: 'value',
+    values: {
+      canonicalJcs: jcsOf(canonicalContent(v.parts)),
+      id: computeDocumentId(v.parts, v.algorithm ?? 'sha256'),
+    },
+  }),
+
+  'manifest-projection': (v) => {
+    const jcs = projectManifestToJcs(v.manifest);
+    return { outcome: 'value', values: { jcs, sha256: sha256Of(jcs) } };
+  },
+
+  'manifest-scope': (v) => {
+    const jcs = jcsOf(v.scope);
+    return { outcome: 'value', values: { jcs, sha256: sha256Of(jcs) } };
+  },
+
+  'manifest-projection-errors': (v) => {
+    // The one kind that expects a raised error. The adapter maps its native
+    // error to a suite code at this boundary; the implementation is never asked
+    // to adopt the vocabulary internally.
+    try {
+      projectManifest(v.manifest);
+      return { outcome: 'value', values: {} }; // ran without raising — the harness will fail it
+    } catch (err) {
+      return { outcome: 'error', error: { code: (err as { code?: string }).code ?? null } };
+    }
+  },
+
+  'jws-header': (v) => ({ outcome: 'value', values: { protectedHeader: encodeProtectedHeader(v.header) } }),
+
+  'jws-signing-input': (v) => ({
+    outcome: 'value',
+    values: { signingInputSha256: sha256Of(jwsSigningInput(encodeProtectedHeader(v.header), v.scope)) },
+  }),
+
+  'jwk-thumbprint': (v) => ({ outcome: 'value', values: { thumbprint: jwkThumbprint(v.jwk) } }),
+
+  multibase: (v) => {
+    const jwk = multibaseKeyToJwk(v.multibase);
+    return { outcome: 'value', values: { jwk, thumbprint: jwkThumbprint(jwk) } };
+  },
+
+  'block-merkle-root': (v) => ({ outcome: 'value', values: { root: blockMerkleRoot(v.leaves) } }),
+
+  'block-merkle-inclusion': (v) => ({ outcome: 'value', values: { included: verifyBlockInclusion(v.leaf, v.path, v.root) } }),
+
+  'block-merkle-leaf': (v) => ({ outcome: 'value', values: { leafJcs: jcsOf(v.block), leafHash: blockLeafHash(v.block, 'sha256') } }),
+
+  'provenance-timestamp': (v) => {
+    const got = checkTimestampBinding(v.timestamp, v.documentId);
+    return {
+      outcome: 'value',
+      values: {
+        boundToDocument: got.boundToDocument,
+        merkleVerified: got.merkleVerified,
+        leaf: got.leaf,
+        problemsEmpty: got.problems.length === 0,
+      },
+    };
+  },
+};
+
+function run(kind: string, v: Record<string, any>): RunOutcome {
+  const runner = RUNNERS[kind];
+  if (runner === undefined) {
+    // A kind this adapter does not implement. Declaring it a skip is honest — the
+    // harness surfaces it rather than counting a silent pass.
+    return { outcome: 'skip' } as RunOutcome;
+  }
+  try {
+    return runner(v);
+  } catch (err) {
+    // A positive kind that unexpectedly raised. Report the error faithfully; the
+    // harness fails it against the expected value, surfacing the real defect.
+    return { outcome: 'error', error: { code: (err as { code?: string }).code ?? null } };
+  }
+}
+
+function main(): void {
+  const suiteRoot = process.argv[2] ?? path.join(__dirname, '..', 'conformance');
+  const suite = JSON.parse(fs.readFileSync(path.join(suiteRoot, 'suite.json'), 'utf8'));
+  const vectorsDir = path.join(suiteRoot, 'vectors');
+
+  const results: AdapterResult[] = [];
+  for (const file of fs.readdirSync(vectorsDir).filter((f) => f.endsWith('.json') && !f.endsWith('.schema.json')).sort()) {
+    const doc = JSON.parse(fs.readFileSync(path.join(vectorsDir, file), 'utf8'));
+    const kind: string = doc.kind;
+    const fileRequires: string[] = Array.isArray(doc.requires) ? doc.requires : [];
+    for (const v of doc.vectors as Array<Record<string, any>>) {
+      // Honour capability scoping: skip a vector needing a capability this
+      // adapter did not declare, rather than attempting it and reporting a
+      // spurious error. This models a real capability-scoped adapter.
+      const required = [...fileRequires, ...(Array.isArray(v.requires) ? v.requires : [])];
+      const missing = required.filter((k) => !CAP_SET.has(k));
+      if (missing.length > 0) {
+        results.push({ kind, name: v.name, outcome: 'skip', skip: { reason: `missing capability: ${missing.join(', ')}` } });
+        continue;
+      }
+      results.push({ kind, name: v.name, ...run(kind, v) });
+    }
+  }
+
+  const report: AdapterReport = {
+    suite: 'cdx-conformance',
+    suiteVersion: suite.suiteVersion,
+    specVersion: suite.specVersion,
+    adapter: { name: 'cdx-reference', version: '0.1.0', level: 0 },
+    capabilities: CAPABILITIES,
+    results,
+  };
+  process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+}
+
+main();

--- a/scripts/lib/conformance-suite.ts
+++ b/scripts/lib/conformance-suite.ts
@@ -1,0 +1,351 @@
+/**
+ * Conformance-suite comparison engine (Level 0, vector track).
+ *
+ * This is the authority that turns an adapter's REPORT of what its
+ * implementation produced into a PASS/FAIL verdict. The split is deliberate and
+ * is the crux of the suite's design:
+ *
+ *   - The ADAPTER runs the implementation under test and reports raw ACTUAL
+ *     values (or a mapped error code). It never decides pass or fail and never
+ *     adopts the suite's error vocabulary internally — it maps its native error
+ *     to a suite code at the boundary (see conformance/errors.json).
+ *   - The SUITE owns every assertion. For each vector kind it knows which
+ *     expected fields to compare and how. That knowledge lives in COMPARATORS
+ *     below and nowhere else, so a third-party adapter cannot pass by asserting
+ *     the wrong thing.
+ *
+ * Capability scoping (user decision): a vector may declare `requires: [key,…]`
+ * naming capabilities from conformance/capabilities.json. If the adapter did not
+ * declare a required capability the vector is SKIPPED — reported explicitly and
+ * counted on its own, never silently dropped and never counted as a pass.
+ *
+ * Severity (user decision): a vector defaults to MUST — a failure is fatal. A
+ * vector marked `severity: "SHOULD"` is advisory: a failure is reported but is
+ * never fatal, so a SHOULD can never sink an otherwise-conformant run.
+ *
+ * NON-NORMATIVE: nothing here is part of the CDX specification. The comparators
+ * encode the published vectors' own expected values; the specification governs
+ * where any disagreement arises.
+ */
+
+export type Severity = 'MUST' | 'SHOULD';
+
+/** One vector's result as an adapter reports it. */
+export interface AdapterResult {
+  kind: string;
+  name: string;
+  /** `value`: the function ran and produced `values`. `error`: it raised (map in `error`). `skip`: the adapter declined. */
+  outcome: 'value' | 'error' | 'skip';
+  values?: Record<string, unknown>;
+  error?: { code?: string | null };
+  skip?: { reason?: string };
+}
+
+/** An adapter's whole report — the file-based protocol's stdout payload. */
+export interface AdapterReport {
+  suite: string;
+  suiteVersion: string;
+  specVersion: string;
+  adapter: { name: string; version: string; level: number };
+  capabilities: string[];
+  results: AdapterResult[];
+}
+
+/** A vector as loaded from a vector file, plus the optional scoping members. */
+export interface SuiteVector {
+  name: string;
+  requires?: string[];
+  severity?: Severity;
+  [field: string]: unknown;
+}
+
+/** A vector file reduced to what the engine needs. */
+export interface SuiteCaseGroup {
+  kind: string;
+  /** File-level capability keys every vector in the file needs (the file tests a gated feature). Merged with each vector's own `requires`. */
+  requires?: string[];
+  vectors: SuiteVector[];
+}
+
+export type CaseStatus = 'pass' | 'fail' | 'skip' | 'missing';
+
+export interface CaseVerdict {
+  kind: string;
+  name: string;
+  status: CaseStatus;
+  severity: Severity;
+  /** True when this case counts against the overall verdict (a MUST that did not pass). */
+  fatal: boolean;
+  detail?: string;
+}
+
+export interface SuiteVerdict {
+  cases: CaseVerdict[];
+  passed: number;
+  /** Fatal outcomes: a MUST that failed or a MUST with no reported result. */
+  failed: number;
+  /** Non-fatal failures: a SHOULD that failed or is missing. Surfaced, never fatal. */
+  advisory: number;
+  skipped: number;
+  /** "kind/name" the adapter reported that no vector in the suite claims. */
+  extraResults: string[];
+  ok: boolean;
+}
+
+// --- per-kind assertion authority ------------------------------------------
+
+interface Comparison {
+  pass: boolean;
+  detail?: string;
+}
+
+/**
+ * A comparator receives a vector and its matching result (already confirmed to
+ * exist and to be in scope) and decides pass/fail. It is the ONLY place that
+ * knows a kind's expected-field names and comparison rules.
+ */
+type Comparator = (v: SuiteVector, r: AdapterResult) => Comparison;
+
+const eq = (actual: unknown, expected: unknown, label: string): Comparison =>
+  actual === expected ? { pass: true } : { pass: false, detail: `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}` };
+
+/**
+ * Order-insensitive canonical serialization, for comparing objects whose member
+ * order is not significant. Used for the decoded JWK: RFC 7638 sorts the required
+ * members before hashing, so a JWK's member order does not affect its thumbprint,
+ * and an implementation emitting the spec's canonical order (crv,kty,x,y) must not
+ * be failed for ordering.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+/** Either the values bag (outcome `value`) or the Comparison that already rules the case out. */
+type Values = { ok: true; v: Record<string, unknown> } | { ok: false; comparison: Comparison };
+
+/** Require outcome `value` and return the values bag; otherwise a failure Comparison. */
+function values(r: AdapterResult): Values {
+  if (r.outcome !== 'value') {
+    return { ok: false, comparison: { pass: false, detail: `expected a computed value, adapter reported outcome "${r.outcome}"${r.error?.code ? ` (error ${r.error.code})` : ''}` } };
+  }
+  return { ok: true, v: r.values ?? {} };
+}
+
+const COMPARATORS: Record<string, Comparator> = {
+  'document-id': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    const jcs = eq(a.v.canonicalJcs, v.expectedCanonicalJcs, 'canonicalJcs');
+    if (!jcs.pass) return jcs;
+    return eq(a.v.id, v.expectedId, 'id');
+  },
+
+  'manifest-projection': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    const jcs = eq(a.v.jcs, v.expectedJcs, 'jcs');
+    if (!jcs.pass) return jcs;
+    return eq(a.v.sha256, v.expectedSha256, 'sha256');
+  },
+
+  'manifest-scope': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    const jcs = eq(a.v.jcs, v.expectedJcs, 'jcs');
+    if (!jcs.pass) return jcs;
+    return eq(a.v.sha256, v.expectedSha256, 'sha256');
+  },
+
+  'manifest-projection-errors': (v, r) => {
+    if (r.outcome !== 'error') {
+      return { pass: false, detail: `expected the projection to raise ${JSON.stringify((v.expect as { code: string }).code)}, adapter reported outcome "${r.outcome}"` };
+    }
+    return eq(r.error?.code, (v.expect as { code: string }).code, 'error code');
+  },
+
+  'jws-header': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    return eq(a.v.protectedHeader, v.expectedProtected, 'protectedHeader');
+  },
+
+  'jws-signing-input': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    return eq(a.v.signingInputSha256, v.expectedSha256, 'signingInputSha256');
+  },
+
+  'jwk-thumbprint': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    return eq(a.v.thumbprint, v.expectedJkt, 'thumbprint');
+  },
+
+  multibase: (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    // The decoded JWK is compared by VALUE, not member order. RFC 7638 sorts the
+    // required members before hashing, so member order does not affect the
+    // thumbprint; an implementation that emits the spec's canonical order
+    // (crv,kty,x,y) is correct and must not fail here. The thumbprint check below
+    // carries the cryptographic assertion; this pins the decoded key's values.
+    const jwk = eq(stableStringify(a.v.jwk), stableStringify(v.expectedJwk), 'jwk (by value)');
+    if (!jwk.pass) return jwk;
+    return eq(a.v.thumbprint, v.expectedJkt, 'thumbprint');
+  },
+
+  'block-merkle-root': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    return eq(a.v.root, v.root, 'root');
+  },
+
+  'block-merkle-inclusion': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    return eq(a.v.included, v.expected, 'included');
+  },
+
+  'block-merkle-leaf': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    const jcs = eq(a.v.leafJcs, v.jcs, 'leafJcs');
+    if (!jcs.pass) return jcs;
+    return eq(a.v.leafHash, v.hash, 'leafHash');
+  },
+
+  'provenance-timestamp': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    const e = v.expected as { boundToDocument: boolean; merkleVerified?: boolean; leaf?: string; problemsEmpty: boolean };
+    const bound = eq(a.v.boundToDocument, e.boundToDocument, 'boundToDocument');
+    if (!bound.pass) return bound;
+    // merkleVerified and leaf are asserted only where the vector defines them
+    // (aggregated timestamps carry them; single tokens do not).
+    if (e.merkleVerified !== undefined) {
+      const mv = eq(a.v.merkleVerified, e.merkleVerified, 'merkleVerified');
+      if (!mv.pass) return mv;
+    }
+    if (e.leaf !== undefined) {
+      const lf = eq(a.v.leaf, e.leaf, 'leaf');
+      if (!lf.pass) return lf;
+    }
+    return eq(a.v.problemsEmpty, e.problemsEmpty, 'problemsEmpty');
+  },
+};
+
+/** Every vector kind the engine can compare. A vector file of any other kind is a suite error. */
+export function comparableKinds(): string[] {
+  return Object.keys(COMPARATORS).sort();
+}
+
+// --- capability scoping ----------------------------------------------------
+
+/** The capability keys a vector needs: its file's `requires` plus its own. */
+export function requiresOf(group: SuiteCaseGroup, v: SuiteVector): string[] {
+  return [...(group.requires ?? []), ...(Array.isArray(v.requires) ? v.requires : [])];
+}
+
+/** Decide whether a set of required capabilities is satisfied by an adapter's declared ones. */
+export function scopeOf(requires: readonly string[], capabilities: ReadonlySet<string>): { inScope: boolean; missing: string[] } {
+  const missing = requires.filter((key) => !capabilities.has(key));
+  return { inScope: missing.length === 0, missing };
+}
+
+/**
+ * Lint every vector's required capabilities (file-level + vector-level) against
+ * the capability catalog. A key that is not a defined capability would otherwise
+ * masquerade as a permanent skip (the adapter can never declare a key that does
+ * not exist), so it is a suite authoring error, surfaced here rather than
+ * silently swallowed.
+ */
+export function validateRequiresKeys(groups: SuiteCaseGroup[], catalog: ReadonlySet<string>): string[] {
+  const problems: string[] = [];
+  for (const g of groups) {
+    // File-level keys are linted once per file, not once per vector, so a single
+    // bad file-level key does not fan out into one message per vector.
+    for (const key of g.requires ?? []) {
+      if (!catalog.has(key)) problems.push(`${g.kind} (file-level) requires unknown capability "${key}"`);
+    }
+    for (const v of g.vectors) {
+      for (const key of Array.isArray(v.requires) ? v.requires : []) {
+        if (!catalog.has(key)) problems.push(`${g.kind}/${v.name} requires unknown capability "${key}"`);
+      }
+    }
+  }
+  return problems;
+}
+
+// --- the run ---------------------------------------------------------------
+
+/**
+ * Compare an adapter report against the suite's vectors and produce a verdict.
+ *
+ * Pure: no file IO, no process state. `groups` are the suite's vectors (already
+ * loaded and schema-validated); `report` is the adapter's stdout payload
+ * (already schema-validated). The overall run is `ok` iff no MUST case failed or
+ * went unreported.
+ */
+export function evaluate(groups: SuiteCaseGroup[], report: AdapterReport): SuiteVerdict {
+  const caps = new Set(report.capabilities);
+  const cases: CaseVerdict[] = [];
+  const key = (kind: string, name: string): string => `${kind}/${name}`;
+
+  const byKey = new Map<string, AdapterResult>();
+  for (const r of report.results) byKey.set(key(r.kind, r.name), r);
+  const allVectorKeys = new Set<string>();
+  for (const g of groups) for (const v of g.vectors) allVectorKeys.add(key(g.kind, v.name));
+
+  for (const g of groups) {
+    const comparator = COMPARATORS[g.kind];
+    for (const v of g.vectors) {
+      const severity: Severity = v.severity === 'SHOULD' ? 'SHOULD' : 'MUST';
+      const push = (status: CaseStatus, fatal: boolean, detail?: string): void => {
+        cases.push({ kind: g.kind, name: v.name, status, severity, fatal, detail });
+      };
+
+      const scope = scopeOf(requiresOf(g, v), caps);
+      if (!scope.inScope) {
+        // Legitimately out of scope: the adapter did not declare a required
+        // capability. A skip is never fatal — but it is never a pass either.
+        push('skip', false, `adapter does not declare: ${scope.missing.join(', ')}`);
+        continue;
+      }
+
+      const r = byKey.get(key(g.kind, v.name));
+      // No usable result for an in-scope vector — whether the adapter omitted it
+      // or self-skipped it — is a shortfall, fatal for a MUST. `skip` status is
+      // reserved for out-of-scope cases so an adapter cannot dodge an in-scope
+      // MUST by declining it.
+      if (r === undefined) {
+        push('missing', severity === 'MUST', 'adapter reported no result for this in-scope vector');
+        continue;
+      }
+      if (r.outcome === 'skip') {
+        push('missing', severity === 'MUST', `adapter self-skipped an in-scope vector${r.skip?.reason ? `: ${r.skip.reason}` : ''}`);
+        continue;
+      }
+      if (comparator === undefined) {
+        push('fail', severity === 'MUST', `suite has no comparator for kind "${g.kind}"`);
+        continue;
+      }
+      const cmp = comparator(v, r);
+      push(cmp.pass ? 'pass' : 'fail', !cmp.pass && severity === 'MUST', cmp.detail);
+    }
+  }
+
+  // Extra results are those matching NO vector in the suite. A result for a
+  // scoped-out vector is NOT extra (it matches a known vector), so a legitimate
+  // capability skip does not booby-trap the run.
+  const extraResults = [...new Set(report.results.map((r) => key(r.kind, r.name)).filter((k) => !allVectorKeys.has(k)))].sort();
+
+  const passed = cases.filter((c) => c.status === 'pass').length;
+  const failed = cases.filter((c) => c.fatal).length;
+  const advisory = cases.filter((c) => !c.fatal && (c.status === 'fail' || c.status === 'missing')).length;
+  const skipped = cases.filter((c) => c.status === 'skip').length;
+
+  return { cases, passed, failed, advisory, skipped, extraResults, ok: failed === 0 };
+}

--- a/scripts/lib/conformance-vectors.ts
+++ b/scripts/lib/conformance-vectors.ts
@@ -27,6 +27,8 @@ export interface VectorFile<T> {
   description: string;
   /** How the expected values were derived — never from the code under test. */
   oracle: string;
+  /** File-level capability keys every vector in the file needs (capabilities.json). */
+  requires?: string[];
   vectors: T[];
 }
 


### PR DESCRIPTION
## Summary

Phase A3 of the conformance suite: the runnable Level-0 skeleton and the contract a third-party implementation follows to check itself against the published known-answer vectors.

- **`conformance/suite.json`** — version-binding manifest (suite version × spec version), adapter levels, and an explicit `conformanceClaim`: a PASS is evidence, not a certification, and confers no trademark.
- **`conformance/capabilities.json`** — capability catalogue grounded in the spec (SHA-256/ES256 baseline; optional hashes/sigs/DIDs/extensions), the capability-scoping model, and the alternate-expectation rule for fixtures.
- **`conformance/ADAPTER.md`** — the contract: tiered levels, the file-based protocol (read the suite, write a report to stdout), the per-kind `values`→expected-field table, capability scoping, SHOULD separation, and error-code mapping.
- **`conformance/report.schema.json` + `scripts/lib/conformance-suite.ts`** — the report wire format and the comparison engine. The suite owns every assertion (per-kind comparators); the adapter only reports actuals and maps native errors to suite codes at the boundary.
- **`scripts/conformance-reference-adapter.ts`** — a reference Level-0 adapter wrapping this repo's libraries; declares only genuinely-computable capabilities (notably not BLAKE3).
- **`scripts/check-conformance.ts`** — the `check:conformance` gate (wired into CI).

**Capability scoping keeps the suite honest about what the spec mandates.** Only `document-id` vectors are pure `core`; the security-extension vectors require `ext:security`, the block-Merkle and provenance-timestamp vectors require `provenance`, and the two SHA-384 vectors require `hash:sha-384` (SHA-256 is the one mandatory algorithm). An adapter lacking a capability is scoped out, never failed; SHOULD failures are advisory and never fatal. Without this the suite would force every reader to implement optional algorithms and the security/provenance extensions.

Also fixes a latent SHA-3 digest-name bug in the vector self-consistency check.

## Test plan

- [x] `check:conformance` self-tests every verdict branch and all 12 comparators' fail paths on synthetic fixtures, then runs the reference adapter as a subprocess over all 87 published vectors (0 failed / 0 skipped).
- [x] Mutation-tested both new paths: dropping `ext:security` from the adapter correctly scopes out 46 vectors and fails the gate; a toothless comparator is caught by its negative fixture.
- [x] Full CI-parity suite green: `tsc --noEmit`, `npm test`, all 21 check gates, template generation, `npm audit`.
- [x] Byte round-trip verified for every vector file (the `requires` additions add no value churn).