### PR TITLE
Add presentation-selection determinism vectors (A5 item 3)

### DIFF
--- a/conformance/ADAPTER.md
+++ b/conformance/ADAPTER.md
@@ -116,6 +116,7 @@ network is required at Level 0.
 | `canonicalize-robustness` | `robustness` (generative — see below) | value / error | none — `accept` → `value`, `reject` → `error` |
 | `structural-constraints` | `structural` (`rule`, `instance`, `blockTypes?`, `root?`, `index?`) | value | `flagged` → (the negation of `structural.expect.valid`) |
 | `anchor-offset` | `anchor` (`text`, `start`, `end`) | value | `selection` → (`anchor.expectedSelection`) |
+| `presentation-selection` | `selection` (`rule`, + `breakpoints`/`width` or `candidates`) | value | `breakpoint` → `name` (`selection.expect.name`); `default` → `index` (`selection.expect.index`) |
 | `manifest-projection` | `manifest` (raw JSON text) | value | `jcs` → (`expectedJcs`); `sha256` → (`expectedSha256`) |
 | `manifest-scope` | `scope` | value | `jcs` → (`expectedJcs`); `sha256` → (`expectedSha256`) |
 | `manifest-projection-errors` | `manifest` (raw JSON text) | **error** | `error.code` → (`expect.code`) |
@@ -189,6 +190,13 @@ Notes that bite:
   spanning an astral character — the exact defect this kind catches. In
   JavaScript, `Array.from(text).slice(start, end).join('')` is correct; the naive
   `text.slice(start, end)` is not.
+- **`presentation-selection` tests only the deterministic rules.** `breakpoint`
+  (§8.2): among breakpoints matching the width (bounds inclusive; an omitted bound
+  is unbounded), report the `name` of the one with the greatest `minWidth`, and on
+  a `minWidth` tie the one appearing **later** in the array; `null` if none match.
+  `default` (§4.3): report the `index` of the first entry marked `default:true`,
+  else `0`. The §4.3 step-1 target narrowing (screen SHOULD prefer
+  continuous/responsive, print SHOULD prefer precise) is advisory and not tested.
 
 ## Capabilities and scoping
 

--- a/conformance/vectors/presentation-selection.json
+++ b/conformance/vectors/presentation-selection.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "./vectors.schema.json",
+  "suite": "cdx-conformance",
+  "specVersion": "0.1",
+  "kind": "presentation-selection",
+  "clause": "Presentation Layers section 8.2 (breakpoint precedence) and section 4.3 (default-presentation selection) — the deterministic selection rules",
+  "description": "The DETERMINISTIC parts of presentation selection: §8.2 breakpoint precedence (greatest minWidth wins; a minWidth tie goes to the later array entry; bounds inclusive; an omitted bound is unbounded) and §4.3 default selection (first entry marked default:true, else the first entry). The §4.3 step-1 target narrowing is advisory (SHOULD) and deliberately not modelled.",
+  "oracle": "Expected results are HAND-DETERMINED from the §8.2 precedence rule and the §4.3 default rule; no snapshot. The reference selectors (scripts/lib/presentation-selection.ts) reproduce them.",
+  "vectors": [
+    {
+      "name": "breakpoint-mobile-at-320",
+      "description": "The §8.2 example at a phone width (320) selects \"mobile\".",
+      "selection": {
+        "rule": "breakpoint",
+        "breakpoints": [
+          {
+            "name": "mobile",
+            "maxWidth": "599px"
+          },
+          {
+            "name": "tablet",
+            "minWidth": "600px",
+            "maxWidth": "1023px"
+          },
+          {
+            "name": "desktop",
+            "minWidth": "1024px"
+          }
+        ],
+        "width": 320,
+        "expect": {
+          "name": "mobile"
+        }
+      }
+    },
+    {
+      "name": "breakpoint-tablet-at-800",
+      "description": "A mid width (800) selects \"tablet\".",
+      "selection": {
+        "rule": "breakpoint",
+        "breakpoints": [
+          {
+            "name": "mobile",
+            "maxWidth": "599px"
+          },
+          {
+            "name": "tablet",
+            "minWidth": "600px",
+            "maxWidth": "1023px"
+          },
+          {
+            "name": "desktop",
+            "minWidth": "1024px"
+          }
+        ],
+        "width": 800,
+        "expect": {
+          "name": "tablet"
+        }
+      }
+    },
+    {
+      "name": "breakpoint-desktop-at-1440",
+      "description": "A wide width (1440) selects \"desktop\".",
+      "selection": {
+        "rule": "breakpoint",
+        "breakpoints": [
+          {
+            "name": "mobile",
+            "maxWidth": "599px"
+          },
+          {
+            "name": "tablet",
+            "minWidth": "600px",
+            "maxWidth": "1023px"
+          },
+          {
+            "name": "desktop",
+            "minWidth": "1024px"
+          }
+        ],
+        "width": 1440,
+        "expect": {
+          "name": "desktop"
+        }
+      }
+    },
+    {
+      "name": "breakpoint-boundary-599-mobile",
+      "description": "maxWidth is inclusive: width 599 still selects \"mobile\".",
+      "selection": {
+        "rule": "breakpoint",
+        "breakpoints": [
+          {
+            "name": "mobile",
+            "maxWidth": "599px"
+          },
+          {
+            "name": "tablet",
+            "minWidth": "600px",
+            "maxWidth": "1023px"
+          },
+          {
+            "name": "desktop",
+            "minWidth": "1024px"
+          }
+        ],
+        "width": 599,
+        "expect": {
+          "name": "mobile"
+        }
+      }
+    },
+    {
+      "name": "breakpoint-boundary-600-tablet",
+      "description": "minWidth is inclusive and mobile’s max (599) is exclusive of 600: width 600 selects \"tablet\".",
+      "selection": {
+        "rule": "breakpoint",
+        "breakpoints": [
+          {
+            "name": "mobile",
+            "maxWidth": "599px"
+          },
+          {
+            "name": "tablet",
+            "minWidth": "600px",
+            "maxWidth": "1023px"
+          },
+          {
+            "name": "desktop",
+            "minWidth": "1024px"
+          }
+        ],
+        "width": 600,
+        "expect": {
+          "name": "tablet"
+        }
+      }
+    },
+    {
+      "name": "breakpoint-overlap-greatest-min-wins",
+      "description": "Two overlapping breakpoints both match width 800; the one with the greater minWidth (600) wins.",
+      "selection": {
+        "rule": "breakpoint",
+        "breakpoints": [
+          {
+            "name": "wide-open",
+            "minWidth": "0px",
+            "maxWidth": "2000px"
+          },
+          {
+            "name": "narrower",
+            "minWidth": "600px",
+            "maxWidth": "2000px"
+          }
+        ],
+        "width": 800,
+        "expect": {
+          "name": "narrower"
+        }
+      }
+    },
+    {
+      "name": "breakpoint-tie-later-wins",
+      "description": "Two breakpoints with the SAME minWidth both match; the one appearing later in the array wins.",
+      "selection": {
+        "rule": "breakpoint",
+        "breakpoints": [
+          {
+            "name": "earlier",
+            "minWidth": "600px"
+          },
+          {
+            "name": "later",
+            "minWidth": "600px"
+          }
+        ],
+        "width": 800,
+        "expect": {
+          "name": "later"
+        }
+      }
+    },
+    {
+      "name": "breakpoint-none-match",
+      "description": "No breakpoint matches width 500; the result is null (no active breakpoint).",
+      "selection": {
+        "rule": "breakpoint",
+        "breakpoints": [
+          {
+            "name": "only",
+            "minWidth": "1000px",
+            "maxWidth": "1100px"
+          }
+        ],
+        "width": 500,
+        "expect": {
+          "name": null
+        }
+      }
+    },
+    {
+      "name": "default-single-marked-entry",
+      "description": "One entry marked default:true is selected (index 1).",
+      "selection": {
+        "rule": "default",
+        "candidates": [
+          {
+            "type": "continuous"
+          },
+          {
+            "type": "responsive",
+            "default": true
+          },
+          {
+            "type": "paginated"
+          }
+        ],
+        "expect": {
+          "index": 1
+        }
+      }
+    },
+    {
+      "name": "default-multiple-marked-first-wins",
+      "description": "When more than one entry is marked default:true, the first such entry (index 0) is used.",
+      "selection": {
+        "rule": "default",
+        "candidates": [
+          {
+            "type": "continuous",
+            "default": true
+          },
+          {
+            "type": "responsive",
+            "default": true
+          }
+        ],
+        "expect": {
+          "index": 0
+        }
+      }
+    },
+    {
+      "name": "default-none-marked-uses-first",
+      "description": "Absent any default:true, the first entry (index 0) is used.",
+      "selection": {
+        "rule": "default",
+        "candidates": [
+          {
+            "type": "continuous"
+          },
+          {
+            "type": "responsive"
+          }
+        ],
+        "expect": {
+          "index": 0
+        }
+      }
+    }
+  ]
+}

--- a/conformance/vectors/vectors.schema.json
+++ b/conformance/vectors/vectors.schema.json
@@ -41,7 +41,8 @@
         "canonicalize",
         "canonicalize-robustness",
         "structural-constraints",
-        "anchor-offset"
+        "anchor-offset",
+        "presentation-selection"
       ]
     },
     "clause": {
@@ -130,6 +131,58 @@
         "expectReject": {
           "const": true,
           "description": "Marks a vector whose input a conformant implementation MUST reject (the operation errors). Used where no portable defect code exists — the assertion is rejection, not an identifier. Mutually exclusive with expectedCanonicalJcs."
+        },
+        "selection": {
+          "type": "object",
+          "description": "A presentation-selection case: a DETERMINISTIC selection rule (Presentation Layers §4.3, §8.2). `breakpoint`: given breakpoints + a viewport width, the active breakpoint name (greatest minWidth wins; a minWidth tie goes to the later array entry; bounds inclusive; omitted bound unbounded). `default`: given a candidate presentation list, the index of the default (first `default:true`, else the first entry). The §4.3 target-narrowing is advisory and not modelled.",
+          "required": [
+            "rule",
+            "expect"
+          ],
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": { "properties": { "rule": { "const": "breakpoint" } }, "required": ["rule"] },
+              "then": { "required": ["breakpoints", "width"] }
+            },
+            {
+              "if": { "properties": { "rule": { "const": "default" } }, "required": ["rule"] },
+              "then": { "required": ["candidates"] }
+            }
+          ],
+          "properties": {
+            "rule": {
+              "enum": ["breakpoint", "default"]
+            },
+            "breakpoints": {
+              "type": "array",
+              "items": { "type": "object" },
+              "description": "breakpoint rule: the responsive breakpoints in declared order."
+            },
+            "width": {
+              "type": "number",
+              "description": "breakpoint rule: the viewport width to resolve."
+            },
+            "candidates": {
+              "type": "array",
+              "items": { "type": "object" },
+              "description": "default rule: the candidate presentation entries in `manifest.presentation[]` order."
+            },
+            "expect": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": ["string", "null"],
+                  "description": "breakpoint rule: the winning breakpoint name, or null if none match."
+                },
+                "index": {
+                  "type": "integer",
+                  "description": "default rule: the index of the selected candidate."
+                }
+              }
+            }
+          }
         },
         "anchor": {
           "type": "object",

--- a/scripts/check-conformance.ts
+++ b/scripts/check-conformance.ts
@@ -183,6 +183,8 @@ const err = (code: string): Pick<AdapterResult, 'outcome' | 'error'> => ({ outco
     ['structural valid-but-flagged', 'structural-constraints', { name: 'n', structural: { expect: { valid: true } } } as unknown as SuiteVector, val({ flagged: true })],
     ['structural invalid-but-clean', 'structural-constraints', { name: 'n', structural: { expect: { valid: false } } } as unknown as SuiteVector, val({ flagged: false })],
     ['anchor-offset wrong-selection', 'anchor-offset', { name: 'n', anchor: { text: 'ab', start: 0, end: 1, expectedSelection: 'a' } } as unknown as SuiteVector, val({ selection: 'b' })],
+    ['presentation breakpoint-wrong', 'presentation-selection', { name: 'n', selection: { rule: 'breakpoint', expect: { name: 'a' } } } as unknown as SuiteVector, val({ name: 'b' })],
+    ['presentation default-wrong', 'presentation-selection', { name: 'n', selection: { rule: 'default', expect: { index: 0 } } } as unknown as SuiteVector, val({ index: 1 })],
   ];
   const report = (kind: string, result: Pick<AdapterResult, 'outcome' | 'values' | 'error'>): AdapterReport => ({
     suite: 'cdx-conformance', suiteVersion: '0.1.0', specVersion: '0.1',

--- a/scripts/conformance-reference-adapter.ts
+++ b/scripts/conformance-reference-adapter.ts
@@ -29,6 +29,7 @@ import { encodeProtectedHeader, jwsSigningInput } from './lib/jws-envelope.js';
 import { jwkThumbprint, multibaseKeyToJwk } from './lib/keyid-resolution.js';
 import { blockLeafHash, blockMerkleRoot, verifyBlockInclusion } from './lib/block-merkle.js';
 import { checkTimestampBinding } from './lib/provenance-timestamp.js';
+import { selectBreakpoint, selectDefaultPresentation, type Breakpoint } from './lib/presentation-selection.js';
 import {
   type Finding,
   ROOT_DOCUMENT,
@@ -132,6 +133,13 @@ const RUNNERS: Record<string, (v: Record<string, any>) => RunOutcome> = {
         id: computeDocumentId(v.parts, v.algorithm ?? 'sha256'),
       },
     };
+  },
+
+  'presentation-selection': (v) => {
+    const sel = v.selection as { rule: 'breakpoint' | 'default'; breakpoints?: Breakpoint[]; width?: number; candidates?: Array<Record<string, unknown>> };
+    return sel.rule === 'breakpoint'
+      ? { outcome: 'value', values: { name: selectBreakpoint(sel.breakpoints ?? [], sel.width ?? 0) } }
+      : { outcome: 'value', values: { index: selectDefaultPresentation(sel.candidates ?? []) } };
   },
 
   'anchor-offset': (v) => {

--- a/scripts/lib/conformance-suite.ts
+++ b/scripts/lib/conformance-suite.ts
@@ -240,6 +240,15 @@ const COMPARATORS: Record<string, Comparator> = {
     return eq(a.v.selection, (v.anchor as { expectedSelection: string }).expectedSelection, 'selection');
   },
 
+  'presentation-selection': (v, r) => {
+    const sel = v.selection as { rule: 'breakpoint' | 'default'; expect: { name?: string | null; index?: number } };
+    const a = values(r);
+    if (!a.ok) return a.comparison;
+    return sel.rule === 'breakpoint'
+      ? eq(a.v.name ?? null, sel.expect.name ?? null, 'active breakpoint')
+      : eq(a.v.index, sel.expect.index, 'selected index');
+  },
+
   'structural-constraints': (v, r) => {
     // The adapter runs the rule's checker and reports whether it FLAGGED the
     // instance. A valid instance is one the rule does NOT flag; an invalid one it

--- a/scripts/lib/presentation-selection.ts
+++ b/scripts/lib/presentation-selection.ts
@@ -1,0 +1,65 @@
+/**
+ * Deterministic presentation-selection rules (Presentation Layers §4.3, §8.2).
+ *
+ * These pin the parts the specification makes DETERMINISTIC — the tie-breaks that
+ * make "which presentation / which breakpoint" reproducible across implementations.
+ * The target-narrowing of §4.3 step 1 (screen SHOULD prefer continuous/responsive,
+ * print SHOULD prefer precise) is advisory and deliberately not modelled here; only
+ * the normative "uses the first…" / "greatest minWidth wins" rules are.
+ *
+ * Pure functions over parsed JSON — no filesystem, no module state — so both a gate
+ * and the conformance reference adapter can share them.
+ */
+
+/** Parse a CSS px length ("600px") or a bare number to a number; undefined otherwise. */
+function pxToNumber(v: unknown): number | undefined {
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') {
+    const m = /^(-?\d+(?:\.\d+)?)px$/.exec(v.trim());
+    if (m) return Number(m[1]);
+  }
+  return undefined;
+}
+
+export interface Breakpoint {
+  name: string;
+  minWidth?: string | number;
+  maxWidth?: string | number;
+}
+
+/**
+ * The active breakpoint for a viewport width (§8.2). Bounds are inclusive and an
+ * omitted bound is unbounded on that side. When several match, the greatest
+ * `minWidth` wins; on a `minWidth` tie the one appearing LATER in the array wins.
+ * Returns the winning breakpoint's `name`, or null if none match.
+ */
+export function selectBreakpoint(breakpoints: Breakpoint[], width: number): string | null {
+  let winner: string | null = null;
+  let winnerMin = -Infinity;
+  let winnerIdx = -1;
+  breakpoints.forEach((bp, i) => {
+    const min = pxToNumber(bp.minWidth) ?? -Infinity;
+    const max = pxToNumber(bp.maxWidth) ?? Infinity;
+    if (min <= width && width <= max) {
+      // greatest minWidth wins; equal minWidth -> the later array entry wins
+      // (iteration is in order, so a later equal-min entry replaces the earlier).
+      if (min > winnerMin || (min === winnerMin && i > winnerIdx)) {
+        winner = bp.name;
+        winnerMin = min;
+        winnerIdx = i;
+      }
+    }
+  });
+  return winner;
+}
+
+/**
+ * The default presentation to show, as an INDEX into `candidates` (§4.3). If any
+ * entry is marked `default: true`, the FIRST such entry is used; otherwise the
+ * first entry. (This operates on an already-narrowed candidate list; the §4.3
+ * step-1 target narrowing is advisory and applied by the caller.)
+ */
+export function selectDefaultPresentation(candidates: Array<Record<string, unknown>>): number {
+  const firstDefault = candidates.findIndex((c) => c && c.default === true);
+  return firstDefault >= 0 ? firstDefault : 0;
+}


### PR DESCRIPTION
## Summary

Completes A5. New `presentation-selection` vector kind for the **deterministic** selection rules of Presentation Layers §4.3 and §8.2 — the parts the spec makes reproducible across implementations.

- **Breakpoint precedence (§8.2)** — among breakpoints matching a viewport width (bounds inclusive; an omitted bound is unbounded), the greatest `minWidth` wins; on a `minWidth` tie the **later** array entry wins; `null` if none match. 8 cases: the spec's mobile/tablet/desktop example at several widths, both inclusive boundaries, overlap (greatest-min-wins), the tie-break, and no-match.
- **Default selection (§4.3)** — the index of the first entry marked `default:true`, else the first entry. 3 cases (single, multiple→first, none→first).

The advisory §4.3 step-1 target-narrowing (screen SHOULD prefer continuous/responsive, print SHOULD prefer precise) is **deliberately not modelled** — only the normative "wins"/"uses the first" tie-breaks are.

A small pure lib (`scripts/lib/presentation-selection.ts`) implements both rules.

## Verification

- [x] `check:conformance` 149/149 via the adapter protocol; the reference selectors reproduce every breakpoint and default outcome.
- [x] **Mutation-tested:** removing the "later wins on a minWidth tie" rule fails the tie/overlap cases exactly (`expected "later", got "earlier"`).
- [x] Schema conditional requirements verified (breakpoint rule needs `breakpoints`+`width`; default needs `candidates`).
- [x] Full CI-parity suite green (25 gates + tsc + npm test).