### PR TITLE
Add canonicalize conformance vectors and independent oracle

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Check conformance suite
         run: npm run check:conformance
 
+      - name: Check canonicalize oracle (independent, non-Node)
+        run: npm run check:canonicalize-oracle
+
       - name: Check block merkle
         run: npm run check:block-merkle
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -15,6 +15,7 @@
 | `capabilities.json` | The catalogue of capability keys an adapter declares support for. `core` is mandatory; optional capabilities scope the cases that require them. |
 | `vectors/` | Portable known-answer vectors (`vectors/*.json`), validated by `vectors/vectors.schema.json`. The source of truth for the Level-0 track. |
 | `report.schema.json` | Schema for the JSON an adapter writes to stdout under the file-based protocol. |
+| `oracles/` | Independent oracle tools that derive vector expectations without this repository's own libraries, so the vectors cannot silently snapshot the code under test. `oracles/canonicalize_oracle.py` (Python stdlib only) generates and re-verifies the `canonicalize` vectors' JCS bytes and digests; `check:canonicalize-oracle` runs it in CI. |
 | `errors.json` | The defect-code vocabulary — stable identifiers for defect classes, each carrying the specification clause it comes from and the load-time disposition the specification assigns. |
 | `errors.schema.json` | Schema for `errors.json`, enforced by `check:enumeration-coverage`. Lives here rather than in `schemas/` because everything in `schemas/` describes normative CDX structures. |
 

--- a/conformance/oracles/canonicalize_oracle.py
+++ b/conformance/oracles/canonicalize_oracle.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Independent oracle for the `canonicalize` conformance vectors.
+
+NON-NORMATIVE. This is a testing artifact. It exists to keep the canonicalization
+vectors HONEST under the suite's oracle discipline: expected values must come from
+an implementation independent of the one under test, never snapshotted from it.
+
+This tool is written in Python and depends only on the standard library
+(`json`, `hashlib`) — it shares no code with this repository's TypeScript
+canonicalizer. It plays two roles:
+
+  * `gen`   — given a hand-authored *canonical object* (the post-canonicalization
+              {content, metadata} structure a human derived by reasoning about the
+              §4.3 rules), emit the RFC 8785 (JCS) serialization and the
+              algorithm-prefixed digest of exactly those bytes. Used while
+              authoring a vector's `expectedCanonicalJcs` / `expectedId`.
+
+  * `check` — re-derive, for every transform vector in canonicalize.json, the
+              digest of the committed `expectedCanonicalJcs` bytes and assert it
+              equals the committed `expectedId`. This proves the byte→hash link
+              with a tool that is not Node, complementing the reference adapter's
+              corroboration of the bytes themselves (two independent serializers
+              agreeing on the JCS is strong evidence it is correct).
+
+Faithfulness note: `json.dumps(..., sort_keys=True, separators=(',', ':'),
+ensure_ascii=False)` matches RFC 8785 for the content these vectors use — keys are
+ASCII (so code-point and UTF-16 key ordering coincide) and numbers are authored in
+already-normalized form (no -0, no exponent forms). Where a vector carries astral
+characters in a string VALUE, array order is authored explicitly and json.dumps
+preserves it. The reference adapter (this repo's TS canonicalizer) independently
+reproduces every `expectedCanonicalJcs`, so any divergence would fail the gate.
+"""
+
+import hashlib
+import json
+import sys
+
+_HASH = {
+    "sha256": hashlib.sha256,
+    "sha384": hashlib.sha384,
+    "sha512": hashlib.sha512,
+    "sha3-256": hashlib.sha3_256,
+    "sha3-512": hashlib.sha3_512,
+}
+
+
+def jcs(obj) -> str:
+    """RFC 8785 JCS for the (ASCII-key, pre-normalized-number) content used here."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def digest(algorithm: str, data: str) -> str:
+    if algorithm not in _HASH:
+        raise SystemExit(f"unsupported algorithm: {algorithm}")
+    return f"{algorithm}:{_HASH[algorithm](data.encode('utf-8')).hexdigest()}"
+
+
+def gen() -> int:
+    """Read a hand-authored canonical object from stdin; emit its JCS and id.
+
+    Stdin is JSON: either {"canonical": <object>, "algorithm": "sha256"} or a bare
+    <object> (algorithm defaults to sha256).
+    """
+    raw = json.load(sys.stdin)
+    if isinstance(raw, dict) and "canonical" in raw:
+        obj = raw["canonical"]
+        algorithm = raw.get("algorithm", "sha256")
+    else:
+        obj, algorithm = raw, "sha256"
+    body = jcs(obj)
+    print(json.dumps({"expectedCanonicalJcs": body, "expectedId": digest(algorithm, body)}, ensure_ascii=False))
+    return 0
+
+
+def check(path: str) -> int:
+    with open(path, encoding="utf-8") as fh:
+        doc = json.load(fh)
+    failures = 0
+    checked = 0
+    for v in doc.get("vectors", []):
+        body = v.get("expectedCanonicalJcs")
+        expected = v.get("expectedId")
+        if body is None or expected is None:
+            continue  # a reject vector, or one that pins no id
+        algorithm = v.get("algorithm", "sha256")
+        actual = digest(algorithm, body)
+        if actual != expected:
+            print(f"  MISMATCH {v['name']}: expectedId {expected} != sha({algorithm}) {actual}")
+            failures += 1
+        else:
+            checked += 1
+    if failures:
+        print(f"{failures} vector(s) failed the independent byte->hash check.")
+        return 1
+    print(f"OK: {checked} canonicalize vector id(s) match the independent digest of their bytes.")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) >= 2 and sys.argv[1] == "gen":
+        return gen()
+    path = sys.argv[2] if len(sys.argv) >= 3 and sys.argv[1] == "check" else "conformance/vectors/canonicalize.json"
+    return check(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/vectors/canonicalize.json
+++ b/conformance/vectors/canonicalize.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "./vectors.schema.json",
+  "suite": "cdx-conformance",
+  "specVersion": "0.1",
+  "kind": "canonicalize",
+  "clause": "Document Hashing section 4.3 (canonical content form)",
+  "description": "Canonical content form (§4.3): fine-grained transform behaviours (marks normalization, text-node merge, derived-field and crdt stripping) and inputs a conformant canonicalizer MUST reject (§4.3.2).",
+  "oracle": "Expected canonical objects are HAND-AUTHORED by reasoning about the §4.3 rules; their JCS bytes and digests come from the independent Python oracle at conformance/oracles/canonicalize_oracle.py (stdlib json + hashlib, sharing no code with this repository’s canonicalizer). A reject vector asserts only that a conformant implementation refuses the input; §4.3.2 makes these inputs ones a reader MUST reject, and canonicalization defects carry no portable code, so no identifier is asserted.",
+  "vectors": [
+    {
+      "name": "marks-empty-omitted",
+      "description": "An empty marks array on a text node is omitted entirely (absent ≡ []); §4.3.1 item 3.",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"x\",\"marks\":[]}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"x\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:2c37b02419f2e517fab21b3f775609c6a8ba3ed6a2147be448616892b26a172f"
+    },
+    {
+      "name": "text-merge-differing-marks-preserved",
+      "description": "Adjacent text nodes with equal (here empty) mark-sets merge; a node with a differing mark-set does not (§4.3.1 item 4).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"Hello \"},{\"type\":\"text\",\"value\":\"brave \"},{\"type\":\"text\",\"value\":\"world\",\"marks\":[\"bold\"]}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"Hello brave \"},{\"marks\":[\"bold\"],\"type\":\"text\",\"value\":\"world\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:21983ca242620aad1bf09ecc462515802cc7971a874a3bf542ef0df861677f91"
+    },
+    {
+      "name": "crdt-stripped-from-block",
+      "description": "A block’s crdt field is stripped and its author-chosen id is alpha-renamed to b0 (§4.3.1 items 1 and 5; §4.1a).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"id\":\"para1\",\"crdt\":{\"seq\":5},\"children\":[{\"type\":\"text\",\"value\":\"hi\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"hi\"}],\"id\":\"b0\",\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:ad2d4b942fd00819c6c679fbfbda58af3a6ab998d21e80dda806be770c8f1837"
+    },
+    {
+      "name": "reject-duplicate-key-manifest",
+      "description": "A duplicate key anywhere in a part (here manifest) is rejected by strict parsing (§4.3.2 item 3).",
+      "parts": {
+        "manifest": "{\"assets\":{},\"assets\":{}}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectReject": true
+    },
+    {
+      "name": "reject-non-nfc-text",
+      "description": "A stored string not in Unicode NFC is rejected, never silently normalized (§4.3.2). Here “cafe” + combining acute (NFD).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"café\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectReject": true
+    },
+    {
+      "name": "reject-unsafe-integer",
+      "description": "An integer beyond the 2^53-1 safe range is rejected (§4.3.2).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"measurement\",\"value\":9007199254740992}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectReject": true
+    },
+    {
+      "name": "text-non-text-child-breaks-run",
+      "description": "A non-text inline child breaks a run of text nodes: the surrounding text nodes are not merged across it (§4.3.1 item 4).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"a\"},{\"type\":\"break\"},{\"type\":\"text\",\"value\":\"b\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"a\"},{\"type\":\"break\"},{\"type\":\"text\",\"value\":\"b\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:d44399a95ec3cdeb074d4cef5e140fcfaf2cb9bc00515f304e9fa1639af8b0c8"
+    },
+    {
+      "name": "crdt-stripped-from-text-then-merges",
+      "description": "crdt is stripped from a text node; the node, now bearing no distinguishing field, merges with its equal-marked neighbour (§4.3.1 items 1 and 4).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"a\",\"crdt\":{\"seq\":1}},{\"type\":\"text\",\"value\":\"b\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"ab\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:5023030a0678e05fd137f822df253997a181aa2a07aa833de0fc072846832158"
+    },
+    {
+      "name": "crdt-stripped-from-extension-block",
+      "description": "crdt stripping is namespace-agnostic: it applies to an unknown namespace:type extension block just as to a core block (§4.3.1 item 1).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"forms:textInput\",\"name\":\"email\",\"crdt\":{\"seq\":1}}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"name\":\"email\",\"type\":\"forms:textInput\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:26969ece0bb4b5be8a37194e92d656777b425195bf9cbc9df9c3bd2a5b58cbb7"
+    },
+    {
+      "name": "alpha-rename-nested-block-document-order",
+      "description": "Block ids are assigned b0,b1,… in document order, and a nested block follows its parent (§4.3.1 item 5): blockquote b0 > paragraph b1, then paragraph b2.",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"blockquote\",\"id\":\"q\",\"children\":[{\"type\":\"paragraph\",\"id\":\"p\",\"children\":[{\"type\":\"text\",\"value\":\"x\"}]}]},{\"type\":\"paragraph\",\"id\":\"after\",\"children\":[{\"type\":\"text\",\"value\":\"y\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"children\":[{\"type\":\"text\",\"value\":\"x\"}],\"id\":\"b1\",\"type\":\"paragraph\"}],\"id\":\"b0\",\"type\":\"blockquote\"},{\"children\":[{\"type\":\"text\",\"value\":\"y\"}],\"id\":\"b2\",\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:aa1d6cece174c557a7dc2d5d8298ffd50999853af94b2a8332df9616af378972"
+    },
+    {
+      "name": "alpha-rename-href-offset-suffix-and-unresolved",
+      "description": "A #blockId reference is rewritten to the canonical name and keeps its /offset suffix (#sec/10-25 → #b0/10-25); an unresolved #ref (#ghost) is left verbatim; the marks re-sort after rewriting (§4.3.1 items 3 and 5).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"heading\",\"level\":1,\"id\":\"sec\",\"children\":[{\"type\":\"text\",\"value\":\"H\"}]},{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"see\",\"marks\":[{\"type\":\"link\",\"href\":\"#sec/10-25\"},{\"type\":\"link\",\"href\":\"#ghost\"}]}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"H\"}],\"id\":\"b0\",\"level\":1,\"type\":\"heading\"},{\"children\":[{\"marks\":[{\"href\":\"#b0/10-25\",\"type\":\"link\"},{\"href\":\"#ghost\",\"type\":\"link\"}],\"type\":\"text\",\"value\":\"see\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:5b62221fee1ef652b6fcef9f4189ff53de0b80c0c56288fd1a76eb68c8ebf9ef"
+    },
+    {
+      "name": "reject-duplicate-block-id",
+      "description": "Two blocks sharing an id in the identifier namespace is a duplicate-id error (§4.3.1 item 5).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"id\":\"dup\",\"children\":[{\"type\":\"text\",\"value\":\"a\"}]},{\"type\":\"paragraph\",\"id\":\"dup\",\"children\":[{\"type\":\"text\",\"value\":\"b\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectReject": true
+    }
+  ]
+}

--- a/conformance/vectors/vectors.schema.json
+++ b/conformance/vectors/vectors.schema.json
@@ -37,7 +37,8 @@
         "block-merkle-root",
         "block-merkle-inclusion",
         "block-merkle-leaf",
-        "provenance-timestamp"
+        "provenance-timestamp",
+        "canonicalize"
       ]
     },
     "clause": {
@@ -82,6 +83,23 @@
         "name",
         "description"
       ],
+      "allOf": [
+        {
+          "$comment": "A vector asserts a value or a rejection, never both: expectReject is mutually exclusive with expectedCanonicalJcs.",
+          "if": {
+            "required": [
+              "expectReject"
+            ]
+          },
+          "then": {
+            "not": {
+              "required": [
+                "expectedCanonicalJcs"
+              ]
+            }
+          }
+        }
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -101,6 +119,14 @@
         },
         "expectedSha256": {
           "$ref": "#/$defs/contentHash"
+        },
+        "expectedCanonicalJcs": {
+          "type": "string",
+          "description": "The RFC 8785 (JCS) byte string a faithful canonicalizer MUST produce. Present on a transform vector; absent on a reject vector."
+        },
+        "expectReject": {
+          "const": true,
+          "description": "Marks a vector whose input a conformant implementation MUST reject (the operation errors). Used where no portable defect code exists — the assertion is rejection, not an identifier. Mutually exclusive with expectedCanonicalJcs."
         },
         "expect": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check:provenance-timestamp": "npx tsx scripts/check-provenance-timestamp.ts",
     "check:conformance-vectors": "npx tsx scripts/check-conformance-vectors.ts",
     "check:conformance": "npx tsx scripts/check-conformance.ts",
+    "check:canonicalize-oracle": "python3 conformance/oracles/canonicalize_oracle.py check",
     "check:block-merkle": "npx tsx scripts/check-block-merkle.ts",
     "check:schema-closure": "npx tsx scripts/check-schema-closure.ts",
     "check:spec-examples": "npx tsx scripts/check-spec-examples.ts",

--- a/scripts/check-conformance.ts
+++ b/scripts/check-conformance.ts
@@ -175,6 +175,9 @@ const err = (code: string): Pick<AdapterResult, 'outcome' | 'error'> => ({ outco
     ['provenance problemsEmpty', 'provenance-timestamp', { name: 'n', expected: { boundToDocument: true, problemsEmpty: true } } as unknown as SuiteVector, val({ boundToDocument: true, problemsEmpty: false })],
     ['provenance merkleVerified', 'provenance-timestamp', { name: 'n', expected: { boundToDocument: true, merkleVerified: true, problemsEmpty: true } } as unknown as SuiteVector, val({ boundToDocument: true, merkleVerified: false, problemsEmpty: true })],
     ['provenance leaf', 'provenance-timestamp', { name: 'n', expected: { boundToDocument: true, leaf: 'sha256:aa', problemsEmpty: true } } as unknown as SuiteVector, val({ boundToDocument: true, leaf: 'sha256:bb', problemsEmpty: true })],
+    ['canonicalize jcs', 'canonicalize', { name: 'n', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' }, val({ canonicalJcs: '{"x":1}', id: 'sha256:aa' })],
+    ['canonicalize id', 'canonicalize', { name: 'n', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' }, val({ canonicalJcs: '{}', id: 'sha256:bb' })],
+    ['canonicalize reject-not-rejected', 'canonicalize', { name: 'n', expectReject: true } as unknown as SuiteVector, val({ canonicalJcs: '{}', id: 'sha256:aa' })],
   ];
   const report = (kind: string, result: Pick<AdapterResult, 'outcome' | 'values' | 'error'>): AdapterReport => ({
     suite: 'cdx-conformance', suiteVersion: '0.1.0', specVersion: '0.1',
@@ -201,6 +204,14 @@ const err = (code: string): Pick<AdapterResult, 'outcome' | 'error'> => ({ outco
   );
   if (reorder.cases[0]?.status === 'pass') ok('multibase JWK compared by value (member order ignored)');
   else fail(`multibase reordered JWK should PASS, got ${reorder.cases[0]?.status}: ${reorder.cases[0]?.detail}`);
+
+  // A canonicalize reject vector PASSES when the adapter reports the input errored.
+  const rejectPass = evaluate(
+    [{ kind: 'canonicalize', vectors: [{ name: 'n', expectReject: true } as unknown as SuiteVector] }],
+    report('canonicalize', err('CDX-E-ANY')),
+  );
+  if (rejectPass.cases[0]?.status === 'pass') ok('canonicalize reject vector passes when the input is rejected');
+  else fail(`canonicalize reject vector should PASS on an error outcome, got ${rejectPass.cases[0]?.status}`);
 }
 
 // 1c. Scoping helpers, file-level requires, and the requires-key lint.

--- a/scripts/conformance-reference-adapter.ts
+++ b/scripts/conformance-reference-adapter.ts
@@ -103,6 +103,19 @@ const RUNNERS: Record<string, (v: Record<string, any>) => RunOutcome> = {
 
   'block-merkle-leaf': (v) => ({ outcome: 'value', values: { leafJcs: jcsOf(v.block), leafHash: blockLeafHash(v.block, 'sha256') } }),
 
+  canonicalize: (v) => {
+    // Transform: the canonical JCS and the document id. On invalid input the
+    // library throws, which run() reports as outcome 'error' — exactly what a
+    // reject vector asserts, so reject vectors need no special handling here.
+    return {
+      outcome: 'value',
+      values: {
+        canonicalJcs: jcsOf(canonicalContent(v.parts)),
+        id: computeDocumentId(v.parts, v.algorithm ?? 'sha256'),
+      },
+    };
+  },
+
   'provenance-timestamp': (v) => {
     const got = checkTimestampBinding(v.timestamp, v.documentId);
     return {

--- a/scripts/lib/conformance-suite.ts
+++ b/scripts/lib/conformance-suite.ts
@@ -217,6 +217,23 @@ const COMPARATORS: Record<string, Comparator> = {
     return eq(a.v.leafHash, v.hash, 'leafHash');
   },
 
+  canonicalize: (v, r) => {
+    // A reject vector asserts only that the implementation REJECTS the input
+    // (the operation errors). No portable defect code exists for canonicalization
+    // failures, so the assertion is rejection, never an identifier — §4.3.2 makes
+    // these inputs ones a conformant reader MUST reject.
+    if (v.expectReject === true) {
+      return r.outcome === 'error'
+        ? { pass: true }
+        : { pass: false, detail: `expected the input to be rejected, adapter reported outcome "${r.outcome}"` };
+    }
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    const jcs = eq(a.v.canonicalJcs, v.expectedCanonicalJcs, 'canonicalJcs');
+    if (!jcs.pass) return jcs;
+    return v.expectedId !== undefined ? eq(a.v.id, v.expectedId, 'id') : { pass: true };
+  },
+
   'provenance-timestamp': (v, r) => {
     const a = values(r);
     if (!a.ok) return a.comparison;


### PR DESCRIPTION
## Summary

Phase A4a of the conformance suite: a new `canonicalize` vector kind covering the canonical content form (§4.3).

- **12 known-answer vectors** (8 transform + 4 reject): empty-marks omission, text-node merge, crdt stripping, block-id alpha-renaming, reference `#id/offset` suffix rewriting, and inputs a conformant canonicalizer MUST reject (duplicate keys, non-NFC text, unsafe integers, duplicate block ids).
- **Rejections assert *rejection*, not a code.** §4.3.2 makes these inputs ones a reader MUST reject; canonicalization failures carry no portable error code, so — as with the error vocabulary — the suite asserts the outcome, never invents an identifier.
- **Independent Python oracle** (`conformance/oracles/canonicalize_oracle.py`, stdlib `json` + `hashlib`, sharing no code with the TS canonicalizer) generates and re-verifies the expected JCS bytes and digests. `check:canonicalize-oracle` runs it in CI; the reference adapter reproduces every vector — so three independent paths corroborate each expectation.
- Schema: new `canonicalize` kind, `expectReject`/`expectedCanonicalJcs` (mutually exclusive), engine comparator + adapter runner + per-kind negative fixtures.

## Scope note

Three candidate vectors were **deliberately dropped** after the spec-fidelity review and are **not** in this PR:
- A text-node-`id` relabeling case that surfaced a genuine **defect in the reference canonicalizer** (it relabels text-node ids, which §4.3.1 items 4–5 say must be preserved) — also present in A2's merged `merge-and-id-boundary` vector. That is a separate, spec-authoritative fix (lib + A2 vector) tracked for a follow-up PR.
- Two malformed-Dublin-Core reject vectors whose rejection rests on the Metadata schema (§7.2), not §4.3 canonicalization — omitted to avoid asserting behaviour §4.3 does not mandate.

## Test plan

- [x] `check:conformance` reproduces all 99 published vectors via the adapter protocol (0 failed / 0 skipped).
- [x] `check:canonicalize-oracle` (independent, non-Node) verifies every transform vector's id is the digest of its committed bytes.
- [x] Byte round-trip + schema validation green; mutual-exclusion constraint verified (both fields → invalid).
- [x] Full CI-parity suite green (25 gates + tsc + npm audit).