### PR TITLE
Add canonicalize-robustness conformance vectors (depth/liveness)

### DIFF
--- a/conformance/ADAPTER.md
+++ b/conformance/ADAPTER.md
@@ -106,12 +106,14 @@ declared capabilities; a vector left unreported is a failure, not a silent pass.
 
 For each kind: the input fields your adapter reads from the vector, the outcome
 it reports, and the `values` keys the suite compares (against the vector's
-expected field, shown in parentheses). All twelve are pure functions — no clock,
-key, or network is required at Level 0.
+expected field, shown in parentheses). All are pure functions — no clock, key, or
+network is required at Level 0.
 
 | Kind | Reads | Outcome | `values` key → (expected field) |
 |------|-------|---------|--------------------------------|
 | `document-id` | `parts` (`manifest`,`content`,`dublinCore`,`assetIndexes?`), `algorithm?` | value | `canonicalJcs` → (`expectedCanonicalJcs`); `id` → (`expectedId`) |
+| `canonicalize` | `parts`, `algorithm?` | value **or error** | transform: `canonicalJcs` → (`expectedCanonicalJcs`), `id` → (`expectedId`); a reject vector (`expectReject`) expects `outcome: "error"` |
+| `canonicalize-robustness` | `robustness` (generative — see below) | value / error | none — `accept` → `value`, `reject` → `error` |
 | `manifest-projection` | `manifest` (raw JSON text) | value | `jcs` → (`expectedJcs`); `sha256` → (`expectedSha256`) |
 | `manifest-scope` | `scope` | value | `jcs` → (`expectedJcs`); `sha256` → (`expectedSha256`) |
 | `manifest-projection-errors` | `manifest` (raw JSON text) | **error** | `error.code` → (`expect.code`) |
@@ -139,6 +141,26 @@ Notes that bite:
   reason still satisfies `problemsEmpty: false`.
 - **`manifest-projection-errors`** is the only kind that expects an error. Report
   `outcome: "error"` with the mapped `code`; reporting a value fails the case.
+- **`canonicalize` reject vectors** (`expectReject: true`) assert only that your
+  implementation *rejects* the input — canonicalization defects carry no portable
+  code, so report `outcome: "error"` (a `code` is optional and ignored). A vector
+  is either a transform (`expectedCanonicalJcs`) or a reject; never both.
+- **`canonicalize-robustness` is generative and parameterised by YOUR bound.**
+  A case carries `robustness: { part, depth: { boundOffset }, of, expect }`. The
+  canonicalization depth limit is implementation-defined (06 §4.3.2), so you
+  expand the case relative to your OWN limit: nest `of` to
+  `(your max depth) + boundOffset` inside the named `part`
+  (`content` = the whole content; `metadata` = a Dublin Core term), then
+  canonicalize. `boundOffset: 0` is the exact bound and MUST **accept** (report
+  `value`); `boundOffset: 1` is one past and MUST **reject** — with a *catchable*
+  error you report as `outcome: "error"`, **never a native stack overflow that
+  crashes your adapter** (a crashed adapter produces no report, so the harness
+  fails every case). Do not ship a literal deep structure in the vector; generate
+  it in memory. Report your limit as `adapter.maxCanonicalizationDepth` so a
+  reviewer can see the depth exercised. Granularity limit: `reject` asserts *that*
+  the input is refused, not the internal reason — a deeply-nested metadata term,
+  for instance, may be refused for depth or for term-validity; both are catchable
+  rejections, and that survival is the property under test.
 
 ## Capabilities and scoping
 

--- a/conformance/report.schema.json
+++ b/conformance/report.schema.json
@@ -30,6 +30,11 @@
           "minimum": 0,
           "maximum": 2,
           "description": "The highest adapter level implemented (0 = vectors, 1 = fixtures + clock, 2 = trust + resolver injection)."
+        },
+        "maxCanonicalizationDepth": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The implementation's own canonicalization depth bound (implementation-defined, 06 §4.3.2). Reported so a reviewer can see the depth a canonicalize-robustness case actually exercised; the adapter nests relative to this, not a fixed value."
         }
       }
     },

--- a/conformance/vectors/canonicalize-robustness.json
+++ b/conformance/vectors/canonicalize-robustness.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "./vectors.schema.json",
+  "suite": "cdx-conformance",
+  "specVersion": "0.1",
+  "kind": "canonicalize-robustness",
+  "clause": "Document Hashing section 4.3 (bounded canonicalization depth; the bound is implementation-defined — Container Format section 5 resource bounds)",
+  "description": "Robustness of the canonicalization depth bound: one level past the implementation’s own maximum nesting depth MUST be rejected with a CATCHABLE error (never a native stack overflow that crashes the process), and the exact bound MUST still canonicalize. Cases are GENERATIVE and expanded by the adapter relative to its own declared bound, so they are portable across implementations with different limits and never ship a literal deep structure.",
+  "oracle": "No expected bytes: a robustness case asserts a liveness property (a catchable rejection one past the implementation’s own depth bound, never a crash) and boundary acceptance at the bound. The adapter generates the input relative to its declared maxCanonicalizationDepth; the harness observes only whether the operation was caught (rejected) or succeeded.",
+  "vectors": [
+    {
+      "name": "content-depth-at-bound-accepted",
+      "description": "Content nested to exactly the implementation’s maximum canonicalization depth still canonicalizes (boundary accept).",
+      "robustness": {
+        "part": "content",
+        "depth": {
+          "boundOffset": 0
+        },
+        "of": 0,
+        "expect": "accept"
+      }
+    },
+    {
+      "name": "content-depth-one-past-bound-rejected",
+      "description": "Content nested one level past the maximum depth is rejected with a catchable, typed error — not a native stack overflow.",
+      "robustness": {
+        "part": "content",
+        "depth": {
+          "boundOffset": 1
+        },
+        "of": 0,
+        "expect": "reject"
+      }
+    },
+    {
+      "name": "metadata-depth-one-past-bound-rejected",
+      "description": "Deeply nested Dublin Core metadata (a term nested past the maximum depth) is rejected with a catchable error, not a crash — for depth or term-validity reasons; the survival, not the reason, is the property under test. The only case that touches the dublinCore path.",
+      "robustness": {
+        "part": "metadata",
+        "depth": {
+          "boundOffset": 1
+        },
+        "of": 0,
+        "expect": "reject"
+      }
+    }
+  ]
+}

--- a/conformance/vectors/vectors.schema.json
+++ b/conformance/vectors/vectors.schema.json
@@ -38,7 +38,8 @@
         "block-merkle-inclusion",
         "block-merkle-leaf",
         "provenance-timestamp",
-        "canonicalize"
+        "canonicalize",
+        "canonicalize-robustness"
       ]
     },
     "clause": {
@@ -127,6 +128,57 @@
         "expectReject": {
           "const": true,
           "description": "Marks a vector whose input a conformant implementation MUST reject (the operation errors). Used where no portable defect code exists — the assertion is rejection, not an identifier. Mutually exclusive with expectedCanonicalJcs."
+        },
+        "robustness": {
+          "type": "object",
+          "description": "A canonicalize-robustness case: GENERATIVE (no literal deep structure, which could itself exceed a parser's own limits). The adapter expands it relative to ITS OWN declared canonicalization depth bound, so the case is portable across implementations with different bounds.",
+          "required": [
+            "part",
+            "depth",
+            "of",
+            "expect"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "part": {
+              "enum": [
+                "content",
+                "metadata"
+              ],
+              "description": "Which part carries the deep structure."
+            },
+            "depth": {
+              "type": "object",
+              "required": [
+                "boundOffset"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "boundOffset": {
+                  "type": "integer",
+                  "minimum": -2,
+                  "maximum": 1,
+                  "description": "Nest `of` to (the adapter's declared max canonicalization depth) + boundOffset, measured at the part's baseline. `boundOffset: 1` is one level past the bound and MUST reject with a catchable error (never a crash); `0` is the exact bound. The range is kept small so a generated depth stays near the bound on every implementation — a large literal depth could overflow a recursive-descent JSON parser UPSTREAM of the depth guard, turning a catchable rejection into an uncatchable crash. NOTE: a `metadata` term sits two levels below the root (dublinCore → terms → term), so its effective absolute depth is 2 higher than a `content` case at the same boundOffset — a `metadata` accept needs boundOffset ≤ -2."
+                }
+              }
+            },
+            "of": {
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "null"
+              ],
+              "description": "The innermost scalar the nesting wraps. Restricted to a scalar so a case cannot smuggle a literal deep structure in via `of`, defeating the generative design."
+            },
+            "expect": {
+              "enum": [
+                "accept",
+                "reject"
+              ],
+              "description": "`accept`: canonicalization succeeds. `reject`: it fails with a CATCHABLE error — a typed rejection the adapter reports, not a native stack overflow that crashes it."
+            }
+          }
         },
         "expect": {
           "type": "object",

--- a/scripts/check-conformance.ts
+++ b/scripts/check-conformance.ts
@@ -178,6 +178,8 @@ const err = (code: string): Pick<AdapterResult, 'outcome' | 'error'> => ({ outco
     ['canonicalize jcs', 'canonicalize', { name: 'n', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' }, val({ canonicalJcs: '{"x":1}', id: 'sha256:aa' })],
     ['canonicalize id', 'canonicalize', { name: 'n', expectedCanonicalJcs: '{}', expectedId: 'sha256:aa' }, val({ canonicalJcs: '{}', id: 'sha256:bb' })],
     ['canonicalize reject-not-rejected', 'canonicalize', { name: 'n', expectReject: true } as unknown as SuiteVector, val({ canonicalJcs: '{}', id: 'sha256:aa' })],
+    ['robustness reject-but-value', 'canonicalize-robustness', { name: 'n', robustness: { expect: 'reject' } } as unknown as SuiteVector, val({})],
+    ['robustness accept-but-error', 'canonicalize-robustness', { name: 'n', robustness: { expect: 'accept' } } as unknown as SuiteVector, err('CDX-E-X')],
   ];
   const report = (kind: string, result: Pick<AdapterResult, 'outcome' | 'values' | 'error'>): AdapterReport => ({
     suite: 'cdx-conformance', suiteVersion: '0.1.0', specVersion: '0.1',
@@ -212,6 +214,12 @@ const err = (code: string): Pick<AdapterResult, 'outcome' | 'error'> => ({ outco
   );
   if (rejectPass.cases[0]?.status === 'pass') ok('canonicalize reject vector passes when the input is rejected');
   else fail(`canonicalize reject vector should PASS on an error outcome, got ${rejectPass.cases[0]?.status}`);
+
+  // canonicalize-robustness positive paths: reject→error and accept→value both pass.
+  const robReject = evaluate([{ kind: 'canonicalize-robustness', vectors: [{ name: 'n', robustness: { expect: 'reject' } } as unknown as SuiteVector] }], report('canonicalize-robustness', err('CDX-E-ANY')));
+  const robAccept = evaluate([{ kind: 'canonicalize-robustness', vectors: [{ name: 'n', robustness: { expect: 'accept' } } as unknown as SuiteVector] }], report('canonicalize-robustness', val({})));
+  if (robReject.cases[0]?.status === 'pass' && robAccept.cases[0]?.status === 'pass') ok('canonicalize-robustness: reject→error and accept→value both pass');
+  else fail(`canonicalize-robustness positive paths wrong: reject=${robReject.cases[0]?.status}, accept=${robAccept.cases[0]?.status}`);
 }
 
 // 1c. Scoping helpers, file-level requires, and the requires-key lint.

--- a/scripts/conformance-reference-adapter.ts
+++ b/scripts/conformance-reference-adapter.ts
@@ -23,7 +23,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { canonicalContent, computeDocumentId, jcsOf } from './lib/canonicalize.js';
+import { canonicalContent, computeDocumentId, jcsOf, MAX_CANONICALIZATION_DEPTH } from './lib/canonicalize.js';
 import { projectManifest, projectManifestToJcs } from './lib/manifest-projection.js';
 import { encodeProtectedHeader, jwsSigningInput } from './lib/jws-envelope.js';
 import { jwkThumbprint, multibaseKeyToJwk } from './lib/keyid-resolution.js';
@@ -32,6 +32,13 @@ import { checkTimestampBinding } from './lib/provenance-timestamp.js';
 import type { AdapterReport, AdapterResult } from './lib/conformance-suite.js';
 
 const sha256Of = (s: string): string => 'sha256:' + crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+
+/** Wrap `leaf` in `depth` nested arrays — the generative expansion of a robustness case. */
+function nestDeep(depth: number, leaf: unknown): unknown {
+  let v: unknown = leaf;
+  for (let i = 0; i < depth; i++) v = [v];
+  return v;
+}
 
 /**
  * Capabilities this implementation genuinely supports at Level 0. Only what the
@@ -116,6 +123,22 @@ const RUNNERS: Record<string, (v: Record<string, any>) => RunOutcome> = {
     };
   },
 
+  'canonicalize-robustness': (v) => {
+    // Expand the generative case relative to THIS implementation's own bound, so
+    // the depth exercised tracks the reference libraries, not a fixed number.
+    const rob = v.robustness as { part: 'content' | 'metadata'; depth: { boundOffset: number }; of: unknown };
+    const nested = nestDeep(MAX_CANONICALIZATION_DEPTH + rob.depth.boundOffset, rob.of);
+    const parts =
+      rob.part === 'metadata'
+        ? { manifest: '{}', content: '{"version":"0.1","blocks":[]}', dublinCore: JSON.stringify({ version: '1.1', terms: { title: 'T', creator: nested } }) }
+        : { manifest: '{}', content: JSON.stringify(nested), dublinCore: '{"version":"1.1","terms":{"title":"T","creator":"C"}}' };
+    // computeDocumentId runs the up-front depth check (assertBoundedDepth) before
+    // any recursive walk: one past the bound throws a typed CanonicalizationError
+    // (caught by run() → outcome 'error'), never a native stack overflow.
+    computeDocumentId(parts, 'sha256');
+    return { outcome: 'value', values: {} };
+  },
+
   'provenance-timestamp': (v) => {
     const got = checkTimestampBinding(v.timestamp, v.documentId);
     return {
@@ -174,7 +197,7 @@ function main(): void {
     suite: 'cdx-conformance',
     suiteVersion: suite.suiteVersion,
     specVersion: suite.specVersion,
-    adapter: { name: 'cdx-reference', version: '0.1.0', level: 0 },
+    adapter: { name: 'cdx-reference', version: '0.1.0', level: 0, maxCanonicalizationDepth: MAX_CANONICALIZATION_DEPTH },
     capabilities: CAPABILITIES,
     results,
   };

--- a/scripts/lib/conformance-suite.ts
+++ b/scripts/lib/conformance-suite.ts
@@ -46,7 +46,7 @@ export interface AdapterReport {
   suite: string;
   suiteVersion: string;
   specVersion: string;
-  adapter: { name: string; version: string; level: number };
+  adapter: { name: string; version: string; level: number; maxCanonicalizationDepth?: number };
   capabilities: string[];
   results: AdapterResult[];
 }
@@ -232,6 +232,21 @@ const COMPARATORS: Record<string, Comparator> = {
     const jcs = eq(a.v.canonicalJcs, v.expectedCanonicalJcs, 'canonicalJcs');
     if (!jcs.pass) return jcs;
     return v.expectedId !== undefined ? eq(a.v.id, v.expectedId, 'id') : { pass: true };
+  },
+
+  'canonicalize-robustness': (v, r) => {
+    const rob = v.robustness as { expect: 'accept' | 'reject' };
+    // reject: a CATCHABLE rejection (outcome 'error'), never a native stack
+    // overflow — an adapter that crashes produces no report, so the harness sees
+    // a missing result and fails it. accept: canonicalization succeeds.
+    if (rob.expect === 'reject') {
+      return r.outcome === 'error'
+        ? { pass: true }
+        : { pass: false, detail: `expected a catchable rejection one past the depth bound, got outcome "${r.outcome}"` };
+    }
+    return r.outcome === 'value'
+      ? { pass: true }
+      : { pass: false, detail: `expected canonicalization to succeed at the depth bound, got outcome "${r.outcome}"${r.error?.code ? ` (error ${r.error.code})` : ''}` };
   },
 
   'provenance-timestamp': (v, r) => {


### PR DESCRIPTION
## Summary

Phase A4b: a `canonicalize-robustness` vector kind for the canonicalization **depth bound** — the class of cases a plain `{input, expected}` vector can't express.

The depth limit is implementation-defined (06 §4.3.2), so cases are **generative and parameterized by the implementation's OWN bound**:
- A case carries `robustness: { part, depth: { boundOffset }, of, expect }`. The adapter nests `of` to `(its own declared max depth) + boundOffset` inside the named part — **never a hardcoded 256**, and no literal deep structure ships in the vector (which could itself overflow a parser).
- `boundOffset: 0` (the exact bound) MUST **accept**; `boundOffset: 1` (one past) MUST **reject** — with a *catchable* error the adapter reports (`outcome: "error"`), **never a native stack overflow that crashes the adapter**. A crashed adapter reports nothing → the harness fails every case, so non-robustness is caught.
- The adapter reports `adapter.maxCanonicalizationDepth` so the depth actually exercised is visible.

Three vectors: content-at-bound (accept), content-one-past (reject), metadata-one-past (reject — the only case touching the Dublin Core depth path).

Also fills an A4a gap: adds the `canonicalize` row to ADAPTER.md's per-kind contract table.

## Review hardening

A focused review confirmed the design sound and shipped vectors correct, and surfaced latent schema traps, now fixed:
- `of` is **scalar-only** — a case cannot smuggle a literal deep structure in via `of`.
- `boundOffset` is **range-bounded** (`-2..1`) — a large depth could overflow a foreign recursive-descent JSON parser *upstream* of its depth guard, converting a catchable rejection into an uncatchable crash (the exact failure the generative design avoids).
- The **metadata +2 wrapper offset** is documented (a Dublin Core term sits two levels below the root), and the metadata vector's description no longer overclaims to isolate the depth guard (it asserts survival — a catchable rejection for depth *or* term-validity).

## Test plan

- [x] `check:conformance` 103/103 via the adapter protocol; reference accepts the boundary (256) and rejects one-past (257) for both content and metadata, relative to its own bound.
- [x] Mutation-tested: corrupting `boundOffset` handling flips the content-reject case to a value and fails the gate.
- [x] Hardened schema verified (non-scalar `of` and out-of-range `boundOffset` rejected).
- [x] Full CI-parity suite green (25 gates + tsc + npm test).