### PR TITLE
Add anchor code-point-offset and algorithm-agility vectors (A5)

### DIFF
--- a/conformance/ADAPTER.md
+++ b/conformance/ADAPTER.md
@@ -115,6 +115,7 @@ network is required at Level 0.
 | `canonicalize` | `parts`, `algorithm?` | value **or error** | transform: `canonicalJcs` → (`expectedCanonicalJcs`), `id` → (`expectedId`); a reject vector (`expectReject`) expects `outcome: "error"` |
 | `canonicalize-robustness` | `robustness` (generative — see below) | value / error | none — `accept` → `value`, `reject` → `error` |
 | `structural-constraints` | `structural` (`rule`, `instance`, `blockTypes?`, `root?`, `index?`) | value | `flagged` → (the negation of `structural.expect.valid`) |
+| `anchor-offset` | `anchor` (`text`, `start`, `end`) | value | `selection` → (`anchor.expectedSelection`) |
 | `manifest-projection` | `manifest` (raw JSON text) | value | `jcs` → (`expectedJcs`); `sha256` → (`expectedSha256`) |
 | `manifest-scope` | `scope` | value | `jcs` → (`expectedJcs`); `sha256` → (`expectedSha256`) |
 | `manifest-projection-errors` | `manifest` (raw JSON text) | **error** | `error.code` → (`expect.code`) |
@@ -181,6 +182,13 @@ Notes that bite:
   consistency) are `SHOULD` (advisory): those manifest fields are advisory and
   their exact semantics are not normatively fixed, so a differing-but-reasonable
   reading is never fatal.
+- **`anchor-offset` is code-point, not UTF-16.** Compute `values.selection` as the
+  `[start, end)` slice of `text` **by Unicode scalar value** (code point), not by
+  UTF-16 code unit. In most languages the native string index is UTF-16
+  (`String.slice`/`charAt`/`substring`, `.length`), which mis-targets any range
+  spanning an astral character — the exact defect this kind catches. In
+  JavaScript, `Array.from(text).slice(start, end).join('')` is correct; the naive
+  `text.slice(start, end)` is not.
 
 ## Capabilities and scoping
 

--- a/conformance/vectors/anchor-offset.json
+++ b/conformance/vectors/anchor-offset.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "./vectors.schema.json",
+  "suite": "cdx-conformance",
+  "specVersion": "0.1",
+  "kind": "anchor-offset",
+  "clause": "Anchors and References section 3 (anchor offsets are code points / Unicode scalar values, not UTF-16 code units)",
+  "description": "Anchor {start,end} ranges index a block’s text content by CODE POINT (Unicode scalar value), not UTF-16 code unit. A reader that uses native string indexing (JS/Java/C#/Swift .length/.charAt are UTF-16) mis-targets any range spanning an astral character. Pure JSON, highest value-per-byte in the spec.",
+  "oracle": "Selections are HAND-DETERMINED by code-point slicing (Array.from(text).slice(start,end)), the offset unit §3 fixes. A UTF-16 implementation counts the emoji as two units and selects a broken surrogate instead of the scalar.",
+  "vectors": [
+    {
+      "name": "bmp-hello-world-selects-world",
+      "description": "The §3 worked example: text content \"Hello, world!\" (13 code points), {7,12} selects \"world\".",
+      "anchor": {
+        "text": "Hello, world!",
+        "start": 7,
+        "end": 12,
+        "expectedSelection": "world"
+      }
+    },
+    {
+      "name": "astral-emoji-selected",
+      "description": "THE code-point-vs-UTF-16 anchor: \"a😀b\" is 3 code points (😀 = U+1F600, one scalar), so {1,2} selects \"😀\". A UTF-16 reader counts 😀 as two units and mis-targets.",
+      "anchor": {
+        "text": "a😀b",
+        "start": 1,
+        "end": 2,
+        "expectedSelection": "😀"
+      }
+    },
+    {
+      "name": "astral-char-before-emoji",
+      "description": "\"a😀b\" {0,1} selects \"a\" — the character before the astral scalar.",
+      "anchor": {
+        "text": "a😀b",
+        "start": 0,
+        "end": 1,
+        "expectedSelection": "a"
+      }
+    },
+    {
+      "name": "astral-char-after-emoji",
+      "description": "\"a😀b\" {2,3} selects \"b\" — proving the astral scalar occupies exactly one offset (a UTF-16 reader would place \"b\" at offset 3).",
+      "anchor": {
+        "text": "a😀b",
+        "start": 2,
+        "end": 3,
+        "expectedSelection": "b"
+      }
+    },
+    {
+      "name": "astral-whole-string",
+      "description": "\"a😀b\" {0,3} selects the whole string \"a😀b\".",
+      "anchor": {
+        "text": "a😀b",
+        "start": 0,
+        "end": 3,
+        "expectedSelection": "a😀b"
+      }
+    },
+    {
+      "name": "combining-mark-is-separate-code-point",
+      "description": "A combining mark is its own code point: \"éb\" is 3 code points (e, U+0301, b), so {2,3} selects \"b\".",
+      "anchor": {
+        "text": "éb",
+        "start": 2,
+        "end": 3,
+        "expectedSelection": "b"
+      }
+    }
+  ]
+}

--- a/conformance/vectors/canonicalize.json
+++ b/conformance/vectors/canonicalize.json
@@ -145,6 +145,51 @@
       },
       "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"id\":\"anchor1\",\"type\":\"text\",\"value\":\"a\"},{\"type\":\"text\",\"value\":\"b\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
       "expectedId": "sha256:73f87fe20f1159fc10b0574219c2ddef32d8ac8d37dbd7d2551023124c67bac7"
+    },
+    {
+      "name": "sha512-document-algorithm-agility",
+      "description": "The document-ID algorithm follows the id prefix (sha512), never a hardcoded default (§3.3) — the same content under a different algorithm yields a different, correctly-prefixed id.",
+      "requires": [
+        "hash:sha-512"
+      ],
+      "algorithm": "sha512",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"sha512\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"sha512\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha512:fc794985621d8773b9265ed1a18de99ce1fa19953e14b5b6a3c73ed421515a8793b9ed20224e32d25539971a3fe76f5e670fc9555b6f3f2fa889f58d6b6fe2fb"
+    },
+    {
+      "name": "sha3-256-document-algorithm-agility",
+      "description": "The document-ID algorithm follows the id prefix (sha3-256), never a hardcoded default (§3.3) — the same content under a different algorithm yields a different, correctly-prefixed id.",
+      "requires": [
+        "hash:sha3-256"
+      ],
+      "algorithm": "sha3-256",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"sha3-256\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"sha3-256\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha3-256:ea905bf7709b24df5e7c6c1bfe109a6eec653ec8bb92ee6e0e10be87f8714eb2"
+    },
+    {
+      "name": "sha3-512-document-algorithm-agility",
+      "description": "The document-ID algorithm follows the id prefix (sha3-512), never a hardcoded default (§3.3) — the same content under a different algorithm yields a different, correctly-prefixed id.",
+      "requires": [
+        "hash:sha3-512"
+      ],
+      "algorithm": "sha3-512",
+      "parts": {
+        "manifest": "{}",
+        "content": "{\"version\":\"0.1\",\"blocks\":[{\"type\":\"paragraph\",\"children\":[{\"type\":\"text\",\"value\":\"sha3-512\"}]}]}",
+        "dublinCore": "{\"version\":\"1.1\",\"terms\":{\"title\":\"T\",\"creator\":\"C\"}}"
+      },
+      "expectedCanonicalJcs": "{\"content\":{\"blocks\":[{\"children\":[{\"type\":\"text\",\"value\":\"sha3-512\"}],\"type\":\"paragraph\"}],\"version\":\"0.1\"},\"metadata\":{\"creator\":[\"C\"],\"title\":\"T\"}}",
+      "expectedId": "sha3-512:4a140d65d86b85d4084e20ae85162f4ac3a7dec97e680ea6b9cc9aa1fa8dd028470ea26bd6f144cff98758b55c948347b8fecc97184ce48ac98e5924043bbe11"
     }
   ]
 }

--- a/conformance/vectors/vectors.schema.json
+++ b/conformance/vectors/vectors.schema.json
@@ -40,7 +40,8 @@
         "provenance-timestamp",
         "canonicalize",
         "canonicalize-robustness",
-        "structural-constraints"
+        "structural-constraints",
+        "anchor-offset"
       ]
     },
     "clause": {
@@ -129,6 +130,35 @@
         "expectReject": {
           "const": true,
           "description": "Marks a vector whose input a conformant implementation MUST reject (the operation errors). Used where no portable defect code exists — the assertion is rejection, not an identifier. Mutually exclusive with expectedCanonicalJcs."
+        },
+        "anchor": {
+          "type": "object",
+          "description": "An anchor-offset case: a block's text content and a {start,end} range. Anchor offsets are CODE POINTS (Unicode scalar values), not UTF-16 code units (Anchors and References §3), so an astral character counts as one — a UTF-16 implementation using string indexing mis-targets the selection.",
+          "required": [
+            "text",
+            "start",
+            "end",
+            "expectedSelection"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "The block's text content (the concatenation of its text-node values)."
+            },
+            "start": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "end": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "expectedSelection": {
+              "type": "string",
+              "description": "The substring the [start,end) code-point range selects."
+            }
+          }
         },
         "structural": {
           "type": "object",

--- a/scripts/check-conformance.ts
+++ b/scripts/check-conformance.ts
@@ -182,6 +182,7 @@ const err = (code: string): Pick<AdapterResult, 'outcome' | 'error'> => ({ outco
     ['robustness accept-but-error', 'canonicalize-robustness', { name: 'n', robustness: { expect: 'accept' } } as unknown as SuiteVector, err('CDX-E-X')],
     ['structural valid-but-flagged', 'structural-constraints', { name: 'n', structural: { expect: { valid: true } } } as unknown as SuiteVector, val({ flagged: true })],
     ['structural invalid-but-clean', 'structural-constraints', { name: 'n', structural: { expect: { valid: false } } } as unknown as SuiteVector, val({ flagged: false })],
+    ['anchor-offset wrong-selection', 'anchor-offset', { name: 'n', anchor: { text: 'ab', start: 0, end: 1, expectedSelection: 'a' } } as unknown as SuiteVector, val({ selection: 'b' })],
   ];
   const report = (kind: string, result: Pick<AdapterResult, 'outcome' | 'values' | 'error'>): AdapterReport => ({
     suite: 'cdx-conformance', suiteVersion: '0.1.0', specVersion: '0.1',

--- a/scripts/conformance-reference-adapter.ts
+++ b/scripts/conformance-reference-adapter.ts
@@ -134,6 +134,16 @@ const RUNNERS: Record<string, (v: Record<string, any>) => RunOutcome> = {
     };
   },
 
+  'anchor-offset': (v) => {
+    const an = v.anchor as { text: string; start: number; end: number };
+    // Anchor offsets are CODE POINTS (Unicode scalar values), not UTF-16 code
+    // units (Anchors and References §3). `Array.from` splits by code point, so an
+    // astral character counts as one; `text.slice(start,end)` (UTF-16) would
+    // mis-target — the exact defect this kind catches.
+    const selection = Array.from(an.text).slice(an.start, an.end).join('');
+    return { outcome: 'value', values: { selection } };
+  },
+
   'structural-constraints': (v) => {
     // Run the named rule's checker over the instance and report whether it
     // FLAGGED — the suite compares that to expect.valid. Block-tree rules use the

--- a/scripts/lib/conformance-suite.ts
+++ b/scripts/lib/conformance-suite.ts
@@ -234,6 +234,12 @@ const COMPARATORS: Record<string, Comparator> = {
     return v.expectedId !== undefined ? eq(a.v.id, v.expectedId, 'id') : { pass: true };
   },
 
+  'anchor-offset': (v, r) => {
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    return eq(a.v.selection, (v.anchor as { expectedSelection: string }).expectedSelection, 'selection');
+  },
+
   'structural-constraints': (v, r) => {
     // The adapter runs the rule's checker and reports whether it FLAGGED the
     // instance. A valid instance is one the rule does NOT flag; an invalid one it


### PR DESCRIPTION
## Summary

Phase A5 — the plan's cheapest, highest value-per-byte KATs.

**New `anchor-offset` kind.** Anchor `{start,end}` ranges index a block's text content by **code point** (Unicode scalar value), not UTF-16 code unit (Anchors and References §3). The flagship `"a😀b"` `{1,2}` → `"😀"` catches every reader that uses native UTF-16 string indexing (JS/Java/C#/Swift `.length`/`.slice`/`.charAt`) — the single best value-per-byte test in the spec. 6 vectors: the spec's own worked examples (`"Hello, world!"` `{7,12}` → `"world"`; the astral example), plus boundary and combining-mark edges.

**Algorithm-agility.** `sha512`, `sha3-256`, `sha3-512` document-id vectors added to the `canonicalize` kind, each scoped to its hash capability. They prove the id algorithm follows the value's own `algorithm:` prefix, never a hardcoded default (§3.3). Ids independently verified by the Python oracle.

## Verification

- [x] `check:conformance` 138/138 via the adapter protocol; the reference reproduces every anchor selection and algorithm-agility id.
- [x] **Mutation-tested (flagship):** replacing the adapter's code-point slice with a UTF-16 `text.slice` fails exactly the astral anchor cases with the broken-surrogate output the kind is built to catch (`"😀"`→`"\ud83d"`, `"b"`→`"\ude00"`), while the BMP case correctly still passes.
- [x] `check:canonicalize-oracle` verifies the three new algorithm-agility ids independently (non-Node).
- [x] Full CI-parity suite green (25 gates + tsc + npm test).

## Remaining A5

The third A5 item — **presentation-selection / breakpoint-precedence determinism** (§4.3, §8.2) — is not in this PR; it needs small new reader-selection logic and is a natural follow-up.