### PR TITLE
Fix: preserve text-node ids in canonicalization (§4.3.1 items 4-5)

### DIFF
--- a/conformance/vectors/canonicalize.json
+++ b/conformance/vectors/canonicalize.json
@@ -134,6 +134,17 @@
         "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
       },
       "expectReject": true
+    },
+    {
+      "name": "text-id-boundary-preserved",
+      "description": "A text node carrying an id is a merge boundary AND its id is preserved verbatim (anchor1 stays anchor1): a text-node id is not in the relabeled namespace (§4.3.1 items 4-5) and is content-significant (item 4 preserves it unchanged).",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"a\",\"id\":\"anchor1\"},{\"type\":\"text\",\"value\":\"b\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"id\":\"anchor1\",\"type\":\"text\",\"value\":\"a\"},{\"type\":\"text\",\"value\":\"b\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:73f87fe20f1159fc10b0574219c2ddef32d8ac8d37dbd7d2551023124c67bac7"
     }
   ]
 }

--- a/conformance/vectors/document-id.json
+++ b/conformance/vectors/document-id.json
@@ -75,14 +75,14 @@
     },
     {
       "name": "merge-and-id-boundary",
-      "description": "Adjacent equal-mark text nodes merge; a text node carrying an id is a boundary, and that id is alpha-renamed (k → b0).",
+      "description": "Adjacent equal-mark text nodes merge; a text node carrying an id is a boundary, and that id is preserved verbatim (k stays k) — a text-node id is outside the relabeled namespace (§4.3.1 items 4-5) and is content-significant.",
       "parts": {
         "manifest": "{}",
         "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"Hello \"},{\"type\":\"text\",\"value\":\"world\"},{\"type\":\"text\",\"value\":\"!\",\"id\":\"k\"},{\"type\":\"text\",\"value\":\"?\"}]}]}",
         "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
       },
-      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"Hello world\"},{\"id\":\"b0\",\"type\":\"text\",\"value\":\"!\"},{\"type\":\"text\",\"value\":\"?\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
-      "expectedId": "sha256:ae20d2e4a55e2113d93e4c99bc5b6abf3654b0ae177211cc5845fcdfcce2d4c8"
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"Hello world\"},{\"id\":\"k\",\"type\":\"text\",\"value\":\"!\"},{\"type\":\"text\",\"value\":\"?\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha256:2032746c797a75e9c34b8ea01cfc8caae33006830150cb8980b3bf983b118bb0"
     },
     {
       "name": "strip-derived-and-crdt",

--- a/scripts/lib/canonicalize.ts
+++ b/scripts/lib/canonicalize.ts
@@ -700,6 +700,13 @@ function definedId(obj: Record<string, unknown>, inMarks: boolean, inArray: bool
     return obj.type === 'anchor' && typeof obj.id === 'string' ? obj.id : undefined;
   }
   if (typeof obj.id !== 'string') return undefined;
+  // A text node is typed but is NOT a content block: its `id` addresses no
+  // relabeled namespace and is preserved verbatim (§4.3.1 item 4 — "a text node
+  // that also carries an `id` … is preserved unchanged"; item 5's namespace is
+  // exhaustively blocks, `anchor` marks, and equation-line/subfigure sub-blocks).
+  // Because it is preserved, a text-node id is content-significant, not a
+  // normalized label — two documents differing only in one do not share an id.
+  if (obj.type === 'text') return undefined;
   const namedArrayItem = inArray && parentKey !== undefined;
   if (typeof obj.type === 'string') {
     // A typed object is a content block unless it is an item of a data-payload array.

--- a/scripts/test-canonicalize.ts
+++ b/scripts/test-canonicalize.ts
@@ -503,7 +503,7 @@ test('merge: adjacent text nodes with equal mark-sets merge; differing marks do 
   ]);
 });
 
-test('merge: a text node carrying an id is a boundary (not merged; id alpha-renamed)', () => {
+test('merge: a text node carrying an id is a boundary; its id is preserved verbatim, not relabeled', () => {
   const children = canonContent({
     content: {
       version: '0.1',
@@ -518,8 +518,11 @@ test('merge: a text node carrying an id is a boundary (not merged; id alpha-rena
       ],
     },
   }).blocks[0].children;
+  // §4.3.1 item 4: a text node with an id is preserved unchanged and acts as a
+  // boundary. A text-node id is NOT in the relabeled namespace (item 5), so it
+  // stays 'anchor1' — never rewritten to a canonical b<N> name.
   assert.deepEqual(children, [
-    { type: 'text', value: 'a', id: 'b0' },
+    { type: 'text', value: 'a', id: 'anchor1' },
     { type: 'text', value: 'b' },
   ]);
 });
@@ -1176,7 +1179,7 @@ test('purity: an unresolved #bN reference is rejected (cannot alias a generated 
   assert.equal(href, '#b');
 });
 
-test('purity: alpha-equivalence holds across a text-node id boundary and merge', () => {
+test('purity: a text-node id is content-significant — differing text-node ids yield different document ids', () => {
   const mk = (id: string) =>
     makeParts({
       content: {
@@ -1186,14 +1189,17 @@ test('purity: alpha-equivalence holds across a text-node id boundary and merge',
             type: 'paragraph',
             children: [
               { type: 'text', value: 'Hello ' },
-              { type: 'text', value: 'world', id }, // id makes this a merge boundary; relabeled
+              { type: 'text', value: 'world', id }, // id makes this a merge boundary AND is preserved verbatim
               { type: 'text', value: '!' },
             ],
           },
         ],
       },
     });
-  assert.equal(computeDocumentId(mk('w'), 'sha256'), computeDocumentId(mk('other'), 'sha256'));
+  // Unlike a BLOCK id (a normalized label), a text-node id is outside the
+  // relabeled namespace (§4.3.1 items 4-5) and preserved verbatim, so it is part
+  // of the content identity: two documents differing only in it are distinct.
+  assert.notEqual(computeDocumentId(mk('w'), 'sha256'), computeDocumentId(mk('other'), 'sha256'));
 });
 
 test('resource bounds: content nested past MAX_CANONICALIZATION_DEPTH throws a typed error, not a RangeError', () => {


### PR DESCRIPTION
## Summary

A spec-conformance defect in the reference canonicalizer, surfaced by the A4 spec-fidelity review and confirmed against §4.3.1.

The identifier-relabeling pass treated **any typed object outside a `marks` array as a content block**, so a text node carrying an `id` had that id rewritten to a canonical `b<N>` name. §4.3.1 is explicit that this is wrong:
- **Item 4**: a text node that also carries an `id` "is **preserved unchanged** and acts as a boundary."
- **Item 5**: the relabeled namespace is *exhaustively* block ids, `anchor`-mark ids, and equation-line/subfigure sub-block ids — a text node's bare `id` is in none of them.

A text-node id is therefore **content-significant**, not a normalized label.

## Why it matters

A2's merged `merge-and-id-boundary` vector encoded the buggy relabeling (`id:"k"` → `id:"b0"`). A third-party implementation that *correctly* preserved the id would have **failed** that vector — the suite penalizing correctness. This is exactly the cross-implementation divergence the conformance suite exists to catch.

## Change

- `definedId` (canonicalize.ts) now excludes `type:"text"`; a text-node id is neither assigned a canonical name (collect pass) nor rewritten (rewrite pass) — both route through `definedId`. Also removes a spurious duplicate-id error when a text-node id equals a block id (distinct namespaces).
- Corrects the `merge-and-id-boundary` vector (re-derived via the independent oracle).
- Updates the two affected canonicalizer unit tests (a text-node id is preserved; differing text-node ids now yield different document ids).
- Adds a `text-id-boundary-preserved` conformance vector.

## Blast radius — contained

No example is affected (none carries a text-node id): `validate:examples`, `check:document-id`, `check:spec-examples` all green. The spec's own worked examples use id-less text nodes, so the spec text was already correct and needs no change.

## Test plan

- [x] Full CI-parity suite green (25 gates + tsc + npm test).
- [x] Independent Python oracle reproduces the corrected/added vector ids; the reviewer independently predicted the resulting hash (`sha256:73f87fe2…`).
- [x] `check:conformance` reproduces all published vectors via the adapter protocol.