### PR TITLE
Take the fast-uri patch that clears GHSA-7p8r-x3mc-p8w7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -564,9 +564,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

A high-severity advisory ([GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), *fast-uri vulnerable to host confusion via backslash authority introducer*) was published after this repository's last green run on `main` (2026-07-30). It makes the `Audit dependencies` step — `npm audit --audit-level=high` — fail, so the validate workflow is now red on `main` and on **every branch cut from it**, regardless of content.

`fast-uri` is a transitive dev dependency of `ajv`, whose constraint is `^3.0.1`, so the fixed `3.1.5` satisfies it without any change to `package.json`:

```
node_modules/fast-uri
-  "version": "3.1.4"
+  "version": "3.1.5"
   "dev": true
```

Lockfile only, three lines. Neither exact-pinned dependency moves — `canonicalize` stays at 2.1.0 and `@types/node` stays on `^22`.

Raised separately rather than folded into the branch that hit it, so the unblock applies to every branch at once and the erratum PR stays free of dependency churn.

## Verification

- `npm ci` reproduces from the lockfile cleanly; `npm ls fast-uri` resolves to `3.1.5`
- `npm audit --audit-level=high` → **found 0 vulnerabilities**
- `npx tsc --noEmit`, `npm test`, and all 28 workflow gates — **30/30 green**

`ajv` is what drives schema validation, so the full sweep was re-run rather than assuming a patch bump of its URI resolver is inert.

## Test plan

- [ ] `npm ci && npm audit --audit-level=high` reports no vulnerabilities
- [ ] Full gate sweep stays green (`npm test`, `npx tsc --noEmit`, and the `npm run` steps in `.github/workflows/validate-schemas.yml`)